### PR TITLE
cache pip packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: python
 python:
   - "2.7"
 
+cache: pip
+
 notifications:
   email: false
 


### PR DESCRIPTION
cache pip packages as mentioned in #663 
pip packages are shared between the builds.
Might give a small speedup here, as there are many builds in parallel.