### PR TITLE
fix the order in the package.order file

### DIFF
--- a/Buildings/Media/Refrigerants/R410A/package.order
+++ b/Buildings/Media/Refrigerants/R410A/package.order
@@ -10,7 +10,7 @@ pressureVap_Tv
 specificIsobaricHeatCapacityVap_Tv
 specificIsochoricHeatCapacityVap_Tv
 specificVolumeVap_pT
+pCri
 R
 TCri
 T_min
-pCri


### PR DESCRIPTION
OpenModelica refuses to load the library because the order of elements in the package.order file is not the same as the one in the package.mo. This PR fixes this issue.

Modelica Specification states:
"Classes and constants that are stored in package.mo are also present in package.order but their relative order should be identical to the one in package.mo (this ensures that the relative order between classes and constants stored in different ways is preserved)."