### PR TITLE
Add compiler directives.

### DIFF
--- a/Buildings/Resources/C-Sources/cfdCosimulation.h
+++ b/Buildings/Resources/C-Sources/cfdCosimulation.h
@@ -14,7 +14,10 @@
 
 #include <stdio.h>
 
-#if defined(_MSC_VER) || defined(__WIN32__) /* Windows */
+#if defined(_MSC_VER) || defined(__WIN32__) \
+ || defined(_WIN32) || defined(WIN32)  \
+ || defined(__CYGWIN__) || defined(__MINGW32__) \
+ || defined(__BORLANDC__) /*Windows and MinGW */
 #include <windows.h>
 #define sleep(x) Sleep(1000*x)
 #else /* Linux*/

--- a/Buildings/Resources/C-Sources/cfdStartCosimulation.c
+++ b/Buildings/Resources/C-Sources/cfdStartCosimulation.c
@@ -144,7 +144,10 @@ int cfdStartCosimulation(char *cfdFilNam, char **name, double *A, double *til,
   /****************************************************************************
   | Get a handle to the DLL module.
   ****************************************************************************/
-#ifdef _MSC_VER || __WIN32__ /*Windows. The WIN32 test is for MinGW */
+#if defined(_MSC_VER) || defined(__WIN32__) \
+ || defined(_WIN32) || defined(WIN32)  \
+ || defined(__CYGWIN__) || defined(__MINGW32__) \
+ || defined(__BORLANDC__) /*Windows and MinGW */
 
 #if _WIN64
   hinstLib = LoadLibrary(TEXT("Resources/Library/win64/ffd.dll"));
@@ -171,7 +174,10 @@ int cfdStartCosimulation(char *cfdFilNam, char **name, double *A, double *til,
 
   /* If the handle is valid, try to get the function address.*/
   if(hinstLib!=NULL) {
-#ifdef _MSC_VER
+#if defined(_MSC_VER) || defined(__WIN32__) \
+ || defined(_WIN32) || defined(WIN32)  \
+ || defined(__CYGWIN__) || defined(__MINGW32__) \
+ || defined(__BORLANDC__) /*Windows and MinGW */
     ProcAdd = (MYPROC) GetProcAddress(hinstLib, "ffd_dll");
 #else
     ProcAdd = (MYPROC) dlsym(hinstLib, "ffd_dll");


### PR DESCRIPTION
@mwetter
I think I have added the compiler directive which works with MinGW. However I am now getting following error messages:

```
FMIL: module = FMICAPI, log level = 5: Calling fmiInitialize
FMIL: module = Model, log level = 4: [INFO][FMU status:OK] <JMIRuntime><value name="build_date">"Feb  1 2017"</value> <value name="build_time">"15:39:37"</value></JMIRuntime>
FMIL: module = Model, log level = 3: [WARNING][FMU status:Warning] <ModelicaMessage category="warning"><value name="msg">"... loading ""tab1"" from ""Z:/Ubuntu/proj/buildings_library/models/modelica/git/buildings/modelica-buildings/Buildings/Resources/weatherdata/USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.mos""&#10;"</value></ModelicaMessage>
FMIL: module = Model, log level = 3: [WARNING][FMU status:Warning] <ModelicaMessage category="warning"><value name="msg">"... loading ""tab1"" from ""Z:/Ubuntu/proj/buildings_library/models/modelica/git/buildings/modelica-buildings/Buildings/Resources/weatherdata/USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.mos""&#10;"</value></ModelicaMessage>
FMIL: module = Model, log level = 3: [WARNING][FMU status:Warning]   <UBoundExceeded category="warning"><value name="message">"Out of bounds for variable roo.irRadExc.J[1]"</value></UBoundExceeded>
FMIL: module = Model, log level = 3: [WARNING][FMU status:Warning]   <UBoundExceeded category="warning"><value name="message">"Out of bounds for variable roo.irRadExc.J[2]"</value></UBoundExceeded>
FMIL: module = Model, log level = 3: [WARNING][FMU status:Warning]   <UBoundExceeded category="warning"><value name="message">"Out of bounds for variable roo.irRadExc.J[3]"</value></UBoundExceeded>
FMIL: module = Model, log level = 3: [WARNING][FMU status:Warning]   <UBoundExceeded category="warning"><value name="message">"Out of bounds for variable roo.irRadExc.J[4]"</value></UBoundExceeded>
FMIL: module = Model, log level = 3: [WARNING][FMU status:Warning]   <UBoundExceeded category="warning"><value name="message">"Out of bounds for variable roo.irRadExc.J[5]"</value></UBoundExceeded>
FMIL: module = Model, log level = 3: [WARNING][FMU status:Warning]   <UBoundExceeded category="warning"><value name="message">"Out of bounds for variable roo.irRadExc.J[6]"</value></UBoundExceeded>
FMIL: module = Model, log level = 3: [WARNING][FMU status:Warning] <ModelicaMessage category="warning"><value name="msg">"Start cosimulation&#10;"</value></ModelicaMessage>
FMIL: module = Model, log level = 3: [WARNING][FMU status:Warning] <ModelicaError category="warning"><value name="msg">"Error: Could not find dll handle.&#10;"</value></ModelicaError>
FMIL: module = Model, log level = 2: [INFO][FMU status:Error] Initialization failed.
FMIL: module = FMICAPI, log level = 5: Calling fmiFreeModelInstance
FMIL: module = FMILIB, log level = 5: Releasing FMU CAPI interface
FMIL: module = FMICAPI, log level = 5: Successfully unloaded FMU binary
FMIL: module = FMILIB, log level = 5: Releasing allocated library resources
FMIL: module = JMPRT, log level = 5: Removing c:\users\thierry\appdata\local\temp\JModelica.org
```
One issue that I see is that Line 153/155 of this code https://github.com/lbl-srg/modelica-buildings/blob/issue612_ffd_mingw/Buildings/Resources/C-Sources/cfdStartCosimulation.c
loads a library which is supposed to be in the Resources folder. Now how does this work with JModelica which exports the model as an FMU? This is for #612.