### PR TITLE
Tentative to fix issue #415. Adding a dummy interface for resistive models

### DIFF
--- a/Buildings/Electrical/AC/OnePhase/Loads/Resistive.mo
+++ b/Buildings/Electrical/AC/OnePhase/Loads/Resistive.mo
@@ -159,8 +159,10 @@ The choices are between a null current or the linearized model.
 </html>", revisions="<html>
 <ul>
 <li>May 14, 2015, by Marco Bonvini:<br/>
-Changed parent class to <code>ResistiveLoad</code> in order
-to help openmodelica parsing the model.
+Changed parent class to <a href=\"modelica://Buildings.Electrical.Interfaces.ResistiveLoad\">
+Buildings.Electrical.Interfaces.ResistiveLoad</a> in order
+to help openmodelica parsing the model. This fixes issue 
+<a href=https://github.com/lbl-srg/modelica-buildings/issues/415>#415</a>.
 </li>
 <li>September 4, 2014, by Michael Wetter:<br/>
 Revised documentation.

--- a/Buildings/Electrical/AC/OnePhase/Loads/Resistive.mo
+++ b/Buildings/Electrical/AC/OnePhase/Loads/Resistive.mo
@@ -1,6 +1,6 @@
 within Buildings.Electrical.AC.OnePhase.Loads;
 model Resistive "Model of a resistive load"
