### PR TITLE
Added vendor annotation showing default value of the conditional removable connectors

### DIFF
--- a/Buildings/Controls/OBC/ASHRAE/G36_PR1/AHUs/MultiZone/VAV/Controller.mo
+++ b/Buildings/Controls/OBC/ASHRAE/G36_PR1/AHUs/MultiZone/VAV/Controller.mo
@@ -1000,7 +1000,7 @@ Buildings.Controls.OBC.ASHRAE.G36_PR1.AHUs.MultiZone.VAV.SetPoints.SupplySignals
 revisions="<html>
 <ul>
 <li>
-October 20, 2020, by jianjun Hu:<br/>
+October 20, 2020, by Jianjun Hu:<br/>
 Added vendor annotation to show the default value of the conditional removable connectors.<br/>
 This is for
 <a href=\"https://github.com/lbl-srg/modelica-buildings/issues/1854\">#1854</a>.

--- a/Buildings/Controls/OBC/ASHRAE/G36_PR1/AHUs/MultiZone/VAV/Controller.mo
+++ b/Buildings/Controls/OBC/ASHRAE/G36_PR1/AHUs/MultiZone/VAV/Controller.mo
@@ -469,14 +469,14 @@ block Controller
     final unit="J/kg",
     final quantity="SpecificEnergy") if use_enthalpy "Outdoor air enthalpy"
     annotation (Placement(transformation(extent={{-240,-110},{-200,-70}}),
-        iconTransformation(extent={{-240,-130},{-200,-90}})));
+        iconTransformation(extent={{-240,-130},{-200,-90}})), __cdl(default=0));
 
   Buildings.Controls.OBC.CDL.Interfaces.RealInput hOutCut(
     final unit="J/kg",
     final quantity="SpecificEnergy") if use_enthalpy
     "OA enthalpy high limit cutoff. For differential enthalpy use return air enthalpy measurement"
     annotation (Placement(transformation(extent={{-240,-140},{-200,-100}}),
-        iconTransformation(extent={{-240,-160},{-200,-120}})));
+        iconTransformation(extent={{-240,-160},{-200,-120}})), __cdl(default=0));
 
   Buildings.Controls.OBC.CDL.Interfaces.RealInput VOut_flow(
     final min=0,
@@ -492,7 +492,7 @@ block Controller
     final quantity = "ThermodynamicTemperature") if use_TMix
     "Measured mixed air temperature, used for freeze protection if use_TMix=true"
     annotation (Placement(transformation(extent={{-240,-200},{-200,-160}}),
-        iconTransformation(extent={{-240,-230},{-200,-190}})));
+        iconTransformation(extent={{-240,-230},{-200,-190}})), __cdl(default=293.15);
 
   Buildings.Controls.OBC.CDL.Interfaces.IntegerInput uOpeMod
     "AHU operation mode status signal"
@@ -513,7 +513,7 @@ block Controller
       use_G36FrePro
    "Freeze protection status, used if use_G36FrePro=true"
     annotation (Placement(transformation(extent={{-240,-320},{-200,-280}}),
-        iconTransformation(extent={{-240,-360},{-200,-320}})));
+        iconTransformation(extent={{-240,-360},{-200,-320}})), __cdl(default=0));
 
   Buildings.Controls.OBC.CDL.Interfaces.BooleanOutput ySupFan
     "Supply fan status, true if fan should be on"
@@ -638,8 +638,10 @@ block Controller
     annotation (Placement(transformation(extent={{0,170},{20,190}})));
 
   Buildings.Controls.OBC.ASHRAE.G36_PR1.AHUs.MultiZone.VAV.SetPoints.OutdoorAirFlow.AHU
