### PR TITLE
Renamed variable in single zone econ limits

### DIFF
--- a/Buildings/Controls/OBC/ASHRAE/G36_PR1/AHUs/SingleZone/VAV/Economizers/Controller.mo
+++ b/Buildings/Controls/OBC/ASHRAE/G36_PR1/AHUs/SingleZone/VAV/Economizers/Controller.mo
@@ -90,7 +90,7 @@ model Controller "Single zone VAV AHU economizer control sequence"
   parameter Modelica.SIunits.VolumeFlowRate VOutDes_flow=2.0
     "Calculated design outdoor airflow rate"
     annotation(Evaluate=true, Dialog(tab="Commissioning", group="Damper position limits"));
-  parameter Real minVOutMinFansSpePos(
+  parameter Real yDam_VOutMin_minSpe(
     final min=outDamPhyPosMin,
     final max=outDamPhyPosMax,
     final unit="1") = 0.4
@@ -103,7 +103,7 @@ model Controller "Single zone VAV AHU economizer control sequence"
     "OA damper position to supply minimum outdoor airflow at maximum fan speed"
     annotation(Evaluate=true, Dialog(tab="Commissioning", group="Damper position limits"));
   parameter Real yDam_VOutDes_minSpe(
-    final min=minVOutMinFansSpePos,
+    final min=yDam_VOutMin_minSpe,
     final max=outDamPhyPosMax,
     final unit="1") = 0.9
     "OA damper position to supply design outdoor airflow at minimum fan speed"
@@ -241,7 +241,7 @@ model Controller "Single zone VAV AHU economizer control sequence"
     final outDamPhyPosMin=outDamPhyPosMin,
     final VOutMin_flow=VOutMin_flow,
     final VOutDes_flow=VOutDes_flow,
-    final minVOutMinFansSpePos=minVOutMinFansSpePos,
+    final yDam_VOutMin_minSpe=yDam_VOutMin_minSpe,
     final yDam_VOutMin_maxSpe=yDam_VOutMin_maxSpe,
     final yDam_VOutDes_minSpe=yDam_VOutDes_minSpe,
     final yDam_VOutDes_maxSpe=yDam_VOutDes_maxSpe)

--- a/Buildings/Controls/OBC/ASHRAE/G36_PR1/AHUs/SingleZone/VAV/Economizers/Subsequences/Limits.mo
+++ b/Buildings/Controls/OBC/ASHRAE/G36_PR1/AHUs/SingleZone/VAV/Economizers/Subsequences/Limits.mo
@@ -11,7 +11,7 @@ block Limits "Single zone VAV AHU minimum outdoor air control - damper position 
     final max=1,
     final unit="1") = 1 "Maximum supply fan operation speed"
     annotation(Evaluate=true, Dialog(tab="Commissioning", group="Damper position limits"));
