### PR TITLE
added default name and fixed parameter specifications, #1944

### DIFF
--- a/Buildings/Controls/OBC/ASHRAE/G36_PR1/AHUs/SingleZone/VAV/Economizers/Subsequences/Enable.mo
+++ b/Buildings/Controls/OBC/ASHRAE/G36_PR1/AHUs/SingleZone/VAV/Economizers/Subsequences/Enable.mo
@@ -295,8 +295,10 @@ equation
   connect(xor.y, truFalHol.u) annotation (Line(points={{96,252},{106,252},{106,
           224},{122,224}},
                       color={255,0,255}));
-    annotation (
-    Icon(graphics={
+
+annotation (
+  defaultComponentName = "enaDis",
+  Icon(graphics={
         Rectangle(
           extent={{-100,-100},{100,100}},
           lineColor={0,0,127},

--- a/Buildings/Controls/OBC/ASHRAE/G36_PR1/TerminalUnits/Validation/Controller.mo
+++ b/Buildings/Controls/OBC/ASHRAE/G36_PR1/TerminalUnits/Validation/Controller.mo
@@ -64,7 +64,7 @@ model Controller "Validate model for controlling VAV terminal box with reheat"
   Buildings.Controls.OBC.CDL.Continuous.Round rou(n=0) "Round the input"
     annotation (Placement(transformation(extent={{-60,-80},{-40,-60}})));
   Buildings.Controls.OBC.CDL.Discrete.ZeroOrderHold zerOrdHol(
-    final samplePeriod=2)
+    final samplePeriod=2) "Mimic damper position"
     annotation (Placement(transformation(extent={{80,58},{100,78}})));
   Buildings.Controls.OBC.CDL.Discrete.ZeroOrderHold zerOrdHol1(
     final samplePeriod=2) "Mimic damper position"

--- a/Buildings/Controls/OBC/CDL/Continuous/MultiMax.mo
+++ b/Buildings/Controls/OBC/CDL/Continuous/MultiMax.mo
@@ -11,7 +11,9 @@ block MultiMax "Output the maximum element of the input vector"
 equation
   y = max(u);
 
-annotation (Icon(coordinateSystem(
+annotation (
+  defaultComponentName = "mulMax",
+  Icon(coordinateSystem(
         preserveAspectRatio=false,
         extent={{-100,-100},{100,100}}),
       graphics={

--- a/Buildings/Controls/OBC/CDL/Continuous/MultiMin.mo
+++ b/Buildings/Controls/OBC/CDL/Continuous/MultiMin.mo
@@ -10,7 +10,10 @@ block MultiMin "Output the minimum element of the input vector"
 
 equation
   y = min(u);
-  annotation (Icon(coordinateSystem(
+
+annotation (
+  defaultComponentName = "mulMin",
+  Icon(coordinateSystem(
         preserveAspectRatio=false,
         extent={{-100,-100},{100,100}}),
         graphics={

--- a/Buildings/Controls/OBC/CDL/Continuous/Sources/TimeTable.mo
+++ b/Buildings/Controls/OBC/CDL/Continuous/Sources/TimeTable.mo
@@ -51,6 +51,7 @@ equation
   connect(tab.y, y) annotation (Line(points={{9,0},{120,0}}, color={0,0,127}));
 
 annotation (
+defaultComponentName = "timTab",
 Documentation(info="<html>
 <p>
 Block that outputs values of a time table.

--- a/Buildings/Controls/OBC/OutdoorLights/DaylightControlled.mo
+++ b/Buildings/Controls/OBC/OutdoorLights/DaylightControlled.mo
@@ -1,8 +1,17 @@
 within Buildings.Controls.OBC.OutdoorLights;
 block DaylightControlled "Controlling the outdoor lighting based on whether the sun is up"
-  parameter Modelica.SIunits.Angle lat(displayUnit="deg") "Latitude";
-  parameter Modelica.SIunits.Angle lon(displayUnit="deg") "Longitude";
-  parameter Modelica.SIunits.Time timZon(displayUnit="h") "Time zone of location";
+  parameter Real lat(
+    final quantity="Angle",
+    final unit="rad",
+    displayUnit="deg") "Latitude";
+  parameter Real lon(
+    final quantity="Angle",
+    final unit="rad",
+    displayUnit="deg") "Longitude";
+  parameter Real timZon(
+    final quantity="Time",
+    final unit="s",
+    displayUnit="h") "Time zone of location";
 
   CDL.Interfaces.RealOutput y(
     final min = 0,

--- a/Buildings/Controls/OBC/Shade/Shade_H.mo
+++ b/Buildings/Controls/OBC/Shade/Shade_H.mo
@@ -1,10 +1,14 @@
 within Buildings.Controls.OBC.Shade;
 block Shade_H "Shade controller with solar irradiation as input"
 
-  parameter Modelica.SIunits.Irradiance HHigh
+  parameter Real HHigh(
+    final quantity="Irradiance",
+    final unit="W/m2")
     "if y=0 and H>=HHigh, switch to y=1";
 
-  parameter Modelica.SIunits.Irradiance HLow
+  parameter Real HLow(
+    final quantity="Irradiance",
+    final unit="W/m2")
     "if y=1 and H<=HLow, switch to y=0";
 
   CDL.Interfaces.RealInput H(final unit = "W/m2")

--- a/Buildings/Controls/OBC/Shade/Shade_T.mo
+++ b/Buildings/Controls/OBC/Shade/Shade_T.mo
@@ -1,10 +1,16 @@
 within Buildings.Controls.OBC.Shade;
 block Shade_T "Shade controller with temperature as input"
 
-  parameter Modelica.SIunits.Temperature THigh
+  parameter Real THigh(
+    final quantity="ThermodynamicTemperature",
+    final unit="K",
+    displayUnit="degC")
     "if y=0 and T>=THigh, switch to y=1";
 
-  parameter Modelica.SIunits.Temperature TLow
+  parameter Real TLow(
+    final quantity="ThermodynamicTemperature",
+    final unit="K",
+    displayUnit="degC")
     "if y=1 and T<=TLow, switch to y=0";
 
   CDL.Interfaces.RealInput T(final unit = "K")

--- a/Buildings/Controls/OBC/Utilities/BaseClasses/OptimalStartCalculation.mo
+++ b/Buildings/Controls/OBC/Utilities/BaseClasses/OptimalStartCalculation.mo
@@ -1,16 +1,26 @@
 within Buildings.Controls.OBC.Utilities.BaseClasses;
 block OptimalStartCalculation
   "Base class for the block OptimalStart"
-  parameter Modelica.SIunits.Time tOptMax "Maximum optimal start time";
-  parameter Modelica.SIunits.Time thrOptOn
+  parameter Real tOptMax(
+    final quantity="Time",
+    final unit="s") "Maximum optimal start time";
+  parameter Real thrOptOn(
+    final quantity="Time",
+    final unit="s")
     "Threshold time for the output optOn to become true";
-  parameter Modelica.SIunits.Time tOptDef
+  parameter Real tOptDef(
+    final quantity="Time",
+    final unit="s")
     "Default optimal start time";
   parameter Integer nDay "Number of previous days for averaging the temperature slope";
-  parameter Modelica.SIunits.TemperatureDifference uLow
+  parameter Real uLow(
+    final quantity="TemperatureDifference",
+    final unit="K")
     "Threshold to determine if the zone temperature reaches the occupied setpoint,
      should be a non-negative number";
-  parameter Modelica.SIunits.TemperatureDifference uHigh
+  parameter Real uHigh(
+    final quantity="TemperatureDifference",
+    final unit="K")
     "Threshold to determine the need to start the HVAC system before occupancy,
      should be greater than uLow";
 
@@ -44,7 +54,9 @@ block OptimalStartCalculation
         iconTransformation(extent={{100,-60},{140,-20}})));
 
 protected
-  parameter Modelica.SIunits.TemperatureSlope temSloDef = 1/3600
+  parameter Real temSloDef(
+    final quantity="TemperatureSlope",
+    final unit="K/s") = 1/3600
     "Default temperature slope in case of zero division";
 
   Buildings.Controls.OBC.CDL.Discrete.TriggeredMovingMean triMovMea(

--- a/Buildings/Controls/OBC/Utilities/OptimalStart.mo
+++ b/Buildings/Controls/OBC/Utilities/OptimalStart.mo
@@ -1,10 +1,12 @@
 within Buildings.Controls.OBC.Utilities;
 block OptimalStart
   "Block that outputs the optimal start time for an HVAC system before occupancy"
-  parameter Modelica.SIunits.Time tOptMax(
+  parameter Real tOptMax(
+    final quantity="Time",
+    final unit="s",
+    displayUnit="h",
     final min=0,
-    max=21600,
-    displayUnit="h") = 10800
+    max=21600) = 10800
     "Maximum optimal start time";
   parameter Integer nDay(min=1) = 3
     "Number of previous days used to compute the optimal start up time";
@@ -12,13 +14,22 @@ block OptimalStart
     "Set to true to compute optimal start for heating";
   parameter Boolean computeCooling = false
     "Set to true to compute optimal start for cooling";
-  parameter Modelica.SIunits.TemperatureDifference uLow(final min=0) = 0
+  parameter Real uLow(
+    final quantity="TemperatureDifference",
+    final unit="K",
+    final min=0) = 0
     "Threshold to determine if the zone temperature reaches the occupied setpoint,
      must be a non-negative number";
-  parameter Modelica.SIunits.TemperatureDifference uHigh(final min=0) = 0.5
+  parameter Real uHigh(
+    final quantity="TemperatureDifference",
+    final unit="K",
+    final min=0) = 0.5
     "Threshold to determine the need to start the HVAC system before occupancy,
      must be greater than uLow";
-  parameter Modelica.SIunits.Time thrOptOn(
+  parameter Real thrOptOn(
+    final quantity="Time",
+    final unit="s",
+    displayUnit="h",
     final min=0,
     max=10800) = 60
     "Threshold time, optimal start on signal becomes true when tOpt larger than thrOptOn";
@@ -83,7 +94,10 @@ block OptimalStart
     "Optimal start time for cooling system"
     annotation (Placement(transformation(extent={{20,-80},{40,-60}})));
 protected
-  parameter Modelica.SIunits.Time tOptDef = 3600
+  parameter Real tOptDef(
+     final quantity="Time",
+    final unit="s",
+    displayUnit="h") = 3600
     "Default optimal start time";
   Buildings.Controls.OBC.CDL.Continuous.Max max
     "Get the maximum optimal start time "


### PR DESCRIPTION
This closes #1944.

- [x] added missing default component name
- [x] added missing comment
- [x] avoided using `Modelica.SIunits.xxx` to specify parameters