### PR TITLE
Simplified Toggle and Latch for #1823

### DIFF
--- a/Buildings/Controls/OBC/CDL/Logical/Latch.mo
+++ b/Buildings/Controls/OBC/CDL/Logical/Latch.mo
@@ -10,38 +10,29 @@ block Latch "Maintains a true signal until change condition"
   Interfaces.BooleanOutput y "Output signal"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
-protected
-  Integer scenario "Scenario index";
-
 initial equation
   pre(y) = pre_y_start;
   pre(u) = false;
   pre(clr) = false;
-  pre(scenario) = 0;
 
 equation
   when initial() then
-    scenario = 1;
-  elsewhen (not clr) and (pre(u) <> u) and (pre(u) == false) then
-    scenario = 2;
-  elsewhen (not clr) and (pre(u) <> u) and (pre(u) == true) then
-    scenario = 3;
-  elsewhen (pre(clr) <> clr) and (pre(clr) == true) and (not u) then
-    scenario = 4;
+    //scenario = 1;
+    y = if clr then false else pre_y_start;
+  elsewhen (not clr) and change(u) and (pre(u) == false) then
+    //scenario = 2;
+    y = not clr;
+  elsewhen (not clr) and change(u) and (pre(u) == true) then
+     //scenario = 3;
+    y = if clr then false else pre(y);
+  elsewhen change(clr) and (pre(clr) == true) and (not u) then
+    //scenario = 4;
+    y = false;
   elsewhen clr then
-    scenario = 5;
+    //scenario = 5;
+    y = false;
   end when;
 
