### PR TITLE
Issue434 tan dyn

### DIFF
--- a/Buildings/Fluid/Storage/BaseClasses/IndirectTankHeatExchanger.mo
+++ b/Buildings/Fluid/Storage/BaseClasses/IndirectTankHeatExchanger.mo
@@ -41,10 +41,13 @@ model IndirectTankHeatExchanger
     "Exterior diameter of the heat exchanger pipe";
 
   parameter Modelica.Fluid.Types.Dynamics energyDynamics=Modelica.Fluid.Types.Dynamics.DynamicFreeInitial
-    "Formulation of energy balance"
+    "Formulation of energy balance for heat exchanger internal fluid mass"
+    annotation(Evaluate=true, Dialog(tab = "Dynamics", group="Equations"));
+  parameter Modelica.Fluid.Types.Dynamics energyDynamicsSolid=Modelica.Fluid.Types.Dynamics.DynamicFreeInitial
+    "Formulation of energy balance for heat exchanger solid mass"
     annotation(Evaluate=true, Dialog(tab = "Dynamics", group="Equations"));
   parameter Modelica.Fluid.Types.Dynamics massDynamics=energyDynamics
-    "Formulation of mass balance"
+    "Formulation of mass balance for heat exchanger"
     annotation(Evaluate=true, Dialog(tab = "Dynamics", group="Equations"));
 
   parameter Boolean homotopyInitialization = true "= true, use homotopy method"
@@ -86,7 +89,7 @@ model IndirectTankHeatExchanger
           each fixed=(energyDynamics == Modelica.Fluid.Types.Dynamics.FixedInitial)),
         der_T(
           each fixed=(energyDynamics == Modelica.Fluid.Types.Dynamics.SteadyStateInitial))) if
-        not (energyDynamics == Modelica.Fluid.Types.Dynamics.SteadyState)
+             not energyDynamicsSolid == Modelica.Fluid.Types.Dynamics.SteadyState
     "Thermal mass of the heat exchanger"
     annotation (Placement(transformation(extent={{-6,6},{14,26}})));
 protected
@@ -283,6 +286,13 @@ equation
           </html>",
           revisions="<html>
           <ul>
+<li>
+July 1, 2015, by Filip Jorissen:<br/>
+Added parameter <code>energyDynamicsSolid</code>.
+This is for 
+<a href=\"https://github.com/lbl-srg/modelica-buildings/issues/434\">
+#434</a>.
+</li>
 <li>
 March 28, 2015, by Filip Jorissen:<br/>
 Propagated <code>allowFlowReversal</code>.

--- a/Buildings/Fluid/Storage/StratifiedEnhancedInternalHex.mo
+++ b/Buildings/Fluid/Storage/StratifiedEnhancedInternalHex.mo
@@ -62,10 +62,13 @@ model StratifiedEnhancedInternalHex
 
   parameter Modelica.Fluid.Types.Dynamics energyDynamicsHex=
     Modelica.Fluid.Types.Dynamics.DynamicFreeInitial
-    "Formulation of energy balance"
+    "Formulation of energy balance for heat exchanger internal fluid mass"
     annotation(Evaluate=true, Dialog(tab = "Dynamics heat exchanger", group="Equations"));
   parameter Modelica.Fluid.Types.Dynamics massDynamicsHex=
-    energyDynamicsHex "Formulation of mass balance"
+    energyDynamicsHex "Formulation of mass balance for heat exchanger"
+    annotation(Evaluate=true, Dialog(tab = "Dynamics heat exchanger", group="Equations"));
+  parameter Modelica.Fluid.Types.Dynamics energyDynamicsHexSolid=Modelica.Fluid.Types.Dynamics.DynamicFreeInitial
+    "Formulation of energy balance for heat exchanger solid mass"
     annotation(Evaluate=true, Dialog(tab = "Dynamics heat exchanger", group="Equations"));
 
   parameter Modelica.SIunits.Length lHex=
