### PR TITLE
Fixed compilation of Python wrapper

### DIFF
--- a/Buildings/Resources/src/python/python27Wrapper.c
+++ b/Buildings/Resources/src/python/python27Wrapper.c
@@ -15,19 +15,24 @@
 //  nIntRea      - Number of integers to read.
 //  strValWri    - String values to write.
 //  nStrWri      - Number of strings to write.
+#include <ModelicaUtilities.h>
+#include "pythonInterpreter.h"
 void pythonExchangeValues(const char * moduleName,
                           const char * functionName,
-                          double * dblValWri, size_t nDblWri,
-                          double * dblValRea, size_t nDblRea,
-                          int * intValWri, size_t nIntWri,
-                          int * intValRea, size_t nIntRea,
-                          const char ** strValWri, size_t nStrWri){
-	pythonExchangeValuesNoModelica(moduleName,
-                          functionName,
-                          dblValWri, nDblWri,
-                          dblValRea, nDblRea,
-                          intValWri, nIntWri,
-                          intValRea, nIntRea,
-                          strValWri, nStrWri,
-			  ModelicaFormatError);
-				  }
+                          const double * dblValWri, int nDblWri,
+                          double * dblValRea, int nDblRea,
+                          const int * intValWri, int nIntWri,
+                          int * intValRea, int nIntRea,
+                          const char ** strValWri, int nStrWri)
+{
+  pythonExchangeValuesNoModelica(
+   moduleName,
+   functionName,
+   dblValWri, nDblWri,
+   dblValRea, nDblRea,
+   intValWri, nIntWri,
+   intValRea, nIntRea,
+   strValWri, nStrWri,
+   ModelicaFormatError
+  );
+}

--- a/Buildings/Resources/src/python/pythonInterpreter.c
+++ b/Buildings/Resources/src/python/pythonInterpreter.c
@@ -1,4 +1,5 @@
 #include "pythonInterpreter.h"
+#include <Python.h>
 void pythonExchangeValuesNoModelica(const char * moduleName,
                           const char * functionName,
                           double * dblValWri, size_t nDblWri,

--- a/Buildings/Resources/src/python/pythonInterpreter.h
+++ b/Buildings/Resources/src/python/pythonInterpreter.h
@@ -28,7 +28,6 @@
 #define MS_NO_COREDLL
 #endif
 #endif
-#include <Python.h>
 #include <stddef.h>  /* stddef defines size_t */
 
 #ifdef __cplusplus
@@ -70,9 +69,9 @@ to not export all symbols but only the needed ones */
 //  inModelicaFormatError - Pointer to ModelicaFormatError
 LBNLPYTHONINTERPRETER_EXPORT void pythonExchangeValuesNoModelica(const char * moduleName,
                           const char * functionName,
-                          double * dblValWri, size_t nDblWri,
+                          const double * dblValWri, size_t nDblWri,
                           double * dblValRea, size_t nDblRea,
-                          int * intValWri, size_t nIntWri,
+                          const int * intValWri, size_t nIntWri,
                           int * intValRea, size_t nIntRea,
                           const char ** strValWri, size_t nStrWri,
 			  void (*inModelicaFormatError)(const char *string,...));


### PR DESCRIPTION
- Move Python.h include to the c-file instead of h-file (not needed there; made compiling the Modelica wrapper harder since it depends on the h-file)
- Included all prototypes necessary to compile python27Wrapper.c
- Made input arrays const as they are required to be
- C input size_t was changed to int since the formal argument was Integer and not size(arr,dim)