-  extends Buildings.Electrical.Interfaces.Load(
+  extends Buildings.Electrical.Interfaces.ResistiveLoad(
     redeclare package PhaseSystem = PhaseSystems.OnePhase,
     redeclare Interfaces.Terminal_n terminal,
     V_nominal(start = 110));
@@ -158,6 +158,10 @@ The choices are between a null current or the linearized model.
 
 </html>", revisions="<html>
 <ul>
+<li>May 14, 2015, by Marco Bonvini:<br/>
+Changed parent class to <code>ResistiveLoad</code> in order
+to help openmodelica parsing the model.
+</li>
 <li>September 4, 2014, by Michael Wetter:<br/>
 Revised documentation.
 </li>

--- a/Buildings/Electrical/DC/Loads/Conductor.mo
+++ b/Buildings/Electrical/DC/Loads/Conductor.mo
@@ -131,8 +131,10 @@ The points are at <i>0.8 V<sub>nom</sub></i> and <i>1.2 V<sub>nom</sub></i>.
 </html>", revisions="<html>
 <ul>
 <li>May 14, 2015, by Marco Bonvini:<br/>
-Changed parent class to <code>ResistiveLoad</code> in order
-to help openmodelica parsing the model.
+Changed parent class to <a href=\"modelica://Buildings.Electrical.Interfaces.ResistiveLoad\">
+Buildings.Electrical.Interfaces.ResistiveLoad</a> in order
+to help openmodelica parsing the model. This fixes issue 
+<a href=https://github.com/lbl-srg/modelica-buildings/issues/415>#415</a>.
 </li>
 <li>June 17, 2014, by Marco Bonvini:<br/>
 Adde parameter <code>initMode</code> that can be used to

--- a/Buildings/Electrical/DC/Loads/Conductor.mo
+++ b/Buildings/Electrical/DC/Loads/Conductor.mo
@@ -1,6 +1,6 @@
 within Buildings.Electrical.DC.Loads;
 model Conductor "Model of a generic DC load"
-    extends Buildings.Electrical.Interfaces.Load(
+    extends Buildings.Electrical.Interfaces.ResistiveLoad(
      redeclare package PhaseSystem = PhaseSystems.TwoConductor,
      redeclare Interfaces.Terminal_n terminal);
 protected
@@ -130,6 +130,10 @@ The points are at <i>0.8 V<sub>nom</sub></i> and <i>1.2 V<sub>nom</sub></i>.
 
 </html>", revisions="<html>
 <ul>
+<li>May 14, 2015, by Marco Bonvini:<br/>
+Changed parent class to <code>ResistiveLoad</code> in order
+to help openmodelica parsing the model.
+</li>
 <li>June 17, 2014, by Marco Bonvini:<br/>
 Adde parameter <code>initMode</code> that can be used to
 select the assumption to be used during initialization phase

--- a/Buildings/Electrical/DC/Loads/Resistor.mo
+++ b/Buildings/Electrical/DC/Loads/Resistor.mo
@@ -1,6 +1,6 @@
 within Buildings.Electrical.DC.Loads;
 model Resistor "Ideal linear electrical resistor"
-  extends Buildings.Electrical.Interfaces.Load(
+  extends Buildings.Electrical.Interfaces.ResistiveLoad(
     redeclare package PhaseSystem = PhaseSystems.TwoConductor,
     redeclare Interfaces.Terminal_n terminal,
     final mode=Buildings.Electrical.Types.Load.FixedZ_steady_state,
@@ -44,6 +44,10 @@ The temperature <i>T</i> is the temperature of the heat port if <code>useHeatPor
 </html>",
  revisions="<html>
 <ul>
+<li>May 14, 2015, by Marco Bonvini:<br/>
+Changed parent class to <code>ResistiveLoad</code> in order
+to help openmodelica parsing the model.
+</li>
 <li>
 February 1, 2013, by Thierry S. Nouidui:<br/>
 First implementation.

--- a/Buildings/Electrical/DC/Loads/Resistor.mo
+++ b/Buildings/Electrical/DC/Loads/Resistor.mo
@@ -45,8 +45,10 @@ The temperature <i>T</i> is the temperature of the heat port if <code>useHeatPor
  revisions="<html>
 <ul>
 <li>May 14, 2015, by Marco Bonvini:<br/>
-Changed parent class to <code>ResistiveLoad</code> in order
-to help openmodelica parsing the model.
+Changed parent class to <a href=\"modelica://Buildings.Electrical.Interfaces.ResistiveLoad\">
+Buildings.Electrical.Interfaces.ResistiveLoad</a> in order
+to help openmodelica parsing the model. This fixes issue 
+<a href=https://github.com/lbl-srg/modelica-buildings/issues/415>#415</a>.
 </li>
 <li>
 February 1, 2013, by Thierry S. Nouidui:<br/>

--- a/Buildings/Electrical/Interfaces/ResistiveLoad.mo
+++ b/Buildings/Electrical/Interfaces/ResistiveLoad.mo
@@ -1,0 +1,20 @@
+within Buildings.Electrical.Interfaces;
+partial model ResistiveLoad "Partial model of a resistive load"
+  extends Load;
+
+  annotation (Documentation(revisions="<html>
+<ul>
+<li>
+May 14, 2015, by Marco Bonvini:<br/>
+Created model to overcome limitation of OpenModelica in parsing the models
+containing resistive loads.
+</li>
+</ul>
+</html>", info="<html>
+<p>
+This is a model of a generic resistive load. This model is an extension of the base load model
+<a href=\"Buildings.Electrical.Interfaces.PartialLoad\">
+Buildings.Electrical.Interfaces.PartialLoad</a>.
+</p>
+</html>"));
+end ResistiveLoad;

--- a/Buildings/Electrical/Interfaces/ResistiveLoad.mo
+++ b/Buildings/Electrical/Interfaces/ResistiveLoad.mo
@@ -6,8 +6,23 @@ partial model ResistiveLoad "Partial model of a resistive load"
 <ul>
 <li>
 May 14, 2015, by Marco Bonvini:<br/>
-Created model to overcome limitation of OpenModelica in parsing the models
-containing resistive loads.
+Created model to solve problems related to OpenModelica as described 
+in issue <a href=https://github.com/lbl-srg/modelica-buildings/issues/415>#415</a>.<br/>
+OpenModelica cannot determine the value
+<code>PhaseSystem.n</code> when models like
+<a href=\"modelica://Buildings.Electrical.AC.OnePhase.Loads.Resistive\">
+Buildings.Electrical.AC.OnePhase.Loads.Resistive</a>
+inherit directly from
+<a href=\"modelica://Buildings.Electrical.Interfaces.LoadBuildings.Electrical.Interfaces.Load\">
+Buildings.Electrical.Interfaces.LoadBuildings.Electrical.Interfaces.Load</a>.<br/>
+The same problem does not happen with models like
+<a href=\"modelica://Buildings.Electrical.AC.OnePhase.Loads.Capacitive\">
+Buildings.Electrical.AC.OnePhase.Loads.Capacitive</a> or
+<a href=\"modelica://Buildings.Electrical.AC.OnePhase.Loads.Inductive\">
+Buildings.Electrical.AC.OnePhase.Loads.Inductive</a> since they inherit
+from a different model.<br/>
+For such a reason this interface for resistive load model has been
+added to the library.
 </li>
 </ul>
 </html>", info="<html>

--- a/Buildings/Electrical/Interfaces/package.order
+++ b/Buildings/Electrical/Interfaces/package.order
@@ -12,6 +12,7 @@ PartialPvBase
 PartialTwoPort
 PartialWindTurbine
 PartialWindTurbineBase
+ResistiveLoad
 Source
 Terminal
 VariableVoltageSource


### PR DESCRIPTION
The simple addition of a new interface for resistive models (basically an empty wrapper of the basic Load interface) seems to help the OpenModelica parser.

This is supposed to fix issue #415.