-    sysOutAirSet(final VPriSysMax_flow=VPriSysMax_flow, final peaSysPop=
-        peaSysPop) "Minimum outdoor airflow setpoint"
+    sysOutAirSet(
+    final VPriSysMax_flow=VPriSysMax_flow, 
+    final peaSysPop=peaSysPop) 
+    "Minimum outdoor airflow setpoint"
     annotation (Placement(transformation(extent={{-40,70},{-20,90}})));
 
   Buildings.Controls.OBC.ASHRAE.G36_PR1.AHUs.MultiZone.VAV.Economizers.Controller eco(
@@ -997,6 +999,12 @@ Buildings.Controls.OBC.ASHRAE.G36_PR1.AHUs.MultiZone.VAV.SetPoints.SupplySignals
 </html>",
 revisions="<html>
 <ul>
+<li>
+October 20, 2020, by jianjun Hu:<br/>
+Added vendor annotation to show the default value of the conditional removable connectors.<br/>
+This is for
+<a href=\"https://github.com/lbl-srg/modelica-buildings/issues/1854\">#1854</a>.
+</li>
 <li>
 July 10, 2020, by Antoine Gautier:<br/>
 Changed default value of integral time for minimum outdoor air control.<br/>

--- a/Buildings/Controls/OBC/ASHRAE/G36_PR1/AHUs/MultiZone/VAV/Economizers/Controller.mo
+++ b/Buildings/Controls/OBC/ASHRAE/G36_PR1/AHUs/MultiZone/VAV/Economizers/Controller.mo
@@ -420,7 +420,7 @@ which may be revised in future versions, set
 </html>", revisions="<html>
 <ul>
 <li>
-October 20, 2020, by jianjun Hu:<br/>
+October 20, 2020, by Jianjun Hu:<br/>
 Added vendor annotation to show the default value of the conditional removable connectors.<br/>
 This is for
 <a href=\"https://github.com/lbl-srg/modelica-buildings/issues/1854\">#1854</a>.

--- a/Buildings/Controls/OBC/ASHRAE/G36_PR1/AHUs/MultiZone/VAV/Economizers/Controller.mo
+++ b/Buildings/Controls/OBC/ASHRAE/G36_PR1/AHUs/MultiZone/VAV/Economizers/Controller.mo
@@ -141,7 +141,8 @@ block Controller "Multi zone VAV AHU economizer control sequence"
     "Physically fixed minimum position of the outdoor air damper"
     annotation (Dialog(tab="Commissioning", group="Physical damper position limits"));
 
-  Buildings.Controls.OBC.CDL.Interfaces.RealInput uTSup(final unit="1")
+  Buildings.Controls.OBC.CDL.Interfaces.RealInput uTSup(
+    final unit="1")
     "Signal for supply air temperature control (T Sup Control Loop Signal in diagram)"
     annotation (Placement(transformation(extent={{-200,20},{-160,60}})));
   Buildings.Controls.OBC.CDL.Interfaces.RealInput TOut(
@@ -158,18 +159,18 @@ block Controller "Multi zone VAV AHU economizer control sequence"
   Buildings.Controls.OBC.CDL.Interfaces.RealInput hOut(
     final unit="J/kg",
     final quantity="SpecificEnergy") if use_enthalpy "Outdoor air enthalpy"
-    annotation (Placement(transformation(extent={{-200,70},{-160,110}})));
+    annotation (Placement(transformation(extent={{-200,70},{-160,110}})), __cdl(default=0));
   Buildings.Controls.OBC.CDL.Interfaces.RealInput hOutCut(
     final unit="J/kg",
     final quantity="SpecificEnergy") if use_enthalpy
     "OA enthalpy high limit cutoff. For differential enthalpy use return air enthalpy measurement"
-    annotation (Placement(transformation(extent={{-200,50},{-160,90}})));
+    annotation (Placement(transformation(extent={{-200,50},{-160,90}})), __cdl(default=0));
   Buildings.Controls.OBC.CDL.Interfaces.RealInput TMix(
     final unit="K",
     final displayUnit="degC",
     final quantity = "ThermodynamicTemperature") if use_TMix
     "Measured mixed air temperature, used for freeze protection"
-    annotation (Placement(transformation(extent={{-200,-70},{-160,-30}})));
+    annotation (Placement(transformation(extent={{-200,-70},{-160,-30}})), __cdl(default=293.15));
   Buildings.Controls.OBC.CDL.Interfaces.RealInput VOut_flow_normalized(
     final unit="1")
     "Measured outdoor volumetric airflow rate, normalized by design minimum outdoor airflow rate"
@@ -180,7 +181,7 @@ block Controller "Multi zone VAV AHU economizer control sequence"
     annotation (Placement(transformation(extent={{-200,-40},{-160,0}})));
   Buildings.Controls.OBC.CDL.Interfaces.IntegerInput uFreProSta if use_G36FrePro
     "Freeze protection status"
-    annotation (Placement(transformation(extent={{-200,-170},{-160,-130}})));
+    annotation (Placement(transformation(extent={{-200,-170},{-160,-130}})), __cdl(default=0));
   Buildings.Controls.OBC.CDL.Interfaces.IntegerInput uOpeMod
     "AHU operation mode status signal"
     annotation (Placement(transformation(extent={{-200,-130},{-160,-90}})));
@@ -418,6 +419,12 @@ which may be revised in future versions, set
 </p>
 </html>", revisions="<html>
 <ul>
+<li>
+October 20, 2020, by jianjun Hu:<br/>
+Added vendor annotation to show the default value of the conditional removable connectors.<br/>
+This is for
+<a href=\"https://github.com/lbl-srg/modelica-buildings/issues/1854\">#1854</a>.
+</li>
 <li>
 July 10, 2020, by Antoine Gautier:<br/>
 Changed default value of integral time for minimum outdoor air control.<br/>

--- a/Buildings/Controls/OBC/ASHRAE/G36_PR1/AHUs/MultiZone/VAV/Economizers/Subsequences/Enable.mo
+++ b/Buildings/Controls/OBC/ASHRAE/G36_PR1/AHUs/MultiZone/VAV/Economizers/Subsequences/Enable.mo
@@ -40,7 +40,7 @@ block Enable
     final quantity="SpecificEnergy") if use_enthalpy
     "Outdoor air enthalpy"
     annotation (Placement(transformation(extent={{-320,170},{-280,210}}),
-        iconTransformation(extent={{-140,40},{-100,80}})));
+        iconTransformation(extent={{-140,40},{-100,80}})), __cdl(default=0));
   Buildings.Controls.OBC.CDL.Interfaces.RealInput TOutCut(
     final unit="K",
     final displayUnit="degC",
@@ -53,7 +53,7 @@ block Enable
     final quantity="SpecificEnergy") if use_enthalpy
     "OA enthalpy high limit cutoff. For differential enthalpy use return air enthalpy measurement"
     annotation (Placement(transformation(extent={{-320,130},{-280,170}}),
-        iconTransformation(extent={{-140,20},{-100,60}})));
+        iconTransformation(extent={{-140,20},{-100,60}})), __cdl(default=0));
 
   Buildings.Controls.OBC.CDL.Interfaces.RealInput uOutDamPosMin(
     final unit="1",
@@ -94,7 +94,8 @@ block Enable
     "Supply fan on/off status signal"
     annotation (Placement(transformation(extent={{-320,80},{-280,120}}),
         iconTransformation(extent={{-140,0},{-100,40}})));
-  Buildings.Controls.OBC.CDL.Interfaces.IntegerInput uFreProSta "Freeze protection stage status signal"
+  Buildings.Controls.OBC.CDL.Interfaces.IntegerInput uFreProSta 
+    "Freeze protection stage status signal"
     annotation (Placement(transformation(extent={{-320,30},{-280,70}}),
         iconTransformation(extent={{-140,-20},{-100,20}})));
 
@@ -414,6 +415,12 @@ This is implemented using a proportional controller with a default deadband of
 </p>
 </html>", revisions="<html>
 <ul>
+<li>
+October 20, 2020, by jianjun Hu:<br/>
+Added vendor annotation to show the default value of the conditional removable connectors.<br/>
+This is for
+<a href=\"https://github.com/lbl-srg/modelica-buildings/issues/1854\">#1854</a>.
+</li>
 <li>
 October 13, 2017, by Michael Wetter:<br/>
 Added freeze protection that tracks mixed air temperature.

--- a/Buildings/Controls/OBC/ASHRAE/G36_PR1/AHUs/MultiZone/VAV/Economizers/Subsequences/Enable.mo
+++ b/Buildings/Controls/OBC/ASHRAE/G36_PR1/AHUs/MultiZone/VAV/Economizers/Subsequences/Enable.mo
@@ -416,7 +416,7 @@ This is implemented using a proportional controller with a default deadband of
 </html>", revisions="<html>
 <ul>
 <li>
-October 20, 2020, by jianjun Hu:<br/>
+October 20, 2020, by Jianjun Hu:<br/>
 Added vendor annotation to show the default value of the conditional removable connectors.<br/>
 This is for
 <a href=\"https://github.com/lbl-srg/modelica-buildings/issues/1854\">#1854</a>.

--- a/Buildings/Controls/OBC/ASHRAE/G36_PR1/AHUs/MultiZone/VAV/Economizers/Subsequences/Modulation.mo
+++ b/Buildings/Controls/OBC/ASHRAE/G36_PR1/AHUs/MultiZone/VAV/Economizers/Subsequences/Modulation.mo
@@ -25,11 +25,12 @@ block Modulation
     "Minimum loop signal for the RA damper to be fully open"
     annotation (Dialog(tab="Commissioning", group="Controller"));
   parameter Real samplePeriod(
-     final unit="s",
-     final quantity="Time")= 300
+    final unit="s",
+    final quantity="Time")= 300
     "Sample period of component, used to limit the rate of change of the dampers (to avoid quick opening that can result in frost)";
 
-  Buildings.Controls.OBC.CDL.Interfaces.RealInput uTSup(final unit="1")
+  Buildings.Controls.OBC.CDL.Interfaces.RealInput uTSup(
+    final unit="1")
     "Signal for supply air temperature control (T Sup Control Loop Signal in diagram)"
     annotation (Placement(transformation(extent={{-160,-20},{-120,20}}),
         iconTransformation(extent={{-140,-20},{-100,20}})));

