### PR TITLE
650_bayWaterHex: Added dT in Carnot baseclass

### DIFF
--- a/Buildings/Fluid/Chillers/BaseClasses/Carnot.mo
+++ b/Buildings/Fluid/Chillers/BaseClasses/Carnot.mo
@@ -50,6 +50,14 @@ partial model Carnot
     "Pressure difference over evaporator"
     annotation (Dialog(group="Nominal condition"));
 
+  parameter Modelica.SIunits.Temperature dTApproachCon(start=0, min=0, displayUnit="K")
+    "Temperature difference between refrigerant and working fluid in condenser"
+    annotation (Dialog(group="Efficiency"));
+
+  parameter Modelica.SIunits.Temperature dTApproachEva(start=0, min=0, displayUnit="K")
+    "Temperature difference between refrigerant and working fluid in evaporator"
+    annotation (Dialog(group="Efficiency"));
+
   parameter Boolean homotopyInitialization=true "= true, use homotopy method"
     annotation (Dialog(tab="Advanced"));
 
@@ -128,10 +136,10 @@ partial model Carnot
     x2=TCon-TEva,
     deltaX=0.25) "Carnot efficiency";
 
-  Modelica.SIunits.Temperature TCon(start=TCon_nominal) = Medium1.temperature(staB1)
-    "Condenser temperature used to compute efficiency";
-  Modelica.SIunits.Temperature TEva(start=TEva_nominal) = Medium2.temperature(staB2)
-    "Evaporator temperature used to compute efficiency";
+  Modelica.SIunits.Temperature TCon(start=TCon_nominal) = Medium1.temperature(staB1)+QCon_flow/QCon_flow_nominal*dTApproachCon
+    "Condenser temperature used to compute efficiency (dT_pinch above water/air temperature at nominal conditions)";
+  Modelica.SIunits.Temperature TEva(start=TEva_nominal) = Medium2.temperature(staB2)-QEva_flow/QEva_flow_nominal*dTApproachEva
+    "Evaporator temperature used to compute efficiency (dt_pinch below water/air temperature at nominal conditions)";
 
 protected
   constant Boolean COP_is_for_cooling
@@ -368,6 +376,10 @@ and the part load ratio are set up.
 </p>
 </html>", revisions="<html>
 <ul>
+<li>
+February 7, 2017, by Felix Buenning:<br/>
+Added temperature difference between fluids in condenser and evaporator.
+</li>
 <li>
 January 2, 2017, by Filip Jorissen:<br/>
 Removed option for choosing what temperature


### PR DESCRIPTION
Added dT in CarnotBaseclass, default is set to 0 (set as a start value as described in style guide)