### PR TITLE
the order of public elements in the package.mo needs to be the same a…

### DIFF
--- a/Buildings/Types/Azimuth/package.order
+++ b/Buildings/Types/Azimuth/package.order
@@ -1,8 +1,8 @@
-E
-N
-NE
-NW
 S
-SE
 SW
 W
+NW
+N
+NE
+E
+SE


### PR DESCRIPTION
…s the order in package.order

Spec says:
Classes and constants that are stored in package.mo are also present in package.order but their relative order should be identical to the one in package.mo (this ensures that the relative order between classes and constants stored in different ways is preserved).