### PR TITLE
Refactor for JModelica translation.

### DIFF
--- a/Buildings/Fluid/HeatExchangers/RadiantSlabs/SingleCircuitSlab.mo
+++ b/Buildings/Fluid/HeatExchangers/RadiantSlabs/SingleCircuitSlab.mo
@@ -36,8 +36,8 @@ model SingleCircuitSlab "Model of a single circuit of a radiant slab"
   Buildings.HeatTransfer.Conduction.MultiLayer con_a[nSeg](
     each final A=A/nSeg,
     each final steadyStateInitial=steadyStateInitial,
-    each final nSta2={layers.material[i].nSta for i in 1:1:iLayPip},
     each layers(
+      final nSta2={layers.material[i].nSta for i in 1:1:iLayPip},
       final nLay = iLayPip,
       final material={layers.material[i] for i in 1:iLayPip},
       final absIR_a=layers.absIR_a,
@@ -56,8 +56,8 @@ model SingleCircuitSlab "Model of a single circuit of a radiant slab"
   Buildings.HeatTransfer.Conduction.MultiLayer con_b[nSeg](
       each final A=A/nSeg,
       each final steadyStateInitial=steadyStateInitial,
-      each final nSta2={layers.material[i].nSta for i in iLayPip + 1:layers.nLay},
       each layers(
+        final nSta2={layers.material[i].nSta for i in iLayPip + 1:layers.nLay},
         final nLay = layers.nLay-iLayPip,
         final material={layers.material[i] for i in iLayPip + 1:layers.nLay},
         final absIR_a=layers.absIR_a,

--- a/Buildings/Fluid/HeatExchangers/RadiantSlabs/SingleCircuitSlab.mo
+++ b/Buildings/Fluid/HeatExchangers/RadiantSlabs/SingleCircuitSlab.mo
@@ -37,7 +37,7 @@ model SingleCircuitSlab "Model of a single circuit of a radiant slab"
     each final A=A/nSeg,
     each final steadyStateInitial=steadyStateInitial,
     each layers(
-      final nSta2={layers.material[i].nSta for i in 1:1:iLayPip},
+      final nSta={layers.material[i].nSta for i in 1:1:iLayPip},
       final nLay = iLayPip,
       final material={layers.material[i] for i in 1:iLayPip},
       final absIR_a=layers.absIR_a,
@@ -57,7 +57,7 @@ model SingleCircuitSlab "Model of a single circuit of a radiant slab"
       each final A=A/nSeg,
       each final steadyStateInitial=steadyStateInitial,
       each layers(
-        final nSta2={layers.material[i].nSta for i in iLayPip + 1:layers.nLay},
+        final nSta={layers.material[i].nSta for i in iLayPip + 1:layers.nLay},
         final nLay = layers.nLay-iLayPip,
         final material={layers.material[i] for i in iLayPip + 1:layers.nLay},
         final absIR_a=layers.absIR_a,
@@ -225,6 +225,10 @@ user's guide</a> for more information.
 </html>",
 revisions="<html>
 <ul>
+<li>
+January 06, 2016, by Thierry S. Nouidui:<br/>
+Renamed parameter <code>nSta2</code> to <code>nSta</code>.
+</li>
 <li>
 November 17, 2016, by Thierry S. Nouidui:<br/>
 Added parameter <code>nSta2</code> to avoid translation error

--- a/Buildings/HeatTransfer/Conduction/MultiLayer.mo
+++ b/Buildings/HeatTransfer/Conduction/MultiLayer.mo
@@ -31,6 +31,7 @@ protected
     sum(layers.material[k].R for k in 1:i) for i in 1:size(layers.material, 1)},
    each steadyStateInitial = steadyStateInitial) "Material layer"
     annotation (Placement(transformation(extent={{-20,-10},{0,10}})));
+
 equation
   // This section assigns the temperatures and heat flow rates of the layer models to
   // an array that makes plotting the results easier.

--- a/Buildings/HeatTransfer/Conduction/MultiLayer.mo
+++ b/Buildings/HeatTransfer/Conduction/MultiLayer.mo
@@ -3,9 +3,9 @@ model MultiLayer
   "Model for heat conductance through a solid with multiple material layers"
   extends Buildings.HeatTransfer.Conduction.BaseClasses.PartialConductor(
    final R=sum(layers.material[i].R for i in 1:size(layers.material, 1)));
-  Modelica.SIunits.Temperature T[sum(nSta)](
+  Modelica.SIunits.Temperature T[sum(layers.nSta2)](
     each nominal = 300) "Temperature at the states";
-  Modelica.SIunits.HeatFlowRate Q_flow[sum(nSta)+nLay]
+  Modelica.SIunits.HeatFlowRate Q_flow[sum(layers.nSta2)+nLay]
     "Heat flow rate from state i to i+1";
   extends Buildings.HeatTransfer.Conduction.BaseClasses.PartialConstruction;
 
@@ -18,13 +18,9 @@ model MultiLayer
     annotation (Dialog(tab="Dynamics"),
                 Evaluate=true);
 
-  parameter Integer nSta2[nLay]={layers.material[i].nSta for i in 1:nLay}
-  "Number of states in a material (do not overwrite, used to work around Dymola 2017 bug)"
-     annotation (Evaluate=true);
-
 protected
   Buildings.HeatTransfer.Conduction.SingleLayer[nLay] lay(
-   final nSta2={nSta2[i] for i in 1:nLay},
+   final nSta2={layers.nSta2[i] for i in 1:nLay},
    each final A=A,
    final stateAtSurface_a = {if i == 1 then stateAtSurface_a else false for i in 1:nLay},
    final stateAtSurface_b = {if i == nLay then stateAtSurface_b else false for i in 1:nLay},
@@ -39,11 +35,11 @@ equation
   // This section assigns the temperatures and heat flow rates of the layer models to
   // an array that makes plotting the results easier.
   for i in 1:nLay loop
-    for j in 1:nSta[i] loop
-      T[sum(nSta[k] for k in 1:(i-1)) +j] = lay[i].T[j];
+    for j in 1:layers.nSta2[i] loop
+      T[sum(layers.nSta2[k] for k in 1:(i-1)) +j] = lay[i].T[j];
     end for;
-    for j in 1:nSta[i]+1 loop
-      Q_flow[sum(nSta[k] for k in 1:i-1)+(i-1)+j] = lay[i].Q_flow[j];
+    for j in 1:layers.nSta2[i]+1 loop
+      Q_flow[sum(layers.nSta2[k] for k in 1:i-1)+(i-1)+j] = lay[i].Q_flow[j];
     end for;
   end for;
   connect(port_a, lay[1].port_a) annotation (Line(
@@ -175,6 +171,10 @@ Buildings.HeatTransfer.Examples</a>.
 </p>
 </html>", revisions="<html>
 <ul>
+<li>
+January 05, 2017, by Thierry S. Nouidui:<br/>
+Removed parameter <code>nSta2</code>.
+</li>
 <li>
 November 17, 2016, by Thierry S. Nouidui:<br/>
 Added parameter <code>nSta2</code> to avoid translation error

--- a/Buildings/HeatTransfer/Conduction/MultiLayer.mo
+++ b/Buildings/HeatTransfer/Conduction/MultiLayer.mo
@@ -3,9 +3,9 @@ model MultiLayer
   "Model for heat conductance through a solid with multiple material layers"
   extends Buildings.HeatTransfer.Conduction.BaseClasses.PartialConductor(
    final R=sum(layers.material[i].R for i in 1:size(layers.material, 1)));
-  Modelica.SIunits.Temperature T[sum(layers.nSta2)](
+  Modelica.SIunits.Temperature T[sum(layers.nSta)](
     each nominal = 300) "Temperature at the states";
-  Modelica.SIunits.HeatFlowRate Q_flow[sum(layers.nSta2)+nLay]
+  Modelica.SIunits.HeatFlowRate Q_flow[sum(layers.nSta)+nLay]
     "Heat flow rate from state i to i+1";
   extends Buildings.HeatTransfer.Conduction.BaseClasses.PartialConstruction;
 
@@ -20,7 +20,7 @@ model MultiLayer
 
 protected
   Buildings.HeatTransfer.Conduction.SingleLayer[nLay] lay(
-   final nSta2={layers.nSta2[i] for i in 1:nLay},
+   final nSta2={layers.nSta[i] for i in 1:nLay},
    each final A=A,
    final stateAtSurface_a = {if i == 1 then stateAtSurface_a else false for i in 1:nLay},
    final stateAtSurface_b = {if i == nLay then stateAtSurface_b else false for i in 1:nLay},
@@ -35,11 +35,11 @@ equation
   // This section assigns the temperatures and heat flow rates of the layer models to
   // an array that makes plotting the results easier.
   for i in 1:nLay loop
-    for j in 1:layers.nSta2[i] loop
-      T[sum(layers.nSta2[k] for k in 1:(i-1)) +j] = lay[i].T[j];
+    for j in 1:layers.nSta[i] loop
+      T[sum(layers.nSta[k] for k in 1:(i-1)) +j] = lay[i].T[j];
     end for;
-    for j in 1:layers.nSta2[i]+1 loop
-      Q_flow[sum(layers.nSta2[k] for k in 1:i-1)+(i-1)+j] = lay[i].Q_flow[j];
+    for j in 1:layers.nSta[i]+1 loop
+      Q_flow[sum(layers.nSta[k] for k in 1:i-1)+(i-1)+j] = lay[i].Q_flow[j];
     end for;
   end for;
   connect(port_a, lay[1].port_a) annotation (Line(

--- a/Buildings/HeatTransfer/Conduction/SingleLayer.mo
+++ b/Buildings/HeatTransfer/Conduction/SingleLayer.mo
@@ -48,7 +48,7 @@ model SingleLayer "Model for single layer heat conductance"
     annotation (Dialog(group="Initialization", enable=not steadyStateInitial));
   parameter Integer nSta2=material.nSta
   "Number of states in a material (do not overwrite, used to work around Dymola 2017 bug)"
-     annotation (Evaluate=true);
+     annotation (Evaluate=true, HideResult=true, Dialog(enable=false, tab="Advanced"));
 protected
   final parameter Integer nSta=
     max(nSta2,

--- a/Buildings/HeatTransfer/Data/OpaqueConstructions.mo
+++ b/Buildings/HeatTransfer/Data/OpaqueConstructions.mo
@@ -11,8 +11,9 @@ package OpaqueConstructions
       annotation (choicesAllMatching=true, Evaluate=false, Placement(transformation(extent={{60,60},{80,80}})));
    final parameter Real R(unit="m2.K/W")=sum(material[i].R for i in 1:nLay)
       "Thermal resistance per unit area";
-   parameter Integer nSta[nLay](each min=1)={material[i].nSta for i in 1:nLay}
-      "Number of states (do not overwrite, used to work around Dymola 2017 bug)";
+    parameter Integer nSta[nLay](each min=1) = {material[i].nSta for i in 1:nLay}
+      "Number of states (do not overwrite, used to work around Dymola 2017 bug)"
+      annotation (HideResult=true, Dialog(enable=false, tab="Advanced"));
    parameter Modelica.SIunits.Emissivity absIR_a=0.9
       "Infrared absorptivity of surface a (usually outside-facing surface)";
    parameter Modelica.SIunits.Emissivity absIR_b=0.9

--- a/Buildings/HeatTransfer/Data/OpaqueConstructions.mo
+++ b/Buildings/HeatTransfer/Data/OpaqueConstructions.mo
@@ -11,8 +11,8 @@ package OpaqueConstructions
       annotation (choicesAllMatching=true, Evaluate=false, Placement(transformation(extent={{60,60},{80,80}})));
    final parameter Real R(unit="m2.K/W")=sum(material[i].R for i in 1:nLay)
       "Thermal resistance per unit area";
-   parameter Integer nSta2[nLay](each min=1)={material[i].nSta for i in 1:nLay}
-      "Number of states";
+   parameter Integer nSta[nLay](each min=1)={material[i].nSta for i in 1:nLay}
+      "Number of states (do not overwrite, used to work around Dymola 2017 bug)";
    parameter Modelica.SIunits.Emissivity absIR_a=0.9
       "Infrared absorptivity of surface a (usually outside-facing surface)";
    parameter Modelica.SIunits.Emissivity absIR_b=0.9
@@ -78,7 +78,7 @@ Buildings.HeatTransfer.Convection.Exterior</a>.
 <ul>
 <li>
 January 05, 2017, by Thierry S. Nouidui:<br/>
-Added parameter <code>nSta2</code> to avoid translation error
+Added parameter <code>nSta</code> to avoid translation error
 in Dymola 2107. This is a work-around for a bug in Dymola
 which will be addressed in future releases.
 </li>

--- a/Buildings/HeatTransfer/Data/OpaqueConstructions.mo
+++ b/Buildings/HeatTransfer/Data/OpaqueConstructions.mo
@@ -11,7 +11,8 @@ package OpaqueConstructions
       annotation (choicesAllMatching=true, Evaluate=false, Placement(transformation(extent={{60,60},{80,80}})));
    final parameter Real R(unit="m2.K/W")=sum(material[i].R for i in 1:nLay)
       "Thermal resistance per unit area";
-
+   parameter Integer nSta2[nLay](each min=1)={material[i].nSta for i in 1:nLay}
+      "Number of states";
    parameter Modelica.SIunits.Emissivity absIR_a=0.9
       "Infrared absorptivity of surface a (usually outside-facing surface)";
    parameter Modelica.SIunits.Emissivity absIR_b=0.9
@@ -73,9 +74,14 @@ and temperature difference. See
 Buildings.HeatTransfer.Convection.Exterior</a>.
 </p>
 </html>",
-  revisions=
-  "<html>
+  revisions="<html>
 <ul>
+<li>
+January 05, 2017, by Thierry S. Nouidui:<br/>
+Added parameter <code>nSta2</code> to avoid translation error
+in Dymola 2107. This is a work-around for a bug in Dymola
+which will be addressed in future releases.
+</li>
 <li>
 July 1, 2013, by Michael Wetter:<br/>
 Changed the annotation of the instance <code>material</code>


### PR DESCRIPTION
This is for #614. This addresses  an `Array index out of bounds: 3, index expression: j` compilation issue in JModelica.
This however does not cause the model to compile as JModelica reports following error:
> Error: in file 'null':
> Semantic error at line 0, column 0: Index reduction failed: Maximum number of differentiations has been reached.
The refactoring is however better as it does not expose the parameter `nSta2` anymore.
The refactoring does not change any reference results.