--- a/Buildings/Controls/OBC/ASHRAE/G36_PR1/AHUs/MultiZone/VAV/SetPoints/OutdoorAirFlow/Zone.mo
+++ b/Buildings/Controls/OBC/ASHRAE/G36_PR1/AHUs/MultiZone/VAV/SetPoints/OutdoorAirFlow/Zone.mo
@@ -63,12 +63,12 @@ block Zone
   Buildings.Controls.OBC.CDL.Interfaces.IntegerInput nOcc if have_occSen
     "Number of occupants"
     annotation (Placement(transformation(extent={{-200,20},{-160,60}}),
-        iconTransformation(extent={{-140,70},{-100,110}})));
+        iconTransformation(extent={{-140,70},{-100,110}})), __cdl(default=0));
 
   Buildings.Controls.OBC.CDL.Interfaces.BooleanInput uWin if have_winSen
     "Window status, true if open, false if closed"
     annotation (Placement(transformation(extent={{-200,-70},{-160,-30}}),
-      iconTransformation(extent={{-140,40},{-100,80}})));
+      iconTransformation(extent={{-140,40},{-100,80}})), __cdl(default=false));
 
   Buildings.Controls.OBC.CDL.Interfaces.BooleanInput uReqOutAir
     "True if the AHU supply fan is on and the zone is in occupied mode"
@@ -621,6 +621,12 @@ Stanke, D., 2010. <i>Dynamic Reset for Multiple-Zone Systems.</i> ASHRAE Journal
 </p>
 </html>", revisions="<html>
 <ul>
+<li>
+October 20, 2020, by jianjun Hu:<br/>
+Added vendor annotation to show the default value of the conditional removable connectors.<br/>
+This is for
+<a href=\"https://github.com/lbl-srg/modelica-buildings/issues/1854\">#1854</a>.
+</li>
 <li>
 March 13, 2020, by Jianjun Hu:<br/>
 Separated from original sequence of finding the system minimum outdoor air setpoint.<br/>

--- a/Buildings/Controls/OBC/ASHRAE/G36_PR1/AHUs/MultiZone/VAV/SetPoints/OutdoorAirFlow/Zone.mo
+++ b/Buildings/Controls/OBC/ASHRAE/G36_PR1/AHUs/MultiZone/VAV/SetPoints/OutdoorAirFlow/Zone.mo
@@ -622,7 +622,7 @@ Stanke, D., 2010. <i>Dynamic Reset for Multiple-Zone Systems.</i> ASHRAE Journal
 </html>", revisions="<html>
 <ul>
 <li>
-October 20, 2020, by jianjun Hu:<br/>
+October 20, 2020, by Jianjun Hu:<br/>
 Added vendor annotation to show the default value of the conditional removable connectors.<br/>
 This is for
 <a href=\"https://github.com/lbl-srg/modelica-buildings/issues/1854\">#1854</a>.

--- a/Buildings/Controls/OBC/ASHRAE/G36_PR1/AHUs/SingleZone/VAV/Controller.mo
+++ b/Buildings/Controls/OBC/ASHRAE/G36_PR1/AHUs/SingleZone/VAV/Controller.mo
@@ -981,7 +981,7 @@ Buildings.Controls.OBC.ASHRAE.G36_PR1.TerminalUnits.ModeAndSetPoints</a>.
 revisions="<html>
 <ul>
 <li>
-October 20, 2020, by jianjun Hu:<br/>
+October 20, 2020, by Jianjun Hu:<br/>
 Added vendor annotation to show the default value of the conditional removable connectors.<br/>
 This is for
 <a href=\"https://github.com/lbl-srg/modelica-buildings/issues/1854\">#1854</a>.