@@ -126,7 +129,8 @@ model StratifiedEnhancedInternalHex
     final linearizeFlowResistance=linearizeFlowResistance,
     final deltaM=deltaM,
     final allowFlowReversal=allowFlowReversalHex,
-    final m_flow_small=1e-4*abs(mHex_flow_nominal))
+    final m_flow_small=1e-4*abs(mHex_flow_nominal),
+    final energyDynamicsSolid=energyDynamicsHexSolid)
     "Heat exchanger inside the tank"
      annotation (Placement(
         transformation(
@@ -159,6 +163,7 @@ protected
 
   final parameter Integer nSegHex = nSegHexTan*hexSegMult
     "Number of heat exchanger segments";
+
 initial equation
   assert(hHex_a >= 0 and hHex_a <= hTan,
     "The parameter hHex_a is outside its valid range.");
@@ -245,6 +250,13 @@ The model requires at least 4 fluid segments. Hence, set <code>nSeg</code> to 4 
 </html>",
 revisions="<html>
 <ul>
+<li>
+July 1, 2015, by Filip Jorissen:<br/>
+Added parameter <code>energyDynamicsHexSolid</code>.
+This is for 
+<a href=\"https://github.com/lbl-srg/modelica-buildings/issues/434\">
+#434</a>.
+</li>
 <li>
 March 28, 2015, by Filip Jorissen:<br/>
 Propagated <code>allowFlowReversal</code> and <code>m_flow_small</code>.

--- a/Buildings/Fluid/Storage/StratifiedEnhancedInternalHex.mo
+++ b/Buildings/Fluid/Storage/StratifiedEnhancedInternalHex.mo
@@ -67,7 +67,7 @@ model StratifiedEnhancedInternalHex
   parameter Modelica.Fluid.Types.Dynamics massDynamicsHex=
     energyDynamicsHex "Formulation of mass balance for heat exchanger"
     annotation(Evaluate=true, Dialog(tab = "Dynamics heat exchanger", group="Equations"));
-  parameter Modelica.Fluid.Types.Dynamics energyDynamicsHexSolid=Modelica.Fluid.Types.Dynamics.DynamicFreeInitial
+  parameter Modelica.Fluid.Types.Dynamics energyDynamicsHexSolid=energyDynamicsHex
     "Formulation of energy balance for heat exchanger solid mass"
     annotation(Evaluate=true, Dialog(tab = "Dynamics heat exchanger", group="Equations"));
 
@@ -110,6 +110,8 @@ model StratifiedEnhancedInternalHex
         iconTransformation(extent={{-110,-90},{-90,-70}})));
 
   BaseClasses.IndirectTankHeatExchanger indTanHex(
+    redeclare final package MediumTan = Medium,
+    redeclare final package MediumHex = MediumHex,
     final nSeg=nSegHex,
     final CHex=CHex,
     final volHexFlu=volHexFlu,
@@ -118,19 +120,17 @@ model StratifiedEnhancedInternalHex
     final THex_nominal=THex_nominal,
     final r_nominal=r_nominal,
     final dExtHex=dExtHex,
-    redeclare final package MediumTan = Medium,
-    redeclare final package MediumHex = MediumHex,
     final dp_nominal=dpHex_nominal,
     final m_flow_nominal=mHex_flow_nominal,
     final energyDynamics=energyDynamicsHex,
+    final energyDynamicsSolid=energyDynamicsHexSolid,
     final massDynamics=massDynamicsHex,
     final computeFlowResistance=computeFlowResistance,
     from_dp=from_dp,
     final linearizeFlowResistance=linearizeFlowResistance,
     final deltaM=deltaM,
     final allowFlowReversal=allowFlowReversalHex,
-    final m_flow_small=1e-4*abs(mHex_flow_nominal),
-    final energyDynamicsSolid=energyDynamicsHexSolid)
+    final m_flow_small=1e-4*abs(mHex_flow_nominal))
     "Heat exchanger inside the tank"
      annotation (Placement(
         transformation(
@@ -184,11 +184,11 @@ equation
      end for;
    end for;
   connect(portHex_a, indTanHex.port_a) annotation (Line(
-      points={{-100,-38},{-74,-38},{-74,32},{-77,32}},
+      points={{-100,-38},{-68,-38},{-68,32},{-77,32}},
       color={0,127,255},
       smooth=Smooth.None));
   connect(indTanHex.port_b, portHex_b) annotation (Line(
-      points={{-97,32},{-100,32},{-100,20},{-76,20},{-76,-80},{-100,-80}},
+      points={{-97,32},{-98,32},{-98,18},{-70,18},{-70,-80},{-100,-80}},
       color={0,127,255},
       smooth=Smooth.None));
 
@@ -250,6 +250,13 @@ The model requires at least 4 fluid segments. Hence, set <code>nSeg</code> to 4 
 </html>",
 revisions="<html>
 <ul>
+<li>
+July 2, 2015, by Michael Wetter:<br/>
+Set the default value <code>energyDynamicsHexSolid=energyDynamicsHex</code>
+rather than
+<code>energyDynamicsHexSolid=Modelica.Fluid.Types.Dynamics.DynamicFreeInitial</code>
+as users are not likely to want different settings.
+</li>
 <li>
 July 1, 2015, by Filip Jorissen:<br/>
 Added parameter <code>energyDynamicsHexSolid</code>.

--- a/Buildings/Fluid/Storage/UsersGuide.mo
+++ b/Buildings/Fluid/Storage/UsersGuide.mo
@@ -120,6 +120,7 @@ width=\"458\" height=\"456\"/>
 <p>
 Optionally, this model computes a dynamic response of the heat exchanger.
 This can be configured using the parameters
+<code>energyDynamicsHexSolid</code>,
 <code>energyDynamicsHex</code> and
 <code>massDynamicsHex</code>.
 For this computation, the fluid volume inside the heat exchanger
@@ -140,6 +141,15 @@ where <i>h</i> is the distance between the heat exchanger inlet and outlet.
 The wall thickness is assumed to be <i>10%</i> of the heat exchanger
 outer diameter.
 For typical applications, users do not need to change these values.
+</p>
+<p>
+Setting <code>energyDynamicsHexSolid</code> to a dynamic balance and
+<code>energyDynamicsHex</code> to a steady-state balance may be of interest
+to remove very fast dynamics of the fluid, while still modeling slower
+dynamics that arises from the metal of the heat exchanger.
+By default, <code>energyDynamicsHexSolid</code> is set
+to the same value as <code>energyDynamicsHex</code>
+as this seems to be the typical configuration.
 </p>
 <p>
 The heat exchanger is implemented in

--- a/Buildings/package.mo
+++ b/Buildings/package.mo
@@ -217,6 +217,15 @@ its class name ends with the string <code>Beta</code>.
                           the model guiding against the violation of these bounds.
        </td>
    </tr>
+   <tr><td valign=\"top\">Buildings.Fluid.Storage.StratifiedEnhancedInternalHex
+       </td>
+       <td valign=\"top\">Added option to set dynamics of heat exchanger material
+                        separately from the dynamics of the fluid inside the heat
+                        exchanger.
+                        This is for issue
+                        <a href=\"https://github.com/lbl-srg/modelica-buildings/issues/434\">#434</a>.
+       </td>
+   </tr>
    <tr><td valign=\"top\">Buildings.Fluid.Interfaces.FourPortHeatMassExchanger<br/>
                           Buildings.Fluid.Interfaces.TwoPortHeatMassExchanger
 


### PR DESCRIPTION
This adds the option to configure the dynamics of the heat exchanger metal independently of the dynamics of the fluid.
The default settings are such that the results are as before, and the model is backwards compatible.

This will close #434 .