### PR TITLE
Updated C-Sources

### DIFF
--- a/Buildings/Resources/C-Sources/exchangeValues.c
+++ b/Buildings/Resources/C-Sources/exchangeValues.c
@@ -1,34 +1,35 @@
-/////////////////////////////////////////////////////
-// External function that exchanges a value with 
-// an array. The array size is dynamically changed
-// as needed.
-//
-// Arguments
-// ---------
-// object: C structure for storage of the array
-// iX: index where x will be stored (1-based index)
-// x:  value to be stored
-// iY: value to be returned (1-based index)
-//
-// Pierre Vigouroux, LBNL                  7/18/2011 
-// svn-id=$Id$
-/////////////////////////////////////////////////////
+/*
+ * External function that exchanges a value with 
+ * an array. The array size is dynamically changed
+ * as needed.
+ *
+ * Arguments
+ * ---------
+ * object: C structure for storage of the array
+ * iX: index where x will be stored (1-based index)
+ * x:  value to be stored
+ * iY: value to be returned (1-based index)
+ *
+ * Pierre Vigouroux, LBNL                  7/18/2011 
+ */
+
+#include "externalObjectStructure.h"
+#include <string.h>
+#include <stdlib.h>
+
 double exchangeValues(void* object, int iX, double x, int iY){
   ExternalObjectStructure* table = (ExternalObjectStructure*) object;
   const int nInc = 10;
   int nTab=table->n;
   int nNew=iX-1+nInc;
-  //  temporary array used while increasing the size of table
+  /*  temporary array used while increasing the size of table */
   double *tab2=NULL;
 
-  ////////////////////////////////////////////
-  // Check input
+  /* Check input */
   if (iX == 0 || iY == 0)
         ModelicaError("Index is one-based in exchangeValues.c.");
-  ////////////////////////////////////////////
-  // Manage memory.
-  //
-  // At first call, initialize storage
+  /* Manage memory
+   * At first call, initialize storage */
   if ( table->x == NULL ){
     table->x= malloc( nNew * sizeof(double) );
     if ( table->x == NULL ) 
@@ -42,28 +43,27 @@ double exchangeValues(void* object, int iX, double x, int iY){
   }
 
   if (iX > nTab){
-    // Assign more memory before storing the value
+    /* Assign more memory before storing the value */
     tab2 = malloc( nTab * sizeof(double) );
     if ( tab2 == NULL ) 
       ModelicaError("Out of memory in storeValue.c when allocating memory for tab2.");
     
-    // Copy the values of x in tab2
+    /* Copy the values of x in tab2 */
     memcpy(tab2, table->x, nTab * sizeof(double) );
     
-    // Increase the size of x
+    /* Increase the size of x */
     free(table->x);
     table->x = malloc(nNew * sizeof(double) );
     if ( table->x == NULL ) 
       ModelicaError("Out of memory in storeValue.c when allocating memory for table->x.");
     table->n = nNew;
-    // Copy previous values
+    /* Copy previous values */
     memcpy(table->x, tab2, nTab * sizeof(double));
     free(tab2);
   }
 
-  ////////////////////////////////////////////
-  // Store and return the data
+  /* Store and return the data */
   table->x[iX-1] = x;
-  //  printf ("returning: %4.2f", table->x[iY-1]);
+  /* printf ("returning: %4.2f", table->x[iY-1]); */
   return table->x[iY-1];
-};
+}

--- a/Buildings/Resources/C-Sources/externalObjectStructure.h
+++ b/Buildings/Resources/C-Sources/externalObjectStructure.h
@@ -1,0 +1,17 @@
+/*
+ * A structure to store an increasing number of double
+ * values.
+ */
+
+#ifndef BUILDINGS_EXTERNALOBJECTSTRUCTURE_H /* Not needed since it is only a typedef; added for safety */
+#define BUILDINGS_EXTERNALOBJECTSTRUCTURE_H
+
+typedef struct ExternalObjectStructure
+{
+  /* array where the data are stored during the simulation */
+  double* x;
+  /* Number of element in the array */
+  int n;
+} ExternalObjectStructure;
+
+#endif

--- a/Buildings/Resources/C-Sources/freeArray.c
+++ b/Buildings/Resources/C-Sources/freeArray.c
@@ -1,16 +1,18 @@
-/////////////////////////////////////////////////////
-// Modelica external function that frees the memory
-// that is allocated by initArray.c or by
-// storeValue.c
-//
-/////////////////////////////////////////////////////
-// When called by the Modelica function "initArray", 
-// this function creates a structure for an array whose
-// number of elements can be enlarged.
-//
-// Pierre Vigouroux, LBNL                  7/18/2011 
-// svn-id=$Id$
-/////////////////////////////////////////////////////
+/*
+ * Modelica external function that frees the memory
+ * that is allocated by initArray.c or by
+ * storeValue.c
+ *
+ * When called by the Modelica function "initArray", 
+ * this function creates a structure for an array whose
+ * number of elements can be enlarged.
+ *
+ * Pierre Vigouroux, LBNL                  7/18/2011 
+ */
+
+#include "externalObjectStructure.h"
+#include <stdlib.h>
+
 void freeArray(void* object)
 { /* Release table storage */
   if ( object != NULL ){
@@ -19,4 +21,3 @@ void freeArray(void* object)
     free(table);
   }
 }
-

--- a/Buildings/Resources/C-Sources/initArray.c
+++ b/Buildings/Resources/C-Sources/initArray.c
@@ -1,34 +1,28 @@
-/////////////////////////////////////////////////////
-// Modelica external function that generates a
-// structure to store an increasing number of double
-// values.
-//
-/////////////////////////////////////////////////////
-// When called by the Modelica function "initArray", 
-// this function creates a structure for an array whose
-// number of elements can be enlarged.
-//
-// Pierre Vigouroux, LBNL                  7/18/2011 
-// svn-id=$Id$
-/////////////////////////////////////////////////////
+/*
+ * Modelica external function that generates a
+ * structure to store an increasing number of double
+ * values.
+ *
+ * When called by the Modelica function "initArray", 
+ * this function creates a structure for an array whose
+ * number of elements can be enlarged.
+ *
+ * Pierre Vigouroux, LBNL                  7/18/2011 
+ */
 
-typedef struct ExternalObjectStructure
-{
-  // array where the data are stored during the simulation
-  double* x;
-  // Number of element in the array
-  int n;
-} ExternalObjectStructure;
+#include "externalObjectStructure.h"
+#include <ModelicaUtilities.h>
+#include <stdlib.h>
 
-// Create the structure "table" and return pointer to "table".
+/* Create the structure "table" and return pointer to "table". */
 void* initArray()
 {
   ExternalObjectStructure* table = malloc(sizeof(ExternalObjectStructure));
   if ( table == NULL ) 
     ModelicaError("Not enough memory in initArray.c.");
-  // Number of elements in the array
-  table->n=0;   // initialise nEle to 0
-  table->x=NULL;   // set the pointer to null
+  /* Number of elements in the array */
+  table->n=0;   /* initialise nEle to 0 */
+  table->x=NULL;   /* set the pointer to null */
 
   return (void*) table;
 };


### PR DESCRIPTION
- Changed line comments to block comments (Modelica uses C of unspecified version; C89 does not have line comments and is a common default since some companies have not yet implemented C99 support)
- The ExternalObjectStructure typedef is now defined in a header so the order in which the C-files were included no longer matters