--- a/Buildings/Controls/OBC/ASHRAE/G36_PR1/AHUs/SingleZone/VAV/Controller.mo
+++ b/Buildings/Controls/OBC/ASHRAE/G36_PR1/AHUs/SingleZone/VAV/Controller.mo
@@ -397,26 +397,26 @@ block Controller
     final quantity = "ThermodynamicTemperature") if use_TMix
     "Measured mixed air temperature, used for freeze protection if use_TMix is true"
     annotation (Placement(transformation(extent={{-240,-70},{-200,-30}}),
-        iconTransformation(extent={{-240,-60},{-200,-20}})));
+        iconTransformation(extent={{-240,-60},{-200,-20}})), __cdl(default=293.15));
   Buildings.Controls.OBC.CDL.Interfaces.RealInput nOcc(final unit="1") if
        have_occSen "Number of occupants"
     annotation (Placement(transformation(extent={{-240,-100},{-200,-60}}),
-        iconTransformation(extent={{-240,-90},{-200,-50}})));
+        iconTransformation(extent={{-240,-90},{-200,-50}})), __cdl(default=0));
   Buildings.Controls.OBC.CDL.Interfaces.BooleanInput uWin if have_winSen
     "Window status, true if open, false if closed"
     annotation (Placement(transformation(extent={{-240,-130},{-200,-90}}),
-        iconTransformation(extent={{-240,-120},{-200,-80}})));
+        iconTransformation(extent={{-240,-120},{-200,-80}})), __cdl(default=false));
   Buildings.Controls.OBC.CDL.Interfaces.RealInput hOut(
     final unit="J/kg",
     final quantity="SpecificEnergy") if use_enthalpy "Outdoor air enthalpy"
     annotation (Placement(transformation(extent={{-240,-170},{-200,-130}}),
-        iconTransformation(extent={{-240,-150},{-200,-110}})));
+        iconTransformation(extent={{-240,-150},{-200,-110}})), __cdl(default=0));
   Buildings.Controls.OBC.CDL.Interfaces.RealInput hCut(
     final unit="J/kg",
     final quantity="SpecificEnergy") if use_enthalpy
     "Economizer enthalpy high limit cutoff. Fixed enthalpy or differential enthalpy"
     annotation (Placement(transformation(extent={{-240,-200},{-200,-160}}),
-        iconTransformation(extent={{-240,-190},{-200,-150}})));
+        iconTransformation(extent={{-240,-190},{-200,-150}})), __cdl(default=0));
   Buildings.Controls.OBC.CDL.Interfaces.RealInput TRet(
     final unit="K",
     displayUnit="degC",
@@ -424,12 +424,12 @@ block Controller
        use_fixed_plus_differential_drybulb
     "Used only for fixed plus differential dry bulb temperature high limit cutoff"
     annotation (Placement(transformation(extent={{-240,-230},{-200,-190}}),
-        iconTransformation(extent={{-240,-230},{-200,-190}})));
+        iconTransformation(extent={{-240,-230},{-200,-190}})), __cdl(default=293.15));
   Buildings.Controls.OBC.CDL.Interfaces.IntegerInput uFreProSta if
        use_G36FrePro
     "Freeze protection status, used if use_G36FrePro=true"
     annotation (Placement(transformation(extent={{-240,-260},{-200,-220}}),
-        iconTransformation(extent={{-240,-270},{-200,-230}})));
+        iconTransformation(extent={{-240,-270},{-200,-230}})), __cdl(default=0));
   Buildings.Controls.OBC.CDL.Interfaces.RealOutput TSupHeaEco(
     final unit="K",
     displayUnit="degC",
@@ -980,6 +980,12 @@ Buildings.Controls.OBC.ASHRAE.G36_PR1.TerminalUnits.ModeAndSetPoints</a>.
 </html>",
 revisions="<html>
 <ul>
+<li>
+October 20, 2020, by jianjun Hu:<br/>
+Added vendor annotation to show the default value of the conditional removable connectors.<br/>
+This is for
+<a href=\"https://github.com/lbl-srg/modelica-buildings/issues/1854\">#1854</a>.
+</li>
 <li>
 June 20, 2020, by Jianjun Hu:<br/>
 Updated the block of specifying operating mode and setpoints.<br/>

--- a/Buildings/Controls/OBC/ASHRAE/G36_PR1/AHUs/SingleZone/VAV/Economizers/Controller.mo
+++ b/Buildings/Controls/OBC/ASHRAE/G36_PR1/AHUs/SingleZone/VAV/Economizers/Controller.mo
@@ -164,7 +164,6 @@ block Controller "Single zone VAV AHU economizer control sequence"
     "Physically fixed minimum position of the return air damper"
     annotation(Dialog(tab="Commissioning", group="Physical damper position limits"));
 
-
   Buildings.Controls.OBC.CDL.Interfaces.RealOutput yHeaCoi
     "Heating coil control signal"
     annotation (Placement(transformation(extent={{140,92},{160,112}}),
@@ -210,8 +209,9 @@ block Controller "Single zone VAV AHU economizer control sequence"
     final quantity="SpecificEnergy") if use_enthalpy "Outdoor air enthalpy"
     annotation (Placement(transformation(extent={{-160,70},{-140,90}}),
       iconTransformation(extent={{-120,36},{-100,56}})), __cdl(default=0));
-  Buildings.Controls.OBC.CDL.Interfaces.RealInput hCut(final unit="J/kg",
-      final quantity="SpecificEnergy") if use_enthalpy
+  Buildings.Controls.OBC.CDL.Interfaces.RealInput hCut(
+    final unit="J/kg",
+    final quantity="SpecificEnergy") if use_enthalpy
     "Outdoor air enthalpy high limit cutoff. For differential enthalpy use return air enthalpy measurement"
     annotation (Placement(transformation(extent={{-160,50},{-140,70}}),
         iconTransformation(extent={{-120,20},{-100,40}})), __cdl(default=0));
@@ -481,7 +481,7 @@ for a description.
 </html>", revisions="<html>
 <ul>
 <li>
-October 20, 2020, by jianjun Hu:<br/>
+October 20, 2020, by Jianjun Hu:<br/>
 Added vendor annotation to show the default value of the conditional removable connectors.<br/>
 This is for
 <a href=\"https://github.com/lbl-srg/modelica-buildings/issues/1854\">#1854</a>.

--- a/Buildings/Controls/OBC/ASHRAE/G36_PR1/AHUs/SingleZone/VAV/Economizers/Controller.mo
+++ b/Buildings/Controls/OBC/ASHRAE/G36_PR1/AHUs/SingleZone/VAV/Economizers/Controller.mo
@@ -164,6 +164,11 @@ block Controller "Single zone VAV AHU economizer control sequence"
     "Physically fixed minimum position of the return air damper"
     annotation(Dialog(tab="Commissioning", group="Physical damper position limits"));
 
+
+  Buildings.Controls.OBC.CDL.Interfaces.RealOutput yHeaCoi
+    "Heating coil control signal"
+    annotation (Placement(transformation(extent={{140,92},{160,112}}),
+        iconTransformation(extent={{100,30},{120,50}})));
   Buildings.Controls.OBC.CDL.Interfaces.RealInput THeaSupSet(
     final unit="K",
     final displayUnit="degC",
@@ -199,25 +204,24 @@ block Controller "Single zone VAV AHU economizer control sequence"
        use_fixed_plus_differential_drybulb
     "Used only for fixed plus differential dry bulb temperature high limit cutoff"
     annotation (Placement(transformation(extent={{-160,90},{-140,110}}),
-        iconTransformation(extent={{-120,52},{-100,72}})));
+        iconTransformation(extent={{-120,52},{-100,72}})), __cdl(default=293.15));
   Buildings.Controls.OBC.CDL.Interfaces.RealInput hOut(
     final unit="J/kg",
     final quantity="SpecificEnergy") if use_enthalpy "Outdoor air enthalpy"
     annotation (Placement(transformation(extent={{-160,70},{-140,90}}),
-      iconTransformation(extent={{-120,36},{-100,56}})));
+      iconTransformation(extent={{-120,36},{-100,56}})), __cdl(default=0));
   Buildings.Controls.OBC.CDL.Interfaces.RealInput hCut(final unit="J/kg",
-      final quantity="SpecificEnergy") if
-                                        use_enthalpy
+      final quantity="SpecificEnergy") if use_enthalpy
     "Outdoor air enthalpy high limit cutoff. For differential enthalpy use return air enthalpy measurement"
     annotation (Placement(transformation(extent={{-160,50},{-140,70}}),
-        iconTransformation(extent={{-120,20},{-100,40}})));
+        iconTransformation(extent={{-120,20},{-100,40}})), __cdl(default=0));
   Buildings.Controls.OBC.CDL.Interfaces.RealInput TMix(
     final unit="K",
     final displayUnit="degC",
     final quantity = "ThermodynamicTemperature") if use_TMix
     "Measured mixed air temperature, used for freeze protection"
     annotation (Placement(transformation(extent={{-160,-50},{-140,-30}}),
-      iconTransformation(extent={{-120,-54},{-100,-34}})));
+      iconTransformation(extent={{-120,-54},{-100,-34}})), __cdl(default=293.15));
 
   Buildings.Controls.OBC.CDL.Interfaces.RealInput VOutMinSet_flow(
     final min=VOutMin_flow,
@@ -322,10 +326,6 @@ protected
     "Freeze protection status is 0. Used if G36 freeze protection is not implemented"
     annotation (Placement(transformation(extent={{-140,-150},{-120,-130}})));
 
-public
-  CDL.Interfaces.RealOutput yHeaCoi "Heating coil control signal"
-    annotation (Placement(transformation(extent={{140,92},{160,112}}),
-        iconTransformation(extent={{100,30},{120,50}})));
 equation
   connect(uSupFan, enaDis.uSupFan)
     annotation (Line(points={{-150,-60},{-100,-60},{-100,-34},{-21,-34}},
@@ -390,15 +390,13 @@ equation
   connect(freProTMix.yFreProInv, outDamMaxFre.u2)
     annotation (Line(points={{82,-7},{88,-7},{88,-56},{98,-56}}, color={0,0,127}));
   connect(freProSta.y, enaDis.uFreProSta)
-    annotation (Line(points={{-118,-140},{-40,-140},{-40,-30},{-21,-30}},
-                                                                        color={255,127,0}));
+    annotation (Line(points={{-118,-140},{-40,-140},{-40,-30},{-21,-30}}, color={255,127,0}));
   connect(freProSta.y, damLim.uFreProSta)
     annotation (Line(points={{-118,-140},{-114,-140},{-114,6},{-102,6}},
       color={255,127,0}));
   connect(uSupFan, mod.uSupFan)
     annotation (Line(points={{-150,-60},{-100,-60},{-100,-10},{18,-10},{18,1}},
       color={255,0,255}));
-
   connect(mod.yHeaCoi, yHeaCoi) annotation (Line(points={{41,14},{46,14},{46,
           102},{150,102}},
                       color={0,0,127}));
@@ -482,6 +480,12 @@ for a description.
 </ul>
 </html>", revisions="<html>
 <ul>
+<li>
+October 20, 2020, by jianjun Hu:<br/>
+Added vendor annotation to show the default value of the conditional removable connectors.<br/>
+This is for
+<a href=\"https://github.com/lbl-srg/modelica-buildings/issues/1854\">#1854</a>.
+</li>
 <li>
 July 30, 2019, by Kun Zhang:<br/>
 Added fixed plus differential dry bulb temperature high limit cut off.

--- a/Buildings/Controls/OBC/ASHRAE/G36_PR1/AHUs/SingleZone/VAV/Economizers/Subsequences/Enable.mo
+++ b/Buildings/Controls/OBC/ASHRAE/G36_PR1/AHUs/SingleZone/VAV/Economizers/Subsequences/Enable.mo
@@ -423,7 +423,7 @@ src=\"modelica://Buildings/Resources/Images/Controls/OBC/ASHRAE/G36_PR1/AHUs/Sin
 </html>", revisions="<html>
 <ul>
 <li>
-October 20, 2020, by jianjun Hu:<br/>
+October 20, 2020, by Jianjun Hu:<br/>
 Added vendor annotation to show the default value of the conditional removable connectors.<br/>
 This is for
 <a href=\"https://github.com/lbl-srg/modelica-buildings/issues/1854\">#1854</a>.

--- a/Buildings/Controls/OBC/ASHRAE/G36_PR1/AHUs/SingleZone/VAV/Economizers/Subsequences/Enable.mo
+++ b/Buildings/Controls/OBC/ASHRAE/G36_PR1/AHUs/SingleZone/VAV/Economizers/Subsequences/Enable.mo
@@ -45,7 +45,7 @@ block Enable
     final quantity="SpecificEnergy") if use_enthalpy
     "Outdoor air enthalpy"
     annotation (Placement(transformation(extent={{-220,160},{-180,200}}),
-      iconTransformation(extent={{-120,30},{-100,50}})));
+      iconTransformation(extent={{-120,30},{-100,50}})), __cdl(default=0));
   Buildings.Controls.OBC.CDL.Interfaces.RealInput TCut(
     final unit="K",
     final displayUnit="degC",
@@ -64,7 +64,7 @@ block Enable
       final quantity="SpecificEnergy") if use_enthalpy
     "OA enthalpy high limit cutoff. For differential enthalpy use return air enthalpy measurement"
     annotation (Placement(transformation(extent={{-220,130},{-180,170}}),
-        iconTransformation(extent={{-120,10},{-100,30}})));
+        iconTransformation(extent={{-120,10},{-100,30}})), __cdl(default=0));
   Buildings.Controls.OBC.CDL.Interfaces.RealInput uOutDamPosMin(
     final unit="1",
     final min=0,
@@ -422,6 +422,12 @@ src=\"modelica://Buildings/Resources/Images/Controls/OBC/ASHRAE/G36_PR1/AHUs/Sin
 </p>
 </html>", revisions="<html>
 <ul>
+<li>
+October 20, 2020, by jianjun Hu:<br/>
+Added vendor annotation to show the default value of the conditional removable connectors.<br/>
+This is for
+<a href=\"https://github.com/lbl-srg/modelica-buildings/issues/1854\">#1854</a>.
+</li>
 <li>
 July 30, 2019, by Kun Zhang:<br/>
 Added the option to allow fixed plus differential dry bulb temperature cutoff.

--- a/Buildings/Controls/OBC/ASHRAE/G36_PR1/AHUs/SingleZone/VAV/SetPoints/ModeAndSetPoints.mo
+++ b/Buildings/Controls/OBC/ASHRAE/G36_PR1/AHUs/SingleZone/VAV/SetPoints/ModeAndSetPoints.mo
@@ -151,15 +151,15 @@ block ModeAndSetPoints "Output zone setpoint with operation mode selection"
   Buildings.Controls.OBC.CDL.Interfaces.RealInput setAdj if cooAdj or sinAdj
     "Setpoint adjustment value"
     annotation (Placement(transformation(extent={{-200,-60},{-160,-20}}),
-      iconTransformation(extent={{-140,-40},{-100,0}})));
+      iconTransformation(extent={{-140,-40},{-100,0}})), __cdl(default=0));
   Buildings.Controls.OBC.CDL.Interfaces.RealInput heaSetAdj if heaAdj
     "Heating setpoint adjustment value"
     annotation (Placement(transformation(extent={{-200,-100},{-160,-60}}),
-      iconTransformation(extent={{-140,-60},{-100,-20}})));
+      iconTransformation(extent={{-140,-60},{-100,-20}})), __cdl(default=0));
   Buildings.Controls.OBC.CDL.Interfaces.BooleanInput uOccSen if have_occSen
     "Occupancy sensor (occupied=true, unoccupied=false)"
     annotation (Placement(transformation(extent={{-200,-140},{-160,-100}}),
-      iconTransformation(extent={{-140,-80},{-100,-40}})));
+      iconTransformation(extent={{-140,-80},{-100,-40}})), __cdl(default=false));
   Buildings.Controls.OBC.CDL.Interfaces.IntegerInput uCooDemLimLev
     "Cooling demand limit level"
     annotation (Placement(transformation(extent={{-200,-180},{-160,-140}}),
@@ -437,6 +437,12 @@ This version is for a single zone only to be used in the Single Zone VAV sequenc
 </p>
 </html>", revisions="<html>
 <ul>
+<li>
+October 20, 2020, by jianjun Hu:<br/>
+Added vendor annotation to show the default value of the conditional removable connectors.<br/>
+This is for
+<a href=\"https://github.com/lbl-srg/modelica-buildings/issues/1854\">#1854</a>.
+</li>
 <li>
 June 16, 2020, by Jianjun Hu:<br/>
 Moved from TerminalUnits.ModeAndSetPoints,

--- a/Buildings/Controls/OBC/ASHRAE/G36_PR1/AHUs/SingleZone/VAV/SetPoints/ModeAndSetPoints.mo
+++ b/Buildings/Controls/OBC/ASHRAE/G36_PR1/AHUs/SingleZone/VAV/SetPoints/ModeAndSetPoints.mo
@@ -438,7 +438,7 @@ This version is for a single zone only to be used in the Single Zone VAV sequenc
 </html>", revisions="<html>
 <ul>
 <li>
-October 20, 2020, by jianjun Hu:<br/>
+October 20, 2020, by Jianjun Hu:<br/>
 Added vendor annotation to show the default value of the conditional removable connectors.<br/>
 This is for
 <a href=\"https://github.com/lbl-srg/modelica-buildings/issues/1854\">#1854</a>.

--- a/Buildings/Controls/OBC/ASHRAE/G36_PR1/AHUs/SingleZone/VAV/SetPoints/OutsideAirFlow.mo
+++ b/Buildings/Controls/OBC/ASHRAE/G36_PR1/AHUs/SingleZone/VAV/SetPoints/OutsideAirFlow.mo
@@ -41,7 +41,7 @@ block OutsideAirFlow
   Buildings.Controls.OBC.CDL.Interfaces.RealInput nOcc(final unit="1") if
        have_occSen "Number of occupants"
     annotation (Placement(transformation(extent={{-240,140},{-200,180}}),
-        iconTransformation(extent={{-140,60},{-100,100}})));
+        iconTransformation(extent={{-140,60},{-100,100}})), __cdl(default=0));
   Buildings.Controls.OBC.CDL.Interfaces.RealInput TZon(
     final unit="K",
     final displayUnit="degC",
@@ -298,6 +298,12 @@ For the single zone system, the required minimum outdoor airflow setpoint
 </p>
 </html>", revisions="<html>
 <ul>
+<li>
+October 20, 2020, by jianjun Hu:<br/>
+Added vendor annotation to show the default value of the conditional removable connectors.<br/>
+This is for
+<a href=\"https://github.com/lbl-srg/modelica-buildings/issues/1854\">#1854</a>.
+</li>
 <li>
 November 2, 2018, by Michael Wetter:<br/>
 Made the input connector <code>nOcc</code> conditionally removable, as it is

--- a/Buildings/Controls/OBC/ASHRAE/G36_PR1/AHUs/SingleZone/VAV/SetPoints/OutsideAirFlow.mo
+++ b/Buildings/Controls/OBC/ASHRAE/G36_PR1/AHUs/SingleZone/VAV/SetPoints/OutsideAirFlow.mo
@@ -299,7 +299,7 @@ For the single zone system, the required minimum outdoor airflow setpoint
 </html>", revisions="<html>
 <ul>
 <li>
-October 20, 2020, by jianjun Hu:<br/>
+October 20, 2020, by Jianjun Hu:<br/>
 Added vendor annotation to show the default value of the conditional removable connectors.<br/>
 This is for
 <a href=\"https://github.com/lbl-srg/modelica-buildings/issues/1854\">#1854</a>.

--- a/Buildings/Controls/OBC/ASHRAE/G36_PR1/Generic/SetPoints/ZoneStatus.mo
+++ b/Buildings/Controls/OBC/ASHRAE/G36_PR1/Generic/SetPoints/ZoneStatus.mo
@@ -471,7 +471,7 @@ setup mode.
 </html>",revisions="<html>
 <ul>
 <li>
-October 20, 2020, by jianjun Hu:<br/>
+October 20, 2020, by Jianjun Hu:<br/>
 Added vendor annotation to show the default value of the conditional removable connectors.<br/>
 This is for
 <a href=\"https://github.com/lbl-srg/modelica-buildings/issues/1854\">#1854</a>.

--- a/Buildings/Controls/OBC/ASHRAE/G36_PR1/Generic/SetPoints/ZoneStatus.mo
+++ b/Buildings/Controls/OBC/ASHRAE/G36_PR1/Generic/SetPoints/ZoneStatus.mo
@@ -51,7 +51,7 @@ block ZoneStatus "Block that outputs zone temperature status"
   Buildings.Controls.OBC.CDL.Interfaces.BooleanInput uWin if have_winSen
     "Window status: true=open, false=close"
     annotation (Placement(transformation(extent={{-200,130},{-160,170}}),
-      iconTransformation(extent={{-140,-60},{-100,-20}})));
+      iconTransformation(extent={{-140,-60},{-100,-20}})), __cdl(default=false));
   Buildings.Controls.OBC.CDL.Interfaces.RealInput TZon(
     final unit="K",
     displayUnit="degC",
@@ -470,6 +470,12 @@ setup mode.
 </ul>
 </html>",revisions="<html>
 <ul>
+<li>
+October 20, 2020, by jianjun Hu:<br/>
+Added vendor annotation to show the default value of the conditional removable connectors.<br/>
+This is for
+<a href=\"https://github.com/lbl-srg/modelica-buildings/issues/1854\">#1854</a>.
+</li>
 <li>
 June 10 15, 2020, by Jianjun Hu:<br/>
 Simplified implementation.

--- a/Buildings/Controls/OBC/ASHRAE/G36_PR1/TerminalUnits/Controller.mo
+++ b/Buildings/Controls/OBC/ASHRAE/G36_PR1/TerminalUnits/Controller.mo
@@ -610,7 +610,7 @@ Buildings.Controls.OBC.ASHRAE.G36_PR1.TerminalUnits.Reheat.SystemRequests</a>.
 </html>", revisions="<html>
 <ul>
 <li>
-October 20, 2020, by jianjun Hu:<br/>
+October 20, 2020, by Jianjun Hu:<br/>
 Added vendor annotation to show the default value of the conditional removable connectors.<br/>
 This is for
 <a href=\"https://github.com/lbl-srg/modelica-buildings/issues/1854\">#1854</a>.

--- a/Buildings/Controls/OBC/ASHRAE/G36_PR1/TerminalUnits/Controller.mo
+++ b/Buildings/Controls/OBC/ASHRAE/G36_PR1/TerminalUnits/Controller.mo
@@ -256,15 +256,15 @@ block Controller "Controller for room VAV box"
   Buildings.Controls.OBC.CDL.Interfaces.RealInput ppmCO2 if have_CO2Sen
     "Measured CO2 concentration"
     annotation (Placement(transformation(extent={{-180,60},{-140,100}}),
-        iconTransformation(extent={{-140,40},{-100,80}})));
+        iconTransformation(extent={{-140,40},{-100,80}})), __cdl(default=0));
   Buildings.Controls.OBC.CDL.Interfaces.RealInput nOcc if have_occSen
     "Number of occupants"
     annotation (Placement(transformation(extent={{-180,30},{-140,70}}),
-        iconTransformation(extent={{-140,20},{-100,60}})));
+        iconTransformation(extent={{-140,20},{-100,60}})), __cdl(default=0));
   Buildings.Controls.OBC.CDL.Interfaces.BooleanInput uWin if have_winSen
     "Window status, true if open, false if closed"
     annotation (Placement(transformation(extent={{-180,0},{-140,40}}),
-        iconTransformation(extent={{-140,0},{-100,40}})));
+        iconTransformation(extent={{-140,0},{-100,40}})), __cdl(default=false));
   Buildings.Controls.OBC.CDL.Interfaces.IntegerInput uOpeMod
     "Zone operation mode"
     annotation (Placement(transformation(extent={{-180,-190},{-140,-150}}),
@@ -609,6 +609,12 @@ Buildings.Controls.OBC.ASHRAE.G36_PR1.TerminalUnits.Reheat.SystemRequests</a>.
 </p>
 </html>", revisions="<html>
 <ul>
+<li>
+October 20, 2020, by jianjun Hu:<br/>
+Added vendor annotation to show the default value of the conditional removable connectors.<br/>
+This is for
+<a href=\"https://github.com/lbl-srg/modelica-buildings/issues/1854\">#1854</a>.
+</li>
 <li>
 October 9, 2020, by Jianjun Hu:<br/>
 Changed the default heating maximum airflow setpoint to 30% of the zone nominal airflow.<br/>

--- a/Buildings/Controls/OBC/ASHRAE/G36_PR1/TerminalUnits/Reheat/DamperValves.mo
+++ b/Buildings/Controls/OBC/ASHRAE/G36_PR1/TerminalUnits/Reheat/DamperValves.mo
@@ -129,7 +129,7 @@ block DamperValves
     final quantity="VolumeFlowRate") if not have_pressureIndependentDamper
     "Measured discharge airflow rate airflow rate"
     annotation (Placement(transformation(extent={{-360,320},{-320,360}}),
-      iconTransformation(extent={{-20,-20},{20,20}},rotation=90,origin={40,-120})));
+      iconTransformation(extent={{-20,-20},{20,20}},rotation=90,origin={40,-120})), __cdl(default=0));
   Buildings.Controls.OBC.CDL.Interfaces.RealInput TSup(
     final unit="K",
     final displayUnit="degC",
@@ -877,6 +877,12 @@ src=\"modelica://Buildings/Resources/Images/Controls/OBC/ASHRAE/G36_PR1/Terminal
 </p>
 </html>", revisions="<html>
 <ul>
+<li>
+October 20, 2020, by jianjun Hu:<br/>
+Added vendor annotation to show the default value of the conditional removable connectors.<br/>
+This is for
+<a href=\"https://github.com/lbl-srg/modelica-buildings/issues/1854\">#1854</a>.
+</li>
 <li>
 April 18, 2020, by Jianjun Hu:<br/>
 Added option to check if the VAV damper is pressure independent.<br/>

--- a/Buildings/Controls/OBC/ASHRAE/G36_PR1/TerminalUnits/Reheat/DamperValves.mo
+++ b/Buildings/Controls/OBC/ASHRAE/G36_PR1/TerminalUnits/Reheat/DamperValves.mo
@@ -878,7 +878,7 @@ src=\"modelica://Buildings/Resources/Images/Controls/OBC/ASHRAE/G36_PR1/Terminal
 </html>", revisions="<html>
 <ul>
 <li>
-October 20, 2020, by jianjun Hu:<br/>
+October 20, 2020, by Jianjun Hu:<br/>
 Added vendor annotation to show the default value of the conditional removable connectors.<br/>
 This is for
 <a href=\"https://github.com/lbl-srg/modelica-buildings/issues/1854\">#1854</a>.

--- a/Buildings/Controls/OBC/ASHRAE/G36_PR1/TerminalUnits/Reheat/SetPoints/ActiveAirFlow.mo
+++ b/Buildings/Controls/OBC/ASHRAE/G36_PR1/TerminalUnits/Reheat/SetPoints/ActiveAirFlow.mo
@@ -792,7 +792,7 @@ not in occupied mode.
 </html>", revisions="<html>
 <ul>
 <li>
-October 20, 2020, by jianjun Hu:<br/>
+October 20, 2020, by Jianjun Hu:<br/>
 Added vendor annotation to show the default value of the conditional removable connectors.<br/>
 This is for
 <a href=\"https://github.com/lbl-srg/modelica-buildings/issues/1854\">#1854</a>.

--- a/Buildings/Controls/OBC/ASHRAE/G36_PR1/TerminalUnits/Reheat/SetPoints/ActiveAirFlow.mo
+++ b/Buildings/Controls/OBC/ASHRAE/G36_PR1/TerminalUnits/Reheat/SetPoints/ActiveAirFlow.mo
@@ -50,15 +50,15 @@ block ActiveAirFlow
   Buildings.Controls.OBC.CDL.Interfaces.RealInput nOcc(final unit="1") if have_occSen
     "Number of occupants"
     annotation (Placement(transformation(extent={{-320,-300},{-280,-260}}),
-        iconTransformation(extent={{-140,-60},{-100,-20}})));
+        iconTransformation(extent={{-140,-60},{-100,-20}})), __cdl(default=0));
   Buildings.Controls.OBC.CDL.Interfaces.RealInput ppmCO2 if have_CO2Sen
     "Detected CO2 conventration"
     annotation (Placement(transformation(extent={{-320,-200},{-280,-160}}),
-        iconTransformation(extent={{-140,20},{-100,60}})));
+        iconTransformation(extent={{-140,20},{-100,60}})), __cdl(default=0));
   Buildings.Controls.OBC.CDL.Interfaces.BooleanInput uWin if have_winSen
     "Window status, true if open, false if closed"
     annotation (Placement(transformation(extent={{-320,-520},{-280,-480}}),
-        iconTransformation(extent={{-140,-100},{-100,-60}})));
+        iconTransformation(extent={{-140,-100},{-100,-60}})), __cdl(default=false));
   Buildings.Controls.OBC.CDL.Interfaces.IntegerInput uOpeMod
     "Zone operation mode"
     annotation (Placement(transformation(extent={{-320,-130},{-280,-90}}),
@@ -791,6 +791,12 @@ not in occupied mode.
 <br/>
 </html>", revisions="<html>
 <ul>
+<li>
+October 20, 2020, by jianjun Hu:<br/>
+Added vendor annotation to show the default value of the conditional removable connectors.<br/>
+This is for
+<a href=\"https://github.com/lbl-srg/modelica-buildings/issues/1854\">#1854</a>.
+</li>
 <li>
 March 11, 2020, by Jianjun Hu:<br/>
 Replaced multisum block with add blocks.<br/>

--- a/Buildings/Controls/OBC/ASHRAE/G36_PR1/TerminalUnits/Reheat/SystemRequests.mo
+++ b/Buildings/Controls/OBC/ASHRAE/G36_PR1/TerminalUnits/Reheat/SystemRequests.mo
@@ -926,7 +926,7 @@ sampled, as sampling were to change the dynamic response.
 </html>", revisions="<html>
 <ul>
 <li>
-October 20, 2020, by jianjun Hu:<br/>
+October 20, 2020, by Jianjun Hu:<br/>
 Added vendor annotation to show the default value of the conditional removable connectors.<br/>
 This is for
 <a href=\"https://github.com/lbl-srg/modelica-buildings/issues/1854\">#1854</a>.

--- a/Buildings/Controls/OBC/ASHRAE/G36_PR1/TerminalUnits/Reheat/SystemRequests.mo
+++ b/Buildings/Controls/OBC/ASHRAE/G36_PR1/TerminalUnits/Reheat/SystemRequests.mo
@@ -98,20 +98,20 @@ block SystemRequests
     final quantity="ThermodynamicTemperature") if have_heaWatCoi
     "Discharge airflow setpoint temperature for heating"
     annotation (Placement(transformation(extent={{-220,-230},{-180,-190}}),
-        iconTransformation(extent={{-140,-60},{-100,-20}})));
+        iconTransformation(extent={{-140,-60},{-100,-20}})), __cdl(default=293.15));
   Buildings.Controls.OBC.CDL.Interfaces.RealInput TDis(
     final unit="K",
     final displayUnit="degC",
     final quantity="ThermodynamicTemperature") if have_heaWatCoi
     "Measured discharge airflow temperature"
     annotation (Placement(transformation(extent={{-220,-310},{-180,-270}}),
-        iconTransformation(extent={{-140,-80},{-100,-40}})));
+        iconTransformation(extent={{-140,-80},{-100,-40}})), __cdl(default=293.15));
   Buildings.Controls.OBC.CDL.Interfaces.RealInput uHeaVal(
     final min=0,
     final max=1,
     final unit="1") if have_heaWatCoi "Heating valve position"
     annotation (Placement(transformation(extent={{-220,-370},{-180,-330}}),
-        iconTransformation(extent={{-140,-100},{-100,-60}})));
+        iconTransformation(extent={{-140,-100},{-100,-60}})), __cdl(default=0));
   Buildings.Controls.OBC.CDL.Interfaces.IntegerOutput yZonPreResReq
     "Zone static pressure reset requests"
     annotation (Placement(transformation(extent={{180,-60},{220,-20}}),
@@ -123,11 +123,11 @@ block SystemRequests
   Buildings.Controls.OBC.CDL.Interfaces.IntegerOutput yHeaValResReq if have_heaWatCoi
     "Hot water reset requests"
     annotation (Placement(transformation(extent={{180,-260},{220,-220}}),
-        iconTransformation(extent={{100,-60},{140,-20}})));
+        iconTransformation(extent={{100,-60},{140,-20}})), __cdl(default=0));
   Buildings.Controls.OBC.CDL.Interfaces.IntegerOutput yHeaPlaReq if (have_heaWatCoi and have_heaPla)
     "Heating plant request"
     annotation (Placement(transformation(extent={{180,-450},{220,-410}}),
-        iconTransformation(extent={{100,-110},{140,-70}})));
+        iconTransformation(extent={{100,-110},{140,-70}})), __cdl(default=0));
   Buildings.Controls.OBC.CDL.Continuous.Hysteresis hys(
     final uLow=errTZonCoo_1 - 0.1,
     final uHigh=errTZonCoo_1 + 0.1)
