### PR TITLE
initialize pointers in constructor to avoid segfault and clean format

### DIFF
--- a/Buildings/Resources/C-Sources/cfdExchangeData.c
+++ b/Buildings/Resources/C-Sources/cfdExchangeData.c
@@ -31,11 +31,11 @@ int cfdExchangeData(double t0, double dt, double *u, size_t nU, size_t nY,
                  double *t1, double *y) {
   size_t i, j, k;
 
-	/*check if current modelica time equals to last time*/
-	/*if yes, it means cfdExchangeData() was called multiple times at one synchronization point, then directly return*/
-	if(abs(cosim->modelica->lt - t0) < 1E-6){
+  /*check if current modelica time equals to last time*/
+  /*if yes, it means cfdExchangeData() was called multiple times at one synchronization point, then directly return*/
+  if(abs(cosim->modelica->lt - t0) < 1E-6){
     return 0;
-	}
+  }
 
   /*--------------------------------------------------------------------------
   | Write data to CFD
@@ -54,7 +54,7 @@ int cfdExchangeData(double t0, double dt, double *u, size_t nU, size_t nY,
 
   cosim->modelica->t = t0;
   cosim->modelica->dt = dt;
-	cosim->modelica->lt = t0;
+  cosim->modelica->lt = t0;
 
   /* Copy the Modelica data to shared memory*/
   for(i=0; i<cosim->para->nSur; i++) {

--- a/Buildings/Resources/C-Sources/cfdSendStopCommand.c
+++ b/Buildings/Resources/C-Sources/cfdSendStopCommand.c
@@ -20,14 +20,14 @@
  */
 void cfdSendStopCommand(void *thread) {
 
-	size_t i = 0;
+  size_t i = 0;
   size_t imax = 10000;
 
-	/*send stop command to FFD*/
+  /*send stop command to FFD*/
   cosim->para->flag = 0;
 
   /* Wait for the feedback from FFD*/
-	while(cosim->para->flag==0 && i<imax) {
+ while(cosim->para->flag==0 && i<imax) {
     if(cosim->para->ffdError==1) {
       ModelicaError(cosim->ffd->msg);
     }
@@ -46,104 +46,104 @@ void cfdSendStopCommand(void *thread) {
     }
   }
   else {
-    ModelicaError("Error: Cannot stop the FFD simulation in required time.");
+    ModelicaMessage("Error: Cannot stop the FFD simulation in required time.");
   }
 
-	/*free memory for variables*/	
-	if (cosim->para->fileName != NULL){
-		free(cosim->para->fileName);		
-	}
-	if (cosim->para->are != NULL){
-		free(cosim->para->are);		
-	}
-	if (cosim->para->til != NULL){
-		free(cosim->para->til);	
-	}
-	if (cosim->para->bouCon != NULL){
-		free(cosim->para->bouCon);		
-	}
-	if (cosim->para->nSur>0){
-		for(i=0; i<cosim->para->nSur; i++) {	
-			free(cosim->para->name[i]);	
-		}
-		if (cosim->para->name != NULL){
-			free(cosim->para->name);		
-		}
-	}
-	if (cosim->para->nSen>0){
-		if (cosim->ffd->senVal != NULL){
-			free(cosim->ffd->senVal);			
-		}
-		for(i=0; i<cosim->para->nSen; i++) {	
-			free(cosim->para->sensorName[i]);	
-		}
-		if (cosim->para->sensorName != NULL){
-			free(cosim->para->sensorName);		
-		}		
-	}	
-	if (cosim->modelica->temHea != NULL){
-		free(cosim->modelica->temHea);		
-	}	
-	if (cosim->para->sha==1){
-		if (cosim->modelica->shaConSig != NULL){
-			free(cosim->modelica->shaConSig);	
-		}		
-		if (cosim->modelica->shaAbsRad != NULL){
-			free(cosim->modelica->shaAbsRad);	
-		}	
-		if (cosim->ffd->TSha != NULL){
-			free(cosim->ffd->TSha);
-		}
-	}
-	if (cosim->para->nPorts>0){	
-		for(i=0; i<cosim->para->nPorts; i++) {	
-			free(cosim->modelica->XiPor[i]);		
-			free(cosim->ffd->XiPor[i]);	
-			free(cosim->modelica->CPor[i]);		
-			free(cosim->ffd->CPor[i]);	
-		}
-		if (cosim->modelica->CPor != NULL){
-			free(cosim->modelica->CPor);
-		}	
-		if (cosim->ffd->CPor != NULL){
-			free(cosim->ffd->CPor);
-		}
-		if (cosim->modelica->XiPor != NULL){
-			free(cosim->modelica->XiPor);		
-		}
-		if (cosim->ffd->XiPor != NULL){
-			free(cosim->ffd->XiPor);
-		}	
-		if (cosim->modelica->TPor != NULL){
-			free(cosim->modelica->TPor);		
-		}
-		if (cosim->ffd->TPor != NULL){
-			free(cosim->ffd->TPor);
-		}
-		for(i=0; i<cosim->para->nPorts; i++) {	
-			free(cosim->para->portName[i]);	
-		}
-		if (cosim->para->portName != NULL){
-			free(cosim->para->portName);		
-		}
-		if (cosim->modelica->mFloRatPor != NULL){
-			free(cosim->modelica->mFloRatPor);		
-		}		
-	}	
-	if (cosim->ffd->temHea != NULL){
-		free(cosim->ffd->temHea);
-	}		
-	if (cosim->para != NULL){
-		free(cosim->para);
-	}	
-	if (cosim->modelica != NULL){
-		free(cosim->modelica);
-	}	
-	if (cosim->ffd != NULL){
-		free(cosim->ffd);
-	}	
-	if (cosim != NULL){
-		free(cosim);
-	}		
+  /*free memory for variables*/  
+  if (cosim->para->fileName != NULL){
+    free(cosim->para->fileName);    
+  }
+  if (cosim->para->are != NULL){
+    free(cosim->para->are);    
+  }
+  if (cosim->para->til != NULL){
+    free(cosim->para->til);  
+  }
+  if (cosim->para->bouCon != NULL){
+    free(cosim->para->bouCon);    
+  }
+  if (cosim->para->nSur>0){
+    for(i=0; i<cosim->para->nSur; i++) {  
+      free(cosim->para->name[i]);  
+    }
+    if (cosim->para->name != NULL){
+      free(cosim->para->name);    
+    }
+  }
+  if (cosim->para->nSen>0){
+    if (cosim->ffd->senVal != NULL){
+      free(cosim->ffd->senVal);      
+    }
+    for(i=0; i<cosim->para->nSen; i++) {  
+      free(cosim->para->sensorName[i]);  
+    }
+    if (cosim->para->sensorName != NULL){
+      free(cosim->para->sensorName);    
+    }    
+  }  
+  if (cosim->modelica->temHea != NULL){
+    free(cosim->modelica->temHea);    
+  }  
+  if (cosim->para->sha==1){
+    if (cosim->modelica->shaConSig != NULL){
+      free(cosim->modelica->shaConSig);  
+    }    
+    if (cosim->modelica->shaAbsRad != NULL){
+      free(cosim->modelica->shaAbsRad);  
+    }  
+    if (cosim->ffd->TSha != NULL){
+      free(cosim->ffd->TSha);
+    }
+  }
+  if (cosim->para->nPorts>0){  
+    for(i=0; i<cosim->para->nPorts; i++) {  
+      free(cosim->modelica->XiPor[i]);    
+      free(cosim->ffd->XiPor[i]);  
+      free(cosim->modelica->CPor[i]);    
+      free(cosim->ffd->CPor[i]);  
+    }
+    if (cosim->modelica->CPor != NULL){
+      free(cosim->modelica->CPor);
+    }  
+    if (cosim->ffd->CPor != NULL){
+      free(cosim->ffd->CPor);
+    }
+    if (cosim->modelica->XiPor != NULL){
+      free(cosim->modelica->XiPor);    
+    }
+    if (cosim->ffd->XiPor != NULL){
+      free(cosim->ffd->XiPor);
+    }  
+    if (cosim->modelica->TPor != NULL){
+      free(cosim->modelica->TPor);    
+    }
+    if (cosim->ffd->TPor != NULL){
+      free(cosim->ffd->TPor);
+    }
+    for(i=0; i<cosim->para->nPorts; i++) {  
+      free(cosim->para->portName[i]);  
+    }
+    if (cosim->para->portName != NULL){
+      free(cosim->para->portName);    
+    }
+    if (cosim->modelica->mFloRatPor != NULL){
+      free(cosim->modelica->mFloRatPor);    
+    }    
+  }  
+  if (cosim->ffd->temHea != NULL){
+    free(cosim->ffd->temHea);
+  }    
+  if (cosim->para != NULL){
+    free(cosim->para);
+  }  
+  if (cosim->modelica != NULL){
+    free(cosim->modelica);
+  }  
+  if (cosim->ffd != NULL){
+    free(cosim->ffd);
+  }  
+  if (cosim != NULL){
+    free(cosim);
+  }    
 
 } /* End of cfdSendStopCommand*/

--- a/Buildings/Resources/C-Sources/cfdStartCosimulation.c
+++ b/Buildings/Resources/C-Sources/cfdStartCosimulation.c
@@ -51,7 +51,6 @@ int cfdStartCosimulation(char *cfdFilNam, char **name, double *A, double *til,
   /****************************************************************************
   | allocate the memory and assign the data
   ****************************************************************************/
-  cosim->para->fileName = NULL;
   cosim->para->fileName = (char *) malloc(sizeof(char)*(strlen(cfdFilNam)+1));
   if (cosim->para->fileName == NULL){
     ModelicaError("Failed to allocate memory for cosim->para->fileName in cfdStartCosimulation.c");
@@ -69,22 +68,18 @@ int cfdStartCosimulation(char *cfdFilNam, char **name, double *A, double *til,
 
   nBou = nSur + nPorts;
 
-  cosim->para->name = NULL;
   cosim->para->name = (char**) malloc(nSur*sizeof(char *));
   if (cosim->para->name == NULL){
     ModelicaError("Failed to allocate memory for cosim->para->name in cfdStartCosimulation.c");
   }
-  cosim->para->are = NULL;
   cosim->para->are = (double *) malloc(nSur*sizeof(double));
   if (cosim->para->are == NULL){
     ModelicaError("Failed to allocate memory for cosim->para->are in cfdStartCosimulation.c");
   }
-  cosim->para->til = NULL;
   cosim->para->til = (double *) malloc(nSur*sizeof(double));
   if (cosim->para->til == NULL){
     ModelicaError("Failed to allocate memory for cosim->para->til in cfdStartCosimulation.c");
   }
-  cosim->para->bouCon = NULL;
   cosim->para->bouCon = (size_t *) malloc(nSur*sizeof(size_t));
   if (cosim->para->bouCon == NULL){
     ModelicaError("Failed to allocate memory for cosim->para->bouCon in cfdStartCosimulation.c");
@@ -102,7 +97,6 @@ int cfdStartCosimulation(char *cfdFilNam, char **name, double *A, double *til,
     cosim->para->bouCon[i] = bouCon[i];
   }
 
-  cosim->para->portName = NULL;
   cosim->para->portName = (char**) malloc(nPorts*sizeof(char *));
   if (cosim->para->portName == NULL){
     ModelicaError("Failed to allocate memory for cosim->para->portName in cfdStartCosimulation.c");
@@ -118,12 +112,10 @@ int cfdStartCosimulation(char *cfdFilNam, char **name, double *A, double *til,
   }
 
   if(haveSensor) {
-    cosim->para->sensorName = NULL;
     cosim->para->sensorName = (char **) malloc(nSen*sizeof(char *));
     if (  cosim->para->sensorName == NULL){
       ModelicaError("Failed to allocate memory for cosim->para->sensorName in cfdStartCosimulation.c");
     }
-    cosim->ffd->senVal = NULL;
     cosim->ffd->senVal = (double *) malloc(nSen*sizeof(double));
     if (  cosim->ffd->senVal == NULL){
       ModelicaError("Failed to allocate memory for cosim->ffd->senVal in cfdStartCosimulation.c");
@@ -146,41 +138,34 @@ int cfdStartCosimulation(char *cfdFilNam, char **name, double *A, double *til,
   cosim->modelica->t = 0;
   cosim->modelica->lt = -1;/*initialize lt to -1 to avoid skipping all exchange() at time = 0*/
 
-  cosim->modelica->temHea = NULL;
   cosim->modelica->temHea = (double *) malloc(nSur*sizeof(double));
   if (cosim->modelica->temHea == NULL){
     ModelicaError("Failed to allocate memory for cosim->modelica->temHea in cfdStartCosimulation.c");
   }
   /* Having a shade for window*/
   if(haveShade==1) {
-    cosim->modelica->shaConSig = NULL;
     cosim->modelica->shaConSig = (double *) malloc(nConExtWin*sizeof(double));
     if (  cosim->modelica->shaConSig == NULL){
       ModelicaError("Failed to allocate memory for cosim->modelica->shaConSig in cfdStartCosimulation.c");
     }
-    cosim->modelica->shaAbsRad = NULL;
     cosim->modelica->shaAbsRad = (double *) malloc(nConExtWin*sizeof(double));
     if (  cosim->modelica->shaAbsRad == NULL){
       ModelicaError("Failed to allocate memory for cosim->modelica->shaAbsRad in cfdStartCosimulation.c");
     }
   }
-  cosim->modelica->mFloRatPor = NULL;
   cosim->modelica->mFloRatPor = (double *) malloc(nPorts*sizeof(double));
   if (cosim->modelica->mFloRatPor == NULL){
     ModelicaError("Failed to allocate memory for cosim->modelica->mFloRatPor in cfdStartCosimulation.c");
   }
-  cosim->modelica->TPor = NULL;
   cosim->modelica->TPor = (double *) malloc(nPorts*sizeof(double));
   if (cosim->modelica->TPor == NULL){
     ModelicaError("Failed to allocate memory for cosim->modelica->TPor in cfdStartCosimulation.c");
   }
 
-  cosim->modelica->XiPor = NULL;
   cosim->modelica->XiPor = (double **) malloc(nPorts*sizeof(double *));
   if (cosim->modelica->XiPor == NULL){
     ModelicaError("Failed to allocate memory for cosim->modelica->XiPor in cfdStartCosimulation.c");
   }
-  cosim->ffd->XiPor = NULL;
   cosim->ffd->XiPor = (double **) malloc(nPorts*sizeof(double *));
   if (cosim->ffd->XiPor == NULL){
     ModelicaError("Failed to allocate memory for cosim->ffd->XiPor in cfdStartCosimulation.c");
@@ -198,12 +183,10 @@ int cfdStartCosimulation(char *cfdFilNam, char **name, double *A, double *til,
     }
   }
 
-  cosim->modelica->CPor = NULL;
   cosim->modelica->CPor = (double **) malloc(nPorts*sizeof(double *));
   if (cosim->modelica->CPor == NULL){
     ModelicaError("Failed to allocate memory for cosim->modelica->CPor in cfdStartCosimulation.c");
   }
-  cosim->ffd->CPor = NULL;
   cosim->ffd->CPor = (double **) malloc(nPorts*sizeof(double *));
   if (cosim->ffd->CPor == NULL){
     ModelicaError("Failed to allocate memory for cosim->ffd->CPor in cfdStartCosimulation.c");
@@ -221,24 +204,20 @@ int cfdStartCosimulation(char *cfdFilNam, char **name, double *A, double *til,
     }
   }
 
-  cosim->ffd->temHea = NULL;
   cosim->ffd->temHea = (double *) malloc(nSur*sizeof(double));
   if (cosim->ffd->temHea == NULL){
     ModelicaError("Failed to allocate memory for cosim->ffd->temHea in cfdStartCosimulation.c");
   }
   if(haveShade==1){
-    cosim->ffd->TSha = NULL;
      cosim->ffd->TSha = (double *) malloc(nConExtWin*sizeof(double));
      if (   cosim->ffd->TSha == NULL){
        ModelicaError("Failed to allocate memory for    cosim->ffd->TSha in cfdStartCosimulation.c");
      }
   }
-  cosim->ffd->TPor = NULL;
   cosim->ffd->TPor = (double *) malloc(nPorts*sizeof(double));
   if (cosim->ffd->TPor == NULL){
     ModelicaError("Failed to allocate memory for cosim->ffd->TPor in cfdStartCosimulation.c");
   }
-  cosim->ffd->msg = NULL;
 
   /****************************************************************************
   | Implicitly launch DLL module.

--- a/Buildings/Resources/C-Sources/cfdcosim.c
+++ b/Buildings/Resources/C-Sources/cfdcosim.c
@@ -32,8 +32,8 @@ void *cfdcosim() {
   /****************************************************************************
   | return modelica error if more than one ffd instances are created
   ****************************************************************************/
-	if ( cosim != NULL )
-		ModelicaError("ModelicaError: Only one room with FFD can be used, but more than one is used.");
+  if ( cosim != NULL )
+    ModelicaError("ModelicaError: Only one room with FFD can be used, but more than one is used.");
 
   /****************************************************************************
   | Allocate memory for cosimulation variables
@@ -61,5 +61,41 @@ void *cfdcosim() {
     ModelicaError("Failed to allocate memory for cosim->ffd in cfdcosim.c");
   }
 
-	return (void*) cosim;
+  /****************************************************************************
+  | Initialize cosimulation variables
+  ****************************************************************************/
+  cosim->modelica->flag = 0;
+  cosim->ffd->flag = 0;
+  cosim->para->flag = 1;
+  cosim->para->ffdError = 0;
+  cosim->para->nSur = 0;
+  cosim->para->nSen = 0;
+  cosim->para->nConExtWin = 0;
+  cosim->para->nPorts = 0;
+  cosim->para->sha = 0;
+  cosim->para->nC = 0;
+  cosim->para->nXi = 0;
+  cosim->ffd->msg = NULL;
+  cosim->para->fileName = NULL;
+  cosim->para->are = NULL;
+  cosim->para->til = NULL;
+  cosim->para->bouCon = NULL;
+  cosim->para->name = NULL;
+  cosim->para->sensorName = NULL;
+  cosim->ffd->senVal = NULL;
+  cosim->modelica->CPor = NULL;
+  cosim->ffd->CPor = NULL;
+  cosim->modelica->XiPor = NULL;
+  cosim->ffd->XiPor = NULL;
+  cosim->modelica->TPor = NULL;
+  cosim->ffd->TPor = NULL;
+  cosim->para->portName = NULL;
+  cosim->modelica->mFloRatPor = NULL;
+  cosim->ffd->temHea = NULL;
+  cosim->modelica->temHea = NULL;
+  cosim->modelica->shaConSig = NULL;
+  cosim->modelica->shaAbsRad = NULL;
+  cosim->ffd->TSha = NULL;
+
+  return (void*) cosim;
 } /* End of cfdcosim()*/


### PR DESCRIPTION
1. initialize pointers in constructor to avoid a segmentation fault
2. clean format