### PR TITLE
Corrected formatting

### DIFF
--- a/Buildings/Resources/Documentation/userGuide/build/html/.buildinfo
+++ b/Buildings/Resources/Documentation/userGuide/build/html/.buildinfo
@@ -1,4 +1,4 @@
 # Sphinx build info version 1
 # This file hashes the configuration used when building these files. When it is not found, a full rebuild will be done.
-config: 9b2ef004d8b591b5724fdc44e5f32b9e
+config: ef20bdfc82d3e06e0e24af1430aed761
 tags: 645f666f9bcd5a90fca523b33c5a78b7

--- a/Buildings/Resources/Documentation/userGuide/build/html/_sources/development.rst.txt
+++ b/Buildings/Resources/Documentation/userGuide/build/html/_sources/development.rst.txt
@@ -334,9 +334,9 @@ Documentation
 
     .. code-block:: html
 
-    See
-    <a href="modelica://Buildings.Fluid.Sensors.Density">
-    Buildings.Fluid.Sensors.Density</a>.
+       See
+       <a href="modelica://Buildings.Fluid.Sensors.Density">
+       Buildings.Fluid.Sensors.Density</a>.
 
 8.  Add a default component name, such as
 

--- a/Buildings/Resources/Documentation/userGuide/build/html/development.html
+++ b/Buildings/Resources/Documentation/userGuide/build/html/development.html
@@ -481,12 +481,11 @@ works on any operating system. See for example the file in
 <li><p>Start headings with <code class="docutils literal notranslate"><span class="pre">&lt;h4&gt;</span></code>.</p></li>
 <li><p>Add hyperlinks to other models using their full name. For example,
 use</p>
-<div class="highlight-html notranslate"><div class="highlight"><pre><span></span>
+<div class="highlight-html notranslate"><div class="highlight"><pre><span></span>See
+<span class="p">&lt;</span><span class="nt">a</span> <span class="na">href</span><span class="o">=</span><span class="s">&quot;modelica://Buildings.Fluid.Sensors.Density&quot;</span><span class="p">&gt;</span>
+Buildings.Fluid.Sensors.Density<span class="p">&lt;/</span><span class="nt">a</span><span class="p">&gt;</span>.
 </pre></div>
 </div>
-<p>See
-&lt;a href=”modelica://Buildings.Fluid.Sensors.Density”&gt;
-Buildings.Fluid.Sensors.Density&lt;/a&gt;.</p>
 </li>
 <li><p>Add a default component name, such as</p>
 <div class="highlight-modelica notranslate"><div class="highlight"><pre><span></span><span class="kr">annotation</span><span class="p">(</span><span class="n">defaultComponentName</span><span class="o">=</span><span class="s2">&quot;senDen&quot;</span><span class="p">,</span> <span class="o">...</span>

--- a/Buildings/Resources/Documentation/userGuide/source/development.rst
+++ b/Buildings/Resources/Documentation/userGuide/source/development.rst
@@ -334,9 +334,9 @@ Documentation
 
     .. code-block:: html
 
-    See
-    <a href="modelica://Buildings.Fluid.Sensors.Density">
-    Buildings.Fluid.Sensors.Density</a>.
+       See
+       <a href="modelica://Buildings.Fluid.Sensors.Density">
+       Buildings.Fluid.Sensors.Density</a>.
 
 8.  Add a default component name, such as
 


### PR DESCRIPTION
This corrects the formatting which lead to a code section in the user guide not being shown.