### PR TITLE
changed back the input name and placement

### DIFF
--- a/Buildings/Controls/OBC/CDL/Continuous/MultiSum.mo
+++ b/Buildings/Controls/OBC/CDL/Continuous/MultiSum.mo
@@ -5,11 +5,10 @@ block MultiSum
   parameter Integer nin(min=0) = 0 "Number of input connections"
     annotation (Dialog(connectorSizing=true), HideResult=true);
   parameter Real k[nin]=fill(1, nin) "Input gains";
+  Interfaces.RealInput u[nin] "Connector of Real input signals"
+    annotation (Placement(transformation(extent={{-140,20},{-100,-20}})));
   Interfaces.RealOutput y "Connector of Real output signal"
-    annotation (Placement(transformation(extent={{100,17},{134,-17}})));
-  Interfaces.RealInput u1 "Connector of Real input signal 1"
-    annotation (Placement(transformation(extent={{-140,-20},{-100,20}}),
-        iconTransformation(extent={{-140,-20},{-100,20}})));
+    annotation (Placement(transformation(extent={{100,-10},{120,10}})));
 equation
   if size(u, 1) > 0 then
     y = k*u;


### PR DESCRIPTION
@mwetter:
I had just copied the input icon from another block and had not paid attention to the name, description and location change in the code. I changed back the input name and location.

I also made the output icon smaller, to be consistent with other similar blocks like yMax.