### PR TITLE
Fixed TApproach mistake and mistake in validation model

### DIFF
--- a/Buildings/Experimental/DistrictHeatingCooling/Plants/LakeWaterHeatExchanger_T.mo
+++ b/Buildings/Experimental/DistrictHeatingCooling/Plants/LakeWaterHeatExchanger_T.mo
@@ -157,10 +157,10 @@ protected
   Modelica.Blocks.Sources.Constant TAppHex(k=TApp)
     "Approach temperature difference"
     annotation (Placement(transformation(extent={{-80,180},{-60,200}})));
-  Modelica.Blocks.Math.Add TWatHea
+  Modelica.Blocks.Math.Add TWatHea(k2=-1)
     "Heat exchanger outlet, taking into account approach"
     annotation (Placement(transformation(extent={{40,190},{60,210}})));
-  Modelica.Blocks.Math.Add TWatCoo(k2=-1)
+  Modelica.Blocks.Math.Add TWatCoo
     "Heat exchanger outlet, taking into account approach"
     annotation (Placement(transformation(extent={{40,220},{60,240}})));
   Modelica.Blocks.Math.Add QExc_flow(k1=-1) "Heat added to water reservoir"
@@ -455,6 +455,10 @@ instances <code>valCoo</code> and <code>valHea</code>.
 </p>
 </html>", revisions="<html>
 <ul>
+<li>
+February 3, 2017, by Felix Buenning:<br/>
+Corrected wrong signs for TApp in TWatCoo and TWatHea.
+</li>
 <li>
 November 8, 2016, by Michael Wetter:<br/>
 Corrected wrong argument type in function call of <code>Medium.temperature_phX</code>.

--- a/Buildings/Experimental/DistrictHeatingCooling/Plants/Validation/LakeWaterHeatExchanger_T_Heating.mo
+++ b/Buildings/Experimental/DistrictHeatingCooling/Plants/Validation/LakeWaterHeatExchanger_T_Heating.mo
@@ -59,7 +59,7 @@ model LakeWaterHeatExchanger_T_Heating
     constrainedby Modelica.Blocks.Interfaces.SO "Water temperature"
     annotation (Placement(transformation(extent={{90,12},{70,32}})));
 
-  Modelica.Blocks.Sources.Constant TWatSou(k=275.15 + 15)
+  Modelica.Blocks.Sources.Constant TWatSou(k=273.15 + 15)
     "Ocean water temperature"
     annotation (Placement(transformation(extent={{-80,70},{-60,90}})));
   Modelica.Blocks.Sources.Constant
@@ -113,6 +113,10 @@ reverses its direction.
 </p>
 </html>", revisions="<html>
 <ul>
+<li>
+February 2, 2017, by Felix Buenning:<br/>
+Corrected offset for temperature from 275.15 to 273.15 in TWatSou.
+</li>
 <li>
 January 11, 2015, by Michael Wetter:<br/>
 First implementation.


### PR DESCRIPTION
Fixed sign of TApproach in LakeWaterHeatexchanger model, Fixed mistake in validation model (changed 275.15K to 273.15K)