-  if clr then
-    y = false;
-  else
-    if (scenario == 1) then y = if clr then false else pre(y);
-    elseif (scenario == 2) then y = true;
-    elseif (scenario == 3) then y = pre(y);
-    elseif (scenario == 4) then y = false;
-    else y = false;
-    end if;
-  end if;
 
 annotation (defaultComponentName="lat",
   Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,
@@ -116,6 +107,10 @@ At initial time, if <code>clr = false</code>, then the output will be
 
 </html>", revisions="<html>
 <ul>
+<li>
+March 9, 2020, by Michael Wetter:<br/>
+Simplified implementation, and made model work with OpenModelica.
+</li>
 <li>
 April 4, 2019, by Jianjun Hu:<br/>
 Corrected implementation that causes wrong output at initial stage. 

--- a/Buildings/Controls/OBC/CDL/Logical/Toggle.mo
+++ b/Buildings/Controls/OBC/CDL/Logical/Toggle.mo
@@ -10,38 +10,29 @@ block Toggle "Toggles output value whenever its input turns true"
   Interfaces.BooleanOutput y "Output signal"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
-protected
-  Integer scenario "Scenario index";
-
 initial equation
   pre(y) = pre_y_start;
   pre(u) = false;
   pre(clr) = false;
-  pre(scenario) = 0;
 
 equation
   when initial() then
-    scenario = 1;
-  elsewhen (not clr) and ((pre(u) <> u) and (pre(u) == false)) and (pre(y) == false) then
-    scenario = 2;
-  elsewhen (not clr) and ((pre(u) <> u) and (pre(u) == false)) and (pre(y) == true) then
-    scenario = 3;
-  elsewhen (not clr) and ((pre(u) <> u) and (pre(u) == true)) then
-    scenario = 4;
+    //scenario = 1
+    y = if clr then false else pre(y);
+  elsewhen (not clr) and change(u) and (pre(u) == false) and (pre(y) == false) then
+    //scenario = 2
+    y = true;
+  elsewhen (not clr) and change(u) and (pre(u) == false) and (pre(y) == true) then
+    //scenario = 3
+    y = false;
+  elsewhen (not clr) and change(u) and (pre(u) == true) then
+    //scenario = 4
+    y = pre(y);
   elsewhen clr then
-    scenario = 5;
+    //scenario = 5
+    y = false;
   end when;
 
-  if clr then
-    y = false;
-  else
-    if (scenario == 1) then y = if clr then false else pre(y);
-    elseif (scenario == 2) then y = true;
-    elseif (scenario == 3) then y = false;
-    elseif (scenario == 4) then y = pre(y);
-    else y = false;
-    end if;
-  end if;
 
 annotation (defaultComponentName="tog",
   Icon(coordinateSystem(preserveAspectRatio=true, extent={{-100,
@@ -125,6 +116,10 @@ At initial time, if <code>clr = false</code>, then the output will be
 
 </html>", revisions="<html>
 <ul>
+<li>
+March 9, 2020, by Michael Wetter:<br/>
+Simplified implementation, and made model work with OpenModelica.
+</li>
 <li>
 April 4, 2019, by Jianjun Hu:<br/>
 Corrected implementation that causes wrong output at initial stage. 

--- a/Buildings/package.mo
+++ b/Buildings/package.mo
@@ -215,7 +215,7 @@ its class name ends with the string <code>Beta</code>.
     <tr><td valign=\"top\">Buildings.Controls.Continuous.LimPID
         </td>
         <td valign=\"top\">Removed homotopy that may be used during initialization to ensure that outputs are bounded.<br/>
-                           This is for <a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1221\">IBPSA, #1221</a>.
+                         This is for <a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1221\">IBPSA, #1221</a>.
         </td>
     </tr>
     <tr><td colspan=\"2\"><b>Buildings.Controls.OBC.CDL</b>
@@ -234,6 +234,28 @@ its class name ends with the string <code>Beta</code>.
                            and unix time stamps are correctly defined with respect to GMT.
                            Added option unix time stamp GMT.<br/>
                            This is for <a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1232\">IBPSA, #1232</a>.
+        </td>
+    </tr>
+    <tr><td valign=\"top\">Buildings.Controls.OBC.CDL.Continuous.Sources.CalendarTime<br/>
+                           Buildings.Controls.OBC.CDL.Types.ZeroTime
+        </td>
+        <td valign=\"top\">Revised implementation such that the meaning of <code>time</code> is better explained
+                           and unix time stamps are correctly defined with respect to GMT.
+                           Added option unix time stamp GMT.<br/>
+                           This is for <a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1232\">IBPSA, #1232</a>.
+        </td>
+    </tr>
+    <tr><td valign=\"top\">Buildings.Controls.OBC.CDL.Logical.Latch<br/>
+                         Buildings.Controls.OBC.CDL.Logical.Toggle
+        </td>
+        <td valign=\"top\">Simplified implementation, which makes them work with OpenModelica.<br/>
+                         This is for <a href=\"https://github.com/lbl-srg/modelica-buildings/issues/1823\">#1823</a>.
+        </td>
+    </tr>
+    <tr><td valign=\"top\">Buildings.Controls.OBC.CDL.Logical.Timer
+        </td>
+        <td valign=\"top\">Added a boolean input to reset the accumulated timer.<br/>
+                           This is for <a href=\"https://github.com/lbl-srg/modelica-buildings/issues/1221\">#1221</a>.
         </td>
     </tr>
     <tr><td colspan=\"2\"><b>Buildings.Controls.OBC.ASHRAE.G36_PR1 </b>
@@ -255,21 +277,6 @@ its class name ends with the string <code>Beta</code>.
         </td>
         <td valign=\"top\">Added assertions and corrected implementation when respond amount is negative.<br/>
                            This is for <a href=\"https://github.com/lbl-srg/modelica-buildings/issues/1530\">#1503</a>.
-        </td>
-    </tr>
-    <tr><td valign=\"top\">Buildings.Controls.OBC.CDL.Continuous.Sources.CalendarTime<br/>
-                           Buildings.Controls.OBC.CDL.Types.ZeroTime
-        </td>
-        <td valign=\"top\">Revised implementation such that the meaning of <code>time</code> is better explained
-                           and unix time stamps are correctly defined with respect to GMT.
-                           Added option unix time stamp GMT.<br/>
-                           This is for <a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1232\">IBPSA, #1232</a>.
-        </td>
-    </tr>
-    <tr><td valign=\"top\">Buildings.Controls.OBC.CDL.Logical.Timer
-        </td>
-        <td valign=\"top\">Added a boolean input to reset the accumulated timer.<br/>
-                           This is for <a href=\"https://github.com/lbl-srg/modelica-buildings/issues/1221\">#1221</a>.
         </td>
     </tr>
     <tr><td colspan=\"2\"><b>Buildings.Examples.Tutorial</b>


### PR DESCRIPTION
This closes #1823 

@JayHuLBL : Please see these changes. These are needed for the models to run with OpenModelica and lead to much simpler implementation. I will merge it if all tests pass. I essentially put all assigments in the `when` section rather than a separate `if-then` section, and simplified for cases where we know what values the variables have.