### PR TITLE
issue1129_energyPlus_zone branch patched for Windows

### DIFF
--- a/Buildings/Resources/C-Sources/EnergyPlus/BuildingInstantiate.h
+++ b/Buildings/Resources/C-Sources/EnergyPlus/BuildingInstantiate.h
@@ -11,7 +11,12 @@
 #include "../cryptographicsHash.h"
 
 #include <stdio.h>
+#ifdef _MSC_VER
+#include <windows.h>
+#else
 #include <unistd.h>
+#endif
+
 
 #include "fmilib.h"
 #include "JM/jm_portability.h"

--- a/Buildings/Resources/C-Sources/EnergyPlus/EnergyPlusFMU.c
+++ b/Buildings/Resources/C-Sources/EnergyPlus/EnergyPlusFMU.c
@@ -13,7 +13,11 @@
 
 #include <stdlib.h>
 #include <string.h>
+#ifdef _MSC_VER
+#include <windows.h>
+#else
 #include <unistd.h>
+#endif
 
 
 static unsigned int Buildings_nFMU = 0;     /* Number of FMUs */

--- a/Buildings/Resources/C-Sources/EnergyPlus/EnergyPlusUtil.c
+++ b/Buildings/Resources/C-Sources/EnergyPlus/EnergyPlusUtil.c
@@ -82,7 +82,8 @@ void logValueReferenceArray(unsigned int level,
 }
 
 
-void printBacktrace(){
+void printBacktrace(){ /* Does nothing on Windows */
+#ifdef __linux__
   void* callstack[128];
   int i, frames = backtrace(callstack, 128);
   char** strs = backtrace_symbols(callstack, frames);
@@ -90,6 +91,7 @@ void printBacktrace(){
     printf("%s\n", strs[i]);
   }
   free(strs);
+#endif
 }
 
 void mallocString(const size_t nChar, const char *error_message, char** str){

--- a/Buildings/Resources/C-Sources/EnergyPlus/EnergyPlusUtil.h
+++ b/Buildings/Resources/C-Sources/EnergyPlus/EnergyPlusUtil.h
@@ -10,11 +10,24 @@
 #include "BuildingInstantiate.h"
 
 #include <stdio.h>
+#ifdef _MSC_VER
+#include <windows.h>
+#define R_OK 4
+#define W_OK 2
+#define X_OK 1
+#define F_OK 0
+#else
 #include <unistd.h>
 #include <execinfo.h>
+#endif
+
+#ifdef __linux__
+#include <execinfo.h>
+#endif
+
 #include <sys/types.h> /* To create directory */
 #include <sys/stat.h>  /* To create directory */
-#include <unistd.h>    /* To use stat to check for directory */
+//#include <unistd.h>    /* To use stat to check for directory */
 #include <errno.h>
 
 #include "fmilib.h"

--- a/Buildings/Resources/C-Sources/EnergyPlus/OutputVariableInstantiate.h
+++ b/Buildings/Resources/C-Sources/EnergyPlus/OutputVariableInstantiate.h
@@ -10,7 +10,11 @@
 #include "BuildingInstantiate.h"
 
 #include <stdio.h>
+#ifdef _MSC_VER
+#include <windows.h>
+#else
 #include <unistd.h>
+#endif
 
 #include "fmilib.h"
 #include "JM/jm_portability.h"

--- a/Buildings/Resources/C-Sources/EnergyPlus/ZoneInstantiate.h
+++ b/Buildings/Resources/C-Sources/EnergyPlus/ZoneInstantiate.h
@@ -10,7 +10,11 @@
 #include "BuildingInstantiate.h"
 
 #include <stdio.h>
+#ifdef _MSC_VER
+#include <windows.h>
+#else
 #include <unistd.h>
+#endif
 
 #include "fmilib.h"
 #include "JM/jm_portability.h"


### PR DESCRIPTION
C sources in Buildings/Resources/C-Sources/EnergyPlus patched to allow building FMUs on Windows, working around the unistd.h and execinfo.h includes.

The printBacktrace function will do nothing on Windows since I'm not aware of a Windows-compiler-portable backtrace approach and didn't take the time to build one.