@@ -925,6 +925,12 @@ sampled, as sampling were to change the dynamic response.
 </p>
 </html>", revisions="<html>
 <ul>
+<li>
+October 20, 2020, by jianjun Hu:<br/>
+Added vendor annotation to show the default value of the conditional removable connectors.<br/>
+This is for
+<a href=\"https://github.com/lbl-srg/modelica-buildings/issues/1854\">#1854</a>.
+</li>
 <li>
 September 13, 2017, by Jianjun Hu:<br/>
 First implementation.

--- a/Buildings/Controls/OBC/ASHRAE/G36_PR1/TerminalUnits/SetPoints/ZoneTemperatures.mo
+++ b/Buildings/Controls/OBC/ASHRAE/G36_PR1/TerminalUnits/SetPoints/ZoneTemperatures.mo
@@ -111,14 +111,14 @@ block ZoneTemperatures
     final quantity="ThermodynamicTemperature") if (cooAdj or sinAdj)
     "Setpoint adjustment value"
     annotation (Placement(transformation(extent={{-460,330},{-420,370}}),
-        iconTransformation(extent={{-140,-30},{-100,10}})));
+        iconTransformation(extent={{-140,-30},{-100,10}})), __cdl(default=0));
   Buildings.Controls.OBC.CDL.Interfaces.RealInput heaSetAdj(
     final unit="K",
     displayUnit="degC",
     final quantity="ThermodynamicTemperature") if heaAdj
     "Heating setpoint adjustment value"
     annotation (Placement(transformation(extent={{-460,250},{-420,290}}),
-        iconTransformation(extent={{-140,-50},{-100,-10}})));
+        iconTransformation(extent={{-140,-50},{-100,-10}})), __cdl(default=0));
   Buildings.Controls.OBC.CDL.Interfaces.IntegerInput uOpeMod
     "AHU operation mode status signal"
     annotation (Placement(transformation(extent={{-460,610},{-420,650}}),
@@ -135,11 +135,11 @@ block ZoneTemperatures
     "Occupancy sensor (occupied=true, unoccupied=false)"
     annotation (Placement(transformation(extent={{-20,-20},{20,20}},
       origin={-440,-270}),iconTransformation(
-      extent={{-20,-20},{20,20}},origin={-120,-110})));
+      extent={{-20,-20},{20,20}},origin={-120,-110})), __cdl(default=false));
   Buildings.Controls.OBC.CDL.Interfaces.BooleanInput uWinSta if have_winSen
     "Window status (open=true, close=false)"
     annotation (Placement(transformation(extent={{-460,-430},{-420,-390}}),
-      iconTransformation(extent={{-20,-20},{20,20}},origin={-120,-130})));
+      iconTransformation(extent={{-20,-20},{20,20}},origin={-120,-130})), __cdl(default=false));
   Buildings.Controls.OBC.CDL.Interfaces.RealOutput TZonCooSet(
     final unit="K",
     displayUnit="degC",
@@ -1390,9 +1390,14 @@ shall prevail in order from highest to lowest priority.</p>
 <li>Demand limit (a. Occupancy sensors; b. Local setpoint adjustment)</li>
 <li>Scheduled setpoints based on zone group mode</li>
 </ul>
-
 </html>", revisions="<html>
 <ul>
+<li>
+October 20, 2020, by jianjun Hu:<br/>
+Added vendor annotation to show the default value of the conditional removable connectors.<br/>
+This is for
+<a href=\"https://github.com/lbl-srg/modelica-buildings/issues/1854\">#1854</a>.
+</li>
 <li>
 October 11, 2017, by Michael Wetter:<br/>
 Removed wrong conditional on <code>yAla</code>.

--- a/Buildings/Controls/OBC/ASHRAE/G36_PR1/TerminalUnits/SetPoints/ZoneTemperatures.mo
+++ b/Buildings/Controls/OBC/ASHRAE/G36_PR1/TerminalUnits/SetPoints/ZoneTemperatures.mo
@@ -1393,7 +1393,7 @@ shall prevail in order from highest to lowest priority.</p>
 </html>", revisions="<html>
 <ul>
 <li>
-October 20, 2020, by jianjun Hu:<br/>
+October 20, 2020, by Jianjun Hu:<br/>
 Added vendor annotation to show the default value of the conditional removable connectors.<br/>
 This is for
 <a href=\"https://github.com/lbl-srg/modelica-buildings/issues/1854\">#1854</a>.


### PR DESCRIPTION
This closes #1854. 

- [x] added default values to conditional removable connectors as following:
- For RealInput, the default values are:
  - If `unit=K`, the default is 293.15 K.
  - If `quantity="Pressure"`, the default is 101325 Pa.
  - If `quantity="PressureDifference"`, the default is 0 Pa.
  - For all other units, the default value is 0.
- For `IntegerInput`, the default value is `0`.
- For `BooleanInput`, the default value is `false`.
- For `DayTypeInput`, the default value is `WorkingDay`.