-  parameter Real minVOutMinFansSpePos(
+  parameter Real yDam_VOutMin_minSpe(
     final min=outDamPhyPosMin,
     final max=outDamPhyPosMax,
     final unit="1") = 0.4
@@ -24,7 +24,7 @@ block Limits "Single zone VAV AHU minimum outdoor air control - damper position 
     "OA damper position to supply minimum outdoor airflow at maximum fan speed"
     annotation(Evaluate=true, Dialog(tab="Commissioning", group="Damper position limits"));
   parameter Real yDam_VOutDes_minSpe(
-    final min=minVOutMinFansSpePos,
+    final min=yDam_VOutMin_minSpe,
     final max=outDamPhyPosMax,
     final unit="1") = 0.9
     "OA damper position to supply design outdoor airflow at minimum fan speed"
@@ -112,8 +112,8 @@ protected
   Buildings.Controls.OBC.CDL.Continuous.Sources.Constant yFanMaxSig(
     final k=yFanMax) "Maximum supply fan speed"
     annotation (Placement(transformation(extent={{-140,80},{-120,100}})));
-  Buildings.Controls.OBC.CDL.Continuous.Sources.Constant minVOutMinFansSpePosSig(final k=
-        minVOutMinFansSpePos)
+  Buildings.Controls.OBC.CDL.Continuous.Sources.Constant yDam_VOutMin_minSpeSig(final k=
+        yDam_VOutMin_minSpe)
     "OA damper position to supply minimum outdoor airflow at minimum fan speed"
     annotation (Placement(transformation(extent={{-140,120},{-120,140}})));
   Buildings.Controls.OBC.CDL.Continuous.Sources.Constant yDam_VOutDes_minSpeSig(
@@ -189,7 +189,7 @@ equation
     annotation (Line(points={{-119,-20},{-100,-20},{-100,54},{14,54}}, color={0,0,127}));
   connect(yDam_VOutDes_maxSpeSig.y, yDam_VOutDes_curSpe.f2)
     annotation (Line(points={{-119,10},{-104,10},{-96,10},{-8,10},{-8,42},{14,42}}, color={0,0,127}));
-  connect(minVOutMinFansSpePosSig.y, yDam_VOutMin_curSpe.f1) annotation (Line(
+  connect(yDam_VOutMin_minSpeSig.y, yDam_VOutMin_curSpe.f1) annotation (Line(
         points={{-119,130},{-120,130},{-118,130},{-28,130},{-28,144},{14,144}},
         color={0,0,127}));
   connect(yDam_VOutMin_maxSpeSig.y, yDam_VOutMin_curSpe.f2)
@@ -373,7 +373,7 @@ at current supply fan speed <code>uSupFanSpe</code> as a linear
 interpolation between the following values set at commissioning:<br/>
 <ul>
 <li>minimum damper position at minimum fan speed for minimum outdoor airflow
-<code>minVOutMinFansSpePos</code> and
+<code>yDam_VOutMin_minSpe</code> and
 </li>
 <li>
 minimum damper position at maximum fan speed for minimum outdoor airflow

--- a/Buildings/Resources/Scripts/Dymola/ConvertBuildings_from_5_to_6.0.0.mos
+++ b/Buildings/Resources/Scripts/Dymola/ConvertBuildings_from_5_to_6.0.0.mos
@@ -57,7 +57,7 @@ convertClass("Buildings.Fluid.HeatExchangers.Ground.Boreholes.UTube",
              "Buildings.Fluid.Geothermal.Boreholes.UTube");
 
 
-// Conversions for
+// Conversions for naming consistency withing the Buildings.Controls.OBC.ASHRAE.G36_PR1 package
 convertClass("Buildings.Controls.OBC.ASHRAE.G36_PR1.AHUs.MultiZone.Controller",
 	     "Buildings.Controls.OBC.ASHRAE.G36_PR1.AHUs.MultiZone.VAV.Controller");
 convertElement("Buildings.Controls.OBC.ASHRAE.G36_PR1.AHUs.MultiZone.Controller",
@@ -145,6 +145,8 @@ convertClass("Buildings.Controls.OBC.ASHRAE.G36_PR1.AHUs.SingleZone.Economizers.
 
 convertClass("Buildings.Controls.OBC.ASHRAE.G36_PR1.AHUs.SingleZone.Economizers.Subsequences.Limits",
 	     "Buildings.Controls.OBC.ASHRAE.G36_PR1.AHUs.SingleZone.VAV.Economizers.Subsequences.Limits");
+convertElement("Buildings.Controls.OBC.ASHRAE.G36_PR1.AHUs.SingleZone.Economizers.Subsequences.Limits",
+               "minVOutMinFansSpePos", "yDam_VOutMin_minSpe")
 
 convertClass("Buildings.Controls.OBC.ASHRAE.G36_PR1.AHUs.SingleZone.Economizers.Subsequences.Modulation",
 	     "Buildings.Controls.OBC.ASHRAE.G36_PR1.AHUs.SingleZone.VAV.Economizers.Subsequences.Modulation");

--- a/Buildings/Resources/Scripts/Dymola/ConvertBuildings_from_5_to_6.0.0.mos
+++ b/Buildings/Resources/Scripts/Dymola/ConvertBuildings_from_5_to_6.0.0.mos
@@ -57,7 +57,7 @@ convertClass("Buildings.Fluid.HeatExchangers.Ground.Boreholes.UTube",
              "Buildings.Fluid.Geothermal.Boreholes.UTube");
 
 
-// Conversions for naming consistency withing the Buildings.Controls.OBC.ASHRAE.G36_PR1 package
+// Conversions for variable naming consistency withing the Buildings.Controls.OBC.ASHRAE.G36_PR1 package
 convertClass("Buildings.Controls.OBC.ASHRAE.G36_PR1.AHUs.MultiZone.Controller",
 	     "Buildings.Controls.OBC.ASHRAE.G36_PR1.AHUs.MultiZone.VAV.Controller");
 convertElement("Buildings.Controls.OBC.ASHRAE.G36_PR1.AHUs.MultiZone.Controller",


### PR DESCRIPTION
Closes #1275.

Renamed ```minVOutMinFansSpePos``` to ```yDam_VOutMin_minSpe``` and added to conversion script.