### PR TITLE
issue1364 OutdoorLights package order

### DIFF
--- a/Buildings/Controls/OBC/package.order
+++ b/Buildings/Controls/OBC/package.order
@@ -3,4 +3,3 @@ CDL
 OutdoorLights
 Shade
 UnitConversions
-


### PR DESCRIPTION
@mwetter:
The package order has been refactored using BuildingsPy package. 
A blank line at the end was removed.