### PR TITLE
add missing each statement to several models

### DIFF
--- a/Buildings/Applications/DataCenters/ChillerCooled/Equipment/IntegratedPrimaryLoadSide.mo
+++ b/Buildings/Applications/DataCenters/ChillerCooled/Equipment/IntegratedPrimaryLoadSide.mo
@@ -47,7 +47,7 @@ model IntegratedPrimaryLoadSide
     k=m_flow/sqrt(dp), with unit=(kg.m)^(1/2)."
     annotation(Dialog(group="Pump"));
   Modelica.Blocks.Interfaces.RealInput yPum[numPum](
-    final unit = "1",
+    each final unit = "1",
     each min=0,
     each max=1)
     "Constant normalized rotational speed"

--- a/Buildings/Electrical/Transmission/BaseClasses/PartialNetwork.mo
+++ b/Buildings/Electrical/Transmission/BaseClasses/PartialNetwork.mo
@@ -11,7 +11,7 @@ partial model PartialNetwork "Partial model that represent an electric network"
     annotation (Placement(transformation(extent={{90,-10},{110,10}})));
   replaceable Buildings.Electrical.Transmission.BaseClasses.PartialBaseLine lines[grid.nLinks](
     each mode=Buildings.Electrical.Types.CableMode.commercial,
-    l=grid.l[:, 1],
+    l={grid.l[i, 1] for i in 1:grid.nLinks},
     each P_nominal=1000,
     each V_nominal=V_nominal)
     "Array of line models, each line connecting two nodes of the grid";

--- a/Buildings/Fluid/SolarCollectors/BaseClasses/EN12975SolarGain.mo
+++ b/Buildings/Fluid/SolarCollectors/BaseClasses/EN12975SolarGain.mo
@@ -35,7 +35,7 @@ model EN12975SolarGain "Model calculating solar gains per the EN12975 standard"
     unit="W/m2", quantity="RadiantEnergyFluenceRate")
     "Direct solar irradiation on a tilted surfce"
     annotation (Placement(transformation(extent={{-140,20},{-100,60}})));
-  Modelica.Blocks.Interfaces.RealOutput QSol_flow[nSeg](final unit="W")
+  Modelica.Blocks.Interfaces.RealOutput QSol_flow[nSeg](each final unit="W")
     "Solar heat gain"
     annotation (Placement(transformation(extent={{100,-10},{120,10}})));
   Modelica.Blocks.Interfaces.RealInput TFlu[nSeg](

--- a/Buildings/Utilities/IO/BCVTB/BCVTB.mo
+++ b/Buildings/Utilities/IO/BCVTB/BCVTB.mo
@@ -38,7 +38,7 @@ model BCVTB
 protected
   parameter Integer socketFD(fixed=false)
     "Socket file descripter, or a negative value if an error occurred";
-  parameter Real _uStart[nDblWri](fixed=false)
+  parameter Real _uStart[nDblWri](each fixed=false)
     "Initial input signal, used during first data transfer with BCVTB";
   constant Integer flaWri=0;
   Real uRInt[nDblWri] "Value of integral";


### PR DESCRIPTION
@mwetter Please review the commits for the 19 errors produced by OpenModelica (excluding the 11 errors related Boreholes):

- Error1-5 relates to the chiller model in the Applications.DataCenters package. Tests in JModelica do not show similar warnings about the "each" statement. The first commit below was not shown in OpenModelica but in JModelica; it is therefore modified as well.

- Error6-10 relates to the simple electric grid model in the Electrical.AC package. Tests in JModelica do not show warnings about the "each" statement. The modification in the second commit below is to make the line easier to understand (it is also where OpenModelica complains about).

- Error 11-14 relates to the heat exchanger model in the Fluid.HeatExchangers package. Tests in JModelica do not show similar warnings about the "each" statement.

- Error 15 from OpenModelica cannot be produced in JModelica as warnings.

- Error 16-17: the third commit corresponds to these two errors

- Error 18-19: the fourth commit corresponds to these two errors