### PR TITLE
Fixed sign mistake causing solar collector model to fail under high

### DIFF
--- a/Buildings/Fluid/SolarCollectors/BaseClasses/ASHRAESolarGain.mo
+++ b/Buildings/Fluid/SolarCollectors/BaseClasses/ASHRAESolarGain.mo
@@ -116,7 +116,7 @@ equation
     QSol_flow[i] = A_c/nSeg*(y_intercept*iam*(HDirTil*(1.0 -
     shaCoe_internal) + HSkyDifTil + HGroDifTil))*
     Buildings.Utilities.Math.Functions.smoothHeaviside(
-     (Medium.T_max+1)-TFlu[i],1);
+     (Medium.T_max-1)-TFlu[i],1);
   end for;
 
   annotation (
@@ -218,15 +218,21 @@ equation
       </p>
     </html>",
     revisions="<html>
-      <ul>
-      <li>
-      November 20, 2014, by Michael Wetter:<br/>
-      Added missing <code>each</code> keyword.
-      </li>
-        <li>
-          Jan 15, 2013, by Peter Grant:<br/>
-          First implementation
-        </li>
-      </ul>
-    </html>"));
+<ul>
+<li>
+June 29, 2015, by Filip Jorissen:<br/>
+Fixed sign mistake causing model to fail under high
+solar irradiation because temperature goes above medium
+temperature bound.
+</li>
+<li>
+November 20, 2014, by Michael Wetter:<br/>
+Added missing <code>each</code> keyword.
+</li>
+<li>
+Jan 15, 2013, by Peter Grant:<br/>
+First implementation
+</li>
+</ul>
+</html>"));
 end ASHRAESolarGain;

--- a/Buildings/Fluid/SolarCollectors/BaseClasses/EN12975SolarGain.mo
+++ b/Buildings/Fluid/SolarCollectors/BaseClasses/EN12975SolarGain.mo
@@ -65,7 +65,7 @@ equation
 
   for i in 1 : nSeg loop
   QSol_flow[i] = A_c/nSeg*(y_intercept*(iamBea*HDirTil*(1.0 - shaCoe_internal) + iamDiff *
-  HSkyDifTil))*Buildings.Utilities.Math.Functions.smoothHeaviside((Medium.T_max+1)-TFlu[i],1);
+  HSkyDifTil))*Buildings.Utilities.Math.Functions.smoothHeaviside((Medium.T_max-1)-TFlu[i],1);
   end for;
   annotation (
     defaultComponentName="solGai",
@@ -137,11 +137,17 @@ equation
       </p>
     </html>",
     revisions="<html>
-      <ul>
-        <li>
-          Jan 15, 2013, by Peter Grant:<br/>
-          First implementation
-        </li>
-      </ul>
-    </html>"));
+<ul>
+<li>
+June 29, 2015, by Filip Jorissen:<br/>
+Fixed sign mistake causing model to fail under high
+solar irradiation because temperature goes above 
+medium temperature bound.
+</li>
+<li>
+Jan 15, 2013, by Peter Grant:<br/>
+First implementation
+</li>
+</ul>
+</html>"));
 end EN12975SolarGain;


### PR DESCRIPTION
solar irradiation because temperature goes above medium temperature bound.

I did not run unit tests since I get an error:
```
*** Error: Fan.mos does not contain any plot command.
You need to add a plot command to include its
results in the regression tests.
```
