### PR TITLE
Initialise index to 0 since the algorithm seems to depend on it

### DIFF
--- a/Buildings/BoundaryConditions/WeatherData/BaseClasses/getHeaderElementTMY3.mo
+++ b/Buildings/BoundaryConditions/WeatherData/BaseClasses/getHeaderElementTMY3.mo
@@ -15,7 +15,7 @@ function getHeaderElementTMY3
 protected
  String lin "Line that is used in parser";
  Integer iLin "Line number";
- Integer index "Index of string #LOCATION";
+ Integer index := 0 "Index of string #LOCATION";
  Integer staInd "Start index used when parsing a real number";
  Integer nexInd "Next index used when parsing a real number";
  Boolean found "Flag, true if #LOCATION has been found";


### PR DESCRIPTION
Modelica Spec says the usage of uninitalised function variables is tool-dependent. In OpenModelica you get whatever is on the stack. Dymola probably initialises it to 0.
