### PR TITLE
Corrected misplaced bracket.

### DIFF
--- a/Buildings/Resources/Scripts/Dymola/ConvertBuildings_from_6_to_7.0.0.mos
+++ b/Buildings/Resources/Scripts/Dymola/ConvertBuildings_from_6_to_7.0.0.mos
@@ -137,7 +137,7 @@ convertModifiers(
     "dpDamRec_nominal=%k1% * 1.2 * %v_nominal%^2 / 2",
     "dpFixRec_nominal=if %dp_nominalIncludesDamper% then %dpRec_nominal% - %k1% * 1.2 * %v_nominal%^2 / 2 else %dpRec_nominal%",
     "dpDamExh_nominal=%k1% * 1.2 * %v_nominal%^2 / 2",
-    "dpFixExh_nominal=if %dp_nominalIncludesDamper% then %dpExh_nominal% - %k1% * 1.2 * %v_nominal%^2 / 2 else %dpExh_nominal%"},
+    "dpFixExh_nominal=if %dp_nominalIncludesDamper% then %dpExh_nominal% - %k1% * 1.2 * %v_nominal%^2 / 2 else %dpExh_nominal%",
     "dpDamOutMin_nominal=%k1% * 1.2 * %v_nominal%^2 / 2",
     "dpFixOutMin_nominal=if %dp_nominalIncludesDamper% then %dpOutMin_nominal% - %k1% * 1.2 * %v_nominal%^2 / 2 else %dpOutMin_nominal%"},
     true);

--- a/Buildings/Resources/Scripts/Dymola/ConvertBuildings_from_6_to_7.0.0.mos
+++ b/Buildings/Resources/Scripts/Dymola/ConvertBuildings_from_6_to_7.0.0.mos
@@ -81,40 +81,24 @@ convertElement(
 
 // Refactoring damper models.
 convertElement(
-    {"Buildings.Fluid.Actuators.Dampers.PressureIndependent",
-    "Fluid.Actuators.Dampers.PressureIndependent",
-    "Actuators.Dampers.PressureIndependent",
-    "Dampers.PressureIndependent",
-    "PressureIndependent"},
+    "Buildings.Fluid.Actuators.Dampers.PressureIndependent",
     "dp_nominal",
     "dpDamper_nominal");
 convertModifiers(
-    {"Buildings.Fluid.Actuators.Dampers.Exponential",
-    "Fluid.Actuators.Dampers.Exponential",
-    "Actuators.Dampers.Exponential",
-    "Dampers.Exponential",
-    "Exponential"},
+    "Buildings.Fluid.Actuators.Dampers.Exponential",
     {"k1=0.45", "v_nominal=1"},
     {"k1=%k1%",
     "dpDamper_nominal=%k1% * 1.2 * %v_nominal%^2 / 2"},
     true);
 convertModifiers(
-    {"Buildings.Fluid.Actuators.Dampers.VAVBoxExponential",
-    "Fluid.Actuators.Dampers.VAVBoxExponential",
-    "Actuators.Dampers.VAVBoxExponential",
-    "Dampers.VAVBoxExponential",
-    "VAVBoxExponential"},
+    "Buildings.Fluid.Actuators.Dampers.VAVBoxExponential",
     {"dp_nominal", "k1=0.45", "v_nominal=1", "dp_nominalIncludesDamper=true"},
     {"k1=%k1%",
     "dpDamper_nominal=%k1% * 1.2 * %v_nominal%^2 / 2",
     "dpFixed_nominal=if %dp_nominalIncludesDamper% then %dp_nominal% - %k1% * 1.2 * %v_nominal%^2 / 2 else %dp_nominal%"},
     true);
 convertModifiers(
-    {"Buildings.Fluid.Actuators.Dampers.MixingBox",
-    "Fluid.Actuators.Dampers.MixingBox",
-    "Actuators.Dampers.MixingBox",
-    "Dampers.MixingBox",
-    "MixingBox"},
+    "Buildings.Fluid.Actuators.Dampers.MixingBox",
     {"dpOut_nominal", "dpRec_nominal", "dpExh_nominal", "k1=0.45", "v_nominal=1", "dp_nominalIncludesDamper=false"},
     {"k1=%k1%",
     "dpDamOut_nominal=%k1% * 1.2 * %v_nominal%^2 / 2",
@@ -125,11 +109,7 @@ convertModifiers(
     "dpFixExh_nominal=if %dp_nominalIncludesDamper% then %dpExh_nominal% - %k1% * 1.2 * %v_nominal%^2 / 2 else %dpExh_nominal%"},
     true);
 convertModifiers(
-    {"Buildings.Fluid.Actuators.Dampers.MixingBoxMinimumFlow",
-    "Fluid.Actuators.Dampers.MixingBoxMinimumFlow",
-    "Actuators.Dampers.MixingBoxMinimumFlow",
-    "Dampers.MixingBoxMinimumFlow",
-    "MixingBoxMinimumFlow"},
+    "Buildings.Fluid.Actuators.Dampers.MixingBoxMinimumFlow",
     {"dpOut_nominal", "dpRec_nominal", "dpExh_nominal", "dpOutMin_nominal", "k1=0.45", "v_nominal=1", "dp_nominalIncludesDamper=false"},
     {"k1=%k1%",
     "dpDamOut_nominal=%k1% * 1.2 * %v_nominal%^2 / 2",
@@ -142,9 +122,5 @@ convertModifiers(
     "dpFixOutMin_nominal=if %dp_nominalIncludesDamper% then %dpOutMin_nominal% - %k1% * 1.2 * %v_nominal%^2 / 2 else %dpOutMin_nominal%"},
     true);
 convertClass(
-    {"Buildings.Fluid.Actuators.Dampers.VAVBoxExponential",
-    "Fluid.Actuators.Dampers.VAVBoxExponential",
-    "Actuators.Dampers.VAVBoxExponential",
-    "Dampers.VAVBoxExponential",
-    "VAVBoxExponential"},
+    "Buildings.Fluid.Actuators.Dampers.VAVBoxExponential",
     "Buildings.Fluid.Actuators.Dampers.Exponential");


### PR DESCRIPTION
@AntoineGautier : This patches a misplaced bracket in the conversion script for the MixingBoxMinimumFlow.

Also, I don't think you need to list
```
{"Buildings.Fluid.Actuators.Dampers.PressureIndependent",
    "Fluid.Actuators.Dampers.PressureIndependent",
    "Actuators.Dampers.PressureIndependent",
    "Dampers.PressureIndependent",
    "PressureIndependent"}
```
because
```
{"Buildings.Fluid.Actuators.Dampers.PressureIndependent"}
```
suffices.