### PR TITLE
Fixed broken hyperlinks

### DIFF
--- a/Buildings/Controls/OBC/ASHRAE/G36_PR1/AHUs/SingleZone/VAV/Controller.mo
+++ b/Buildings/Controls/OBC/ASHRAE/G36_PR1/AHUs/SingleZone/VAV/Controller.mo
@@ -653,7 +653,7 @@ equation
   connect(intEqu.y, switch.u) annotation (Line(points={{-78,-230},{-72,-230}}, color={255,0,255}));
   connect(outAirSetPoi.uWin, uWin) annotation (Line(points={{38,34},{8,34},{8,-110},
           {-220,-110}},color={255,0,255}));
-  connect(TZon, cooPI.u_m) annotation (Line(points={{-220,130},{-30,130},{-30,148}},
+  connect(TZon, cooPI.u_m) annotation (Line(points={{-220,130},{-40,130},{-40,148}},
           color={0,0,127}));
   connect(nOcc, outAirSetPoi.nOcc) annotation (Line(points={{-220,-80},{-60,-80},
           {-60,38},{38,38}}, color={0,0,127}));
@@ -687,14 +687,14 @@ equation
                                   color={0,0,127}));
   connect(heaPI.y, zonSta.uHea) annotation (Line(points={{-58,220},{0,220},{0,144},
           {38,144}}, color={0,0,127}));
-  connect(cooPI.y, setPoiVAV.uCoo) annotation (Line(points={{-18,160},{20,160},{
+  connect(cooPI.y, setPoiVAV.uCoo) annotation (Line(points={{-28,160},{20,160},{
           20,195},{38,195}}, color={0,0,127}));
-  connect(cooPI.y, zonSta.uCoo) annotation (Line(points={{-18,160},{20,160},{20,
+  connect(cooPI.y, zonSta.uCoo) annotation (Line(points={{-28,160},{20,160},{20,
           136},{38,136}}, color={0,0,127}));
   connect(switch.y, heaPI.trigger) annotation (Line(points={{-48,-230},{-36,-230},
           {-36,84},{-76,84},{-76,208}}, color={255,0,255}));
-  connect(switch.y, cooPI.trigger) annotation (Line(points={{-48,-230},{-36,-230},
-          {-36,148}}, color={255,0,255}));
+  connect(switch.y, cooPI.trigger) annotation (Line(points={{-48,-230},{-46,-230},
+          {-46,148}}, color={255,0,255}));
   connect(TZon, heaPI.u_m) annotation (Line(points={{-220,130},{-70,130},{-70,208}},
           color={0,0,127}));
   connect(setPoiVAV.TSupCoo, cooCoi.TSupCoo) annotation (Line(points={{62,190},{
@@ -712,7 +712,7 @@ equation
   connect(modSetPoi.TZonCooSet, ave.u1) annotation (Line(points={{-118,160},{-50,
           160},{-50,206},{-42,206}}, color={0,0,127}));
   connect(modSetPoi.TZonCooSet, cooPI.u_s) annotation (Line(points={{-118,160},{
-          -42,160}}, color={0,0,127}));
+          -52,160}}, color={0,0,127}));
   connect(modSetPoi.TZonCooSet, TZonCooSet) annotation (Line(points={{-118,160},
           {-50,160},{-50,60},{220,60}}, color={0,0,127}));
   connect(TZon, modSetPoi.TZon) annotation (Line(points={{-220,130},{-168,130},{
@@ -974,8 +974,8 @@ Buildings.Controls.OBC.ASHRAE.G36_PR1.AHUs.SingleZone.VAV.SetPoints.OutsideAirFl
 <h4>Zone air heating and cooling setpoints</h4>
 <p>
 Zone air heating and cooling setpoints as well as system operation modes are detailed at
-<a href=\"modelica://Buildings.Controls.OBC.ASHRAE.G36_PR1.TerminalUnits.ModeAndSetPoints\">
-Buildings.Controls.OBC.ASHRAE.G36_PR1.TerminalUnits.ModeAndSetPoints</a>.
+<a href=\"modelica://Buildings.Controls.OBC.ASHRAE.G36_PR1.AHUs.SingleZone.VAV.SetPoints.ModeAndSetPoints\">
+Buildings.Controls.OBC.ASHRAE.G36_PR1.AHUs.SingleZone.VAV.SetPoints.ModeAndSetPoints</a>.
 </p>
 </html>",
 revisions="<html>

--- a/Buildings/Controls/OBC/ASHRAE/G36_PR1/AHUs/SingleZone/VAV/Controller.mo
+++ b/Buildings/Controls/OBC/ASHRAE/G36_PR1/AHUs/SingleZone/VAV/Controller.mo
@@ -653,7 +653,7 @@ equation
   connect(intEqu.y, switch.u) annotation (Line(points={{-78,-230},{-72,-230}}, color={255,0,255}));
   connect(outAirSetPoi.uWin, uWin) annotation (Line(points={{38,34},{8,34},{8,-110},
           {-220,-110}},color={255,0,255}));
-  connect(TZon, cooPI.u_m) annotation (Line(points={{-220,130},{-40,130},{-40,148}},
+  connect(TZon, cooPI.u_m) annotation (Line(points={{-220,130},{-30,130},{-30,148}},
           color={0,0,127}));
   connect(nOcc, outAirSetPoi.nOcc) annotation (Line(points={{-220,-80},{-60,-80},
           {-60,38},{38,38}}, color={0,0,127}));
@@ -687,14 +687,14 @@ equation
                                   color={0,0,127}));
   connect(heaPI.y, zonSta.uHea) annotation (Line(points={{-58,220},{0,220},{0,144},
           {38,144}}, color={0,0,127}));
-  connect(cooPI.y, setPoiVAV.uCoo) annotation (Line(points={{-28,160},{20,160},{
+  connect(cooPI.y, setPoiVAV.uCoo) annotation (Line(points={{-18,160},{20,160},{
           20,195},{38,195}}, color={0,0,127}));
-  connect(cooPI.y, zonSta.uCoo) annotation (Line(points={{-28,160},{20,160},{20,
+  connect(cooPI.y, zonSta.uCoo) annotation (Line(points={{-18,160},{20,160},{20,
           136},{38,136}}, color={0,0,127}));
   connect(switch.y, heaPI.trigger) annotation (Line(points={{-48,-230},{-36,-230},
           {-36,84},{-76,84},{-76,208}}, color={255,0,255}));
-  connect(switch.y, cooPI.trigger) annotation (Line(points={{-48,-230},{-46,-230},
-          {-46,148}}, color={255,0,255}));
+  connect(switch.y, cooPI.trigger) annotation (Line(points={{-48,-230},{-36,-230},
+          {-36,148}}, color={255,0,255}));
   connect(TZon, heaPI.u_m) annotation (Line(points={{-220,130},{-70,130},{-70,208}},
           color={0,0,127}));
   connect(setPoiVAV.TSupCoo, cooCoi.TSupCoo) annotation (Line(points={{62,190},{
@@ -712,7 +712,7 @@ equation
   connect(modSetPoi.TZonCooSet, ave.u1) annotation (Line(points={{-118,160},{-50,
           160},{-50,206},{-42,206}}, color={0,0,127}));
   connect(modSetPoi.TZonCooSet, cooPI.u_s) annotation (Line(points={{-118,160},{
-          -52,160}}, color={0,0,127}));
+          -42,160}}, color={0,0,127}));
   connect(modSetPoi.TZonCooSet, TZonCooSet) annotation (Line(points={{-118,160},
           {-50,160},{-50,60},{220,60}}, color={0,0,127}));
   connect(TZon, modSetPoi.TZon) annotation (Line(points={{-220,130},{-168,130},{

--- a/Buildings/package.mo
+++ b/Buildings/package.mo
@@ -8364,9 +8364,6 @@ on the Buildings library.
 </p>
 <ul>
 <li>
-<a href=\"modelica://Buildings.UsersGuide.ReleaseNotes.Version_7_0_1\">Version 7.0.1</a>
-</li>
-<li>
 <a href=\"modelica://Buildings.UsersGuide.ReleaseNotes.Version_7_0_0\">Version 7.0.0</a> (May 28, 2020)
 </li>
 <li>

--- a/Buildings/package.mo
+++ b/Buildings/package.mo
@@ -843,8 +843,7 @@ xxx
     <tr><td valign=\"top\">Buildings.Controls.OBC.ASHRAE.G36_PR1.AHUs.SingleZone.VAV.Controller
         </td>
         <td valign=\"top\">Replaced the mode and setpoint calculation block with
-                           <a href=\"modelica://Buildings.Controls.OBC.ASHRAE.G36_PR1.TerminalUnits.ModeAndSetPoints\">
-                           Buildings.Controls.OBC.ASHRAE.G36_PR1.TerminalUnits.ModeAndSetPoints</a>.<br/>
+                           <code>Buildings.Controls.OBC.ASHRAE.G36_PR1.TerminalUnits.ModeAndSetPoints</code>.<br/>
                            This is for <a href=\"https://github.com/lbl-srg/modelica-buildings/issues/1709\">#1709</a>
         </td>
     </tr>
@@ -1089,13 +1088,11 @@ xxx
         <td valign=\"top\">Reimplemented to add new block for specifying the minimum outdoor airfow setpoint.
                            The new block avoids vector-valued calculations.<br/>
                            The reimplemented controller needs to work with
-                           <a href=\"modelica://Buildings.Controls.OBC.ASHRAE.G36_PR1.AHUs.MultiZone.VAV.SetPoints.OutdoorAirFlow.Zone\">
-                           Buildings.Controls.OBC.ASHRAE.G36_PR1.AHUs.MultiZone.VAV.SetPoints.OutdoorAirFlow.Zone</a> and
-                           <a href=\"modelica://Buildings.Controls.OBC.ASHRAE.G36_PR1.AHUs.MultiZone.VAV.SetPoints.OutdoorAirFlow.SumZone\">
-                           Buildings.Controls.OBC.ASHRAE.G36_PR1.AHUs.MultiZone.VAV.SetPoints.OutdoorAirFlow.SumZone</a>,
+                           <code>Buildings.Controls.OBC.ASHRAE.G36_PR1.AHUs.MultiZone.VAV.SetPoints.OutdoorAirFlow.Zone</code> and
+                           <code>Buildings.Controls.OBC.ASHRAE.G36_PR1.AHUs.MultiZone.VAV.SetPoints.OutdoorAirFlow.SumZone</code>,
                            to calculate the zone level minimum outdoor airflow setpoints and then find the sum, the minimum and
                            the maximum of these setpoints. See
-                           <a href=\"modelica://Buildings.Examples.VAVReheat.Guideline36\">Buildings.Examples.VAVReheat.Guideline36</a>.
+                           <code>Buildings.Examples.VAVReheat.Guideline36</code>.
                            <br/>
                            This is for <a href=\"https://github.com/lbl-srg/modelica-buildings/issues/1829\">#1829</a>.
         </td>
@@ -1109,8 +1106,7 @@ xxx
     <tr><td valign=\"top\">Buildings.Controls.OBC.ASHRAE.G36_PR1.AHUs.SingleZone.VAV.ModeAndSetPoints
         </td>
         <td valign=\"top\">Removed from the library as it can be replaced by
-                           <a href=\"modelica://Buildings.Controls.OBC.ASHRAE.G36_PR1.TerminalUnits.ModeAndSetPoints\">
-                           Buildings.Controls.OBC.ASHRAE.G36_PR1.TerminalUnits.ModeAndSetPoints</a>.<br/>
+                           <code>Buildings.Controls.OBC.ASHRAE.G36_PR1.TerminalUnits.ModeAndSetPoints</code>.<br/>
                            This is for <a href=\"https://github.com/lbl-srg/modelica-buildings/issues/1709\">#1709</a>
         </td>
     </tr>
@@ -1334,10 +1330,8 @@ xxx
                            Buildings.Fluid.Sources.MassFlowSource_h
         </td>
         <td valign=\"top\">Refactored handling of mass fractions which was needed to handle media such as
-                           <a href=\"modelica://Modelica.Media.IdealGases.MixtureGases.FlueGasSixComponents\">
-                           Modelica.Media.IdealGases.MixtureGases.FlueGasSixComponents</a> and
-                           <a href=\"modelica://Modelica.Media.IdealGases.MixtureGases.SimpleNaturalGas\">
-                           Modelica.Media.IdealGases.MixtureGases.SimpleNaturalGas</a>.<br/>
+                           <code>Modelica.Media.IdealGases.MixtureGases.FlueGasSixComponents</code> and
+                           <code>Modelica.Media.IdealGases.MixtureGases.SimpleNaturalGas</code>.<br/>
                            Prior to this change, use of these media led to a translation error.<br/>
                            This is for
                            <a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1205\">IBPSA, #1205</a>.

--- a/Buildings/package.mo
+++ b/Buildings/package.mo
@@ -2908,8 +2908,7 @@ This closes <a href=\"https://github.com/lbl-srg/modelica-buildings/issues/565\"
                           from the TMY3 weather data file. The call to
                           <code>Buildings.BoundaryConditions.WeatherData.BaseClasses.getAbsolutePath</code>
                           has been removed as it calls the function
-                          <a href=\"modelica://Modelica.Utilities.Files.loadResource\">
-                          Modelica.Utilities.Files.loadResource</a>, whose return value needs
+                          <code>Modelica.Utilities.Files.loadResource</code>, whose return value needs
                           to be known at compilation time to store the weather data in the FMU.
                           This is not supported by JModelica.
                           Most models should still work as this call has been added at a higher level
@@ -2927,8 +2926,7 @@ This closes <a href=\"https://github.com/lbl-srg/modelica-buildings/issues/565\"
        <td valign=\"top\">Set <code>zer(final k=0)</code> and made
                           <code>swi</code>, <code>zer</code> and
                           <code>zer1</code> protected, as they are for
-                          <a href=\"modelica://Buildings.Controls.Continuous.PIDHysteresis\">
-                          Buildings.Controls.Continuous.PIDHysteresis</a>.
+                          <code>Buildings.Controls.Continuous.PIDHysteresis</code>.
                           Only models that access these instances, which typically is not the case,
                           are affected by this change.
        </td>
@@ -3184,8 +3182,7 @@ This closes <a href=\"https://github.com/lbl-srg/modelica-buildings/issues/565\"
     <tr><td valign=\"top\">Buildings.HeatTransfer.Conduction.BaseClasses.PartialConstruction
        </td>
        <td valign=\"top\">Removed parameter <code>A</code> as it is already declared in
-                          <a href=\"modelica://Buildings.HeatTransfer.Conduction.BaseClasses.PartialConductor\">
-                          Buildings.HeatTransfer.Conduction.BaseClasses.PartialConductor</a>
+                          <code>Buildings.HeatTransfer.Conduction.BaseClasses.PartialConductor</code>
                           which is often used with this class.
        </td>
     </tr>
@@ -3963,8 +3960,7 @@ This closes <a href=\"https://github.com/lbl-srg/modelica-buildings/issues/565\"
    <tr><td valign=\"top\">Buildings.Utilities.Psychrometrics.Functions.saturationPressure
        </td>
        <td valign=\"top\">Changed <code>smoothOrder</code> from <i>5</i> to <i>1</i> as
-                         <a href=\"modelica://Buildings.Utilities.Math.Functions.spliceFunction\">
-                         Buildings.Utilities.Math.Functions.spliceFunction</a> is only once
+                         <code>Buildings.Utilities.Math.Functions.spliceFunction</code> is only once
                          continuously differentiable.
                          Inlined the function.
        </td>
@@ -4138,15 +4134,13 @@ The following major additions have been done in version 2.0:
 <li>
 A CFD model
 that is embedded in a thermal zone has been added.
-This model is implemented in <a href=\"modelica://Buildings.ThermalZones.Detailed.CFD\">Buildings.ThermalZones.Detailed.CFD</a>.
+This model is implemented in <code>Buildings.ThermalZones.Detailed.CFD</code>.
 The CFD model is an implementation of the Fast Fluid Dynamics code
 that allows three-dimensional CFD inside a thermal zone,
 coupled to building heat transfer, HVAC components and feedback control loops.
 </li>
 <li>
-A new package
-<a href=\"modelica://Buildings.Electrical\">Buildings.Electrical</a>
-has been added.
+A new package <code>Buildings.Electrical</code> has been added.
 This package allows studying
 buildings to electrical grid integration. It includes models for loads, transformers,
 cables, batteries, PV and wind turbines.
@@ -4155,15 +4149,12 @@ The models compute voltage, current, active and reactive power
 based on the quasi-stationary assumption or using the dynamic phasorial representation.
 </li>
 <li>
-The new package
-<a href=\"modelica://Buildings.Controls.DemandResponse\">
-Buildings.Controls.DemandResponse</a>
+The new package <code>Buildings.Controls.DemandResponse</code>
 contains models for demand response simulation.
 </li>
 <li>
 The new package
-<a href=\"modelica://Buildings.Controls.Predictors\">
-Buildings.Controls.Predictors</a>
+<code>Buildings.Controls.Predictors</code>
 contains a data-driven model that predicts the electrical load
 of a building. The prediction can be done
 either using an average baseline or
@@ -4250,8 +4241,7 @@ to <b style=\"color:blue\">existing</b> libraries:
                        and, through the fluid port, to the air conditioning system.
                        Currently, the supported CFD program is the
                        Fast Fluid Dynamics (FFD) program.
-                       See
-                       <a href=\"modelica://Buildings.ThermalZones.Detailed.UsersGuide.CFD\">Buildings.ThermalZones.Detailed.UsersGuide.CFD</a>
+                       See <code>Buildings.ThermalZones.Detailed.UsersGuide.CFD</code>
                        for detailed explanations.
     </td>
     </tr>
@@ -4306,8 +4296,7 @@ have been <b style=\"color:blue\">improved</b> in a
     </td>
     <td valign=\"top\">Removed parameter <code>m1_flow_nominal</code>, as this parameter is already
                     declared in its base class
-                    <a href=\"modelica://Buildings.Fluid.Interfaces.PartialFourPortInterface\">
-                    Buildings.Fluid.Interfaces.PartialFourPortInterface</a>.
+                    <code>Buildings.Fluid.Interfaces.PartialFourPortInterface</code>.
                     This change avoids an error in OpenModelica as the two declarations
                     had a different value for the <code>min</code> attribute, which is not valid
                     in Modelica.
@@ -4565,8 +4554,7 @@ have been <b style=\"color:blue\">improved</b> in a
                        The new <i>&epsilon;-NTU</i> formulation has shown to lead to
                        about five times faster
                        computation on several test cases including the models in
-                       <a href=\"modelica://Buildings.ThermalZones.Detailed.FLEXLAB.Rooms.Examples\">
-                       Buildings.ThermalZones.Detailed.FLEXLAB.Rooms.Examples</a>.<br/>
+                       <code>Buildings.ThermalZones.Detailed.FLEXLAB.Rooms.Examples</code>.<br/>
                        For Dymola, the conversion script will automatically
                        update existing models.
  </td>
@@ -4627,8 +4615,7 @@ have been <b style=\"color:blue\">improved</b> in a
                        In addition, the performance
                        data of all movers are now stored in a record.
                        These records are in
-                       <a href=\"modelica://Buildings.Fluid.Movers.Data\">
-                       Buildings.Fluid.Movers.Data</a>.
+                       <code>Buildings.Fluid.Movers.Data</code>.
                        For most existing instances, it should be sufficient to enclose
                        the existing performance data in a record called <code>per</code>.
                        For example,
@@ -4649,8 +4636,8 @@ have been <b style=\"color:blue\">improved</b> in a
                        &nbsp;&nbsp;&nbsp;dp={2*dp_nominal,dp_nominal,0})));<br/>
                        </code>
                        <br/>
-                       See the <a href=\"modelica://Buildings.Fluid.Movers.UsersGuide\">
-                       User's Guide</a> for more information about these records.
+                       See the <code>Buildings.Fluid.Movers.UsersGuide</code> for more
+                       information about these records.
                        <br/><br/>
                        For Dymola, the conversion script will
                        update existing models to use the old implementations
@@ -4667,8 +4654,7 @@ have been <b style=\"color:blue\">improved</b> in a
 <td>
                        Renamed all media to simplify the media selection.
                        For typical building energy simulation,
-                       <a href=\"modelica://Buildings.Media.Air\">Buildings.Media.Air</a> and
-                       <a href=\"modelica://Buildings.Media.Water\">Buildings.Media.Water</a>
+                       <code>Buildings.Media.Air</code> and <code>Buildings.Media.Water</code>
                        should be used.<br/><br/>
                        The following changes were made.<br/><br/>
                        Renamed <code>Buildings.Media.GasesPTDecoupled.MoistAirUnsaturated</code><br/>
@@ -5164,10 +5150,8 @@ have been fixed:
         Documentation(info="<html>
 <p>
 Version 1.5 build 2 is a maintenance release that corrects an error in
-<a href=\"modelica://Buildings.Fluid.HeatExchangers.DryCoilDiscretized\">
-Buildings.Fluid.HeatExchangers.DryCoilDiscretized</a> and in
-<a href=\"modelica://Buildings.Fluid.HeatExchangers.WetCoilDiscretized\">
-Buildings.Fluid.HeatExchangers.WetCoilDiscretized</a>.
+<code>Buildings.Fluid.HeatExchangers.DryCoilDiscretized</code> and in
+<code>Buildings.Fluid.HeatExchangers.WetCoilDiscretized</code>.
 It is fully compatible with version 1.5 build 1.
 <!-- Errors that have been fixed -->
 <p>
@@ -5353,8 +5337,7 @@ have been <b style=\"color:blue\">improved</b> in a
                        This is required to allow changing the
                        material properties after compilation.
                        Note, however, that the number of state variables in
-                       <a href=\"modelica://Buildings.HeatTransfer.Data.BaseClasses.Material\">
-                       Buildings.HeatTransfer.Data.BaseClasses.Material</a>
+                       <code>Buildings.HeatTransfer.Data.BaseClasses.Material</code>
                        are only computed when the model is translated, because
                        the number of state variables is fixed
                        at compilation time.
@@ -5772,8 +5755,7 @@ have been fixed:
 <p>
 Version 1.4 build 1 contains the new package <code>Buildings.Utilities.IO.Python27</code>
 that allows calling Python functions from Modelica.
-It also contains in the package <a href=\"modelica://Buildings.HeatTransfer.Conduction.SingleLayer\">
-Buildings.HeatTransfer.Conduction.SingleLayer</a>
+It also contains in the package <code>Buildings.HeatTransfer.Conduction.SingleLayer</code>
 a new model for heat conduction in phase change material. This model can be used as a layer
 of the room heat transfer model.
 </p>
@@ -5781,11 +5763,9 @@ of the room heat transfer model.
 <p>
 Non-backward compatible changes had to be introduced
 in the valve models
-<a href=\"modelica://Buildings.Fluid.Actuators.Valves\">
-Buildings.Fluid.Actuators.Valves</a> to fully comply with the Modelica language specification,
-and in the models in the package
-<a href=\"modelica://Buildings.Utilities.Diagnostics\">
-Buildings.Utilities.Diagnostics</a>
+<code>Buildings.Fluid.Actuators.Valves</code> to fully comply with the Modelica
+language specification, and in the models in the package
+<code>Buildings.Utilities.Diagnostics</code>
 as they used the <code>cardinality</code> function which is deprecated in the Modelica
 Language Specification.
 </p>
@@ -6018,8 +5998,7 @@ have been fixed:
     </td>
     <td valign=\"top\">
     Described in
-    <a href=\"modelica://Buildings.HeatTransfer.Data.Solids\">
-    Buildings.HeatTransfer.Data.Solids</a>
+    <code>Buildings.HeatTransfer.Data.Solids</code>
     how the parameter <code>nStaRef</code> is used
     to compute the spatial grid that is used for simulating transient heat conduction.
     </td>
@@ -6497,8 +6476,7 @@ have been <b style=\"color:blue\">improved</b> in a
                        and <code>wWin</code> when updating models
                        from a previous version of the library.<br/>
                        See the information section in
-                       <a href=\"modelica://Buildings.ThermalZones.Detailed.MixedAir\">
-                       Buildings.ThermalZones.Detailed.MixedAir</a> for how to use these models.
+                       <code>Buildings.ThermalZones.Detailed.MixedAir</code> for how to use these models.
     </td>
 </tr>
 </table>
@@ -6635,8 +6613,7 @@ Version 1.1 build 1 contains improvements to models that address numerical probl
 In particular, flow machines and actuators now have an optional filter
 that converts step changes in the input signal to a smooth change in
 speed or actuator position.
-Also, (<a href=\"modelica://Buildings.Examples.Tutorial\">
-Buildings.Examples.Tutorial</a>)
+Also, (<code>Buildings.Examples.Tutorial</code>)
 has been added to provide step-by-step instruction for how to build
 system models.
 <!-- New libraries -->
@@ -6810,8 +6787,7 @@ have been <b style=\"color:blue\">improved</b> in a
                        Previous models that instantiate these components need to change the
                        assignment of <code>dp_nominal</code> to an assignment of
                        <code>dpValve_nominal</code>.
-                       See also <a href=\"modelica://Buildings.Fluid.Actuators.UsersGuide\">
-                       Buildings.Fluid.Actuators.UsersGuide</a>.
+                       See also <code>Buildings.Fluid.Actuators.UsersGuide</code>.
     </td>
 </tr>
 
@@ -6942,11 +6918,9 @@ Note:
 The use of filters for actuator and flow machine input
 signals changes the dynamic response of feedback control loops.
 Therefore, control gains may need to be retuned.
-See <a href=\"modelica://Buildings.Fluid.Actuators.UsersGuide\">
-Buildings.Fluid.Actuators.UsersGuide</a>
+See <code>Buildings.Fluid.Actuators.UsersGuide</code>
 and
-<a href=\"modelica://Buildings.Fluid.Movers.UsersGuide\">
-Buildings.Fluid.Movers.UsersGuide</a> for recommended control
+<code>Buildings.Fluid.Movers.UsersGuide</code> for recommended control
 gains and further details.
 </li>
 </ul>
@@ -7247,8 +7221,7 @@ are used as steady-state models, have been improved.</td>
                      Adding sensor dynamics avoids numerical problems when mass flow
                      rates are close to zero and the sensor is configured to allow
                      flow reversal. See
-                     <a href=\"modelica://Buildings.Fluid.Sensors.UsersGuide\">
-                     Buildings.Fluid.Sensors.UsersGuide</a> for details.</td>
+                     <code>Buildings.Fluid.Sensors.UsersGuide</code> for details.</td>
 </tr>
 
 <tr><td colspan=\"2\"><b>Buildings.Fluid.Storage</b></td></tr>
@@ -7362,8 +7335,7 @@ near zero flow if the components have exactly two fluid ports connected.</td>
 <tr><td colspan=\"2\"><b>Buildings.Fluid.Sensors</b></td></tr>
 <tr><td valign=\"top\">Buildings.Fluid.Sensors.TemperatureTwoPortDynamic</td>
     <td valign=\"top\">This model has been deleted since the sensor
-                     <a href=\"modelica://Buildings.Fluid.Sensors.TemperatureTwoPort\">
-                     Buildings.Fluid.Sensors.TemperatureTwoPort</a> has been revised
+                     <code>Buildings.Fluid.Sensors.TemperatureTwoPort</code> has been revised
                      and can now also be used as a dynamic model of a sensor.</td>
 </tr>
 
@@ -7561,8 +7533,7 @@ Versions are identified with two numbers <code>x.y</code> and a build number. Th
 release of each version has the build number <code>1</code>. For each released bug fix,
 the build number is incremented.
 See
-<a href=\"modelica://Modelica.UsersGuide.ReleaseNotes.VersionManagement\">
-Modelica.UsersGuide.ReleaseNotes.VersionManagement</a> for details.
+<code>Modelica.UsersGuide.ReleaseNotes.VersionManagement</code> for details.
 </li>
 <li>
 To allow adding scripts for multiple simulation environments,
@@ -7588,8 +7559,7 @@ that can lead to wrong simulation results):
 
 <table class=\"releaseTable\" summary=\"summary\" border=\"1\" cellspacing=\"0\" cellpadding=\"2\" style=\"border-collapse:collapse;\">
   <tr><td colspan=\"2\"><b>Buildings.ThermalZones</b></td></tr>
-  <tr><td valign=\"top\"><a href=\"modelica://Buildings.ThermalZones.Detailed.BaseClasses.InfraredRadiationExchange\">
-  Buildings.ThermalZones.Detailed.BaseClasses.InfraredRadiationExchange</a></td>
+  <tr><td valign=\"top\"><code>Buildings.ThermalZones.Detailed.BaseClasses.InfraredRadiationExchange</code></td>
       <td valign=\"top\">The model <code>Buildings.ThermalZones.Detailed.BaseClasses.InfraredRadiationExchange</code>
       had an error in the view factor approximation.
       The error caused too much radiosity to flow from large to small surfaces because the law of reciprocity
@@ -7611,19 +7581,16 @@ Updated library to Modelica 3.2.
 Added <code>homotopy</code> operator.
 </li>
 <li>
-Restructured package <a href=\"modelica://Buildings.HeatTransfer\">
-Buildings.HeatTransfer</a>.
+Restructured package <code>Buildings.HeatTransfer</code>.
 </li>
 <li>
-Rewrote the models in <a href=\"modelica://Buildings.Fluid.Actuators\">
-Buildings.Fluid.Actuators</a> to avoid having the flow coefficient
+Rewrote the models in <code>Buildings.Fluid.Actuators</code> to avoid having the flow coefficient
 <code>k</code> as an algebraic variable.
 This increases robustness.
 </li>
 <li>
 Rewrote energy, species and trace substance balance in
-<a href=\"modelica://Buildings.Fluid.Interfaces.StaticTwoPortHeatMassExchanger\">
-Buildings.Fluid.Interfaces.StaticTwoPortHeatMassExchanger</a>
+<code>Buildings.Fluid.Interfaces.StaticTwoPortHeatMassExchanger</code>
 to better handle zero mass flow rate.
 </li>
 <li>
@@ -7632,8 +7599,7 @@ in single substance media
 to allow use of the room model with media that do not contain water vapor.
 </li>
 <li>
-Revised <a href=\"modelica://Buildings.Fluid.Sources.Outside\">
-Buildings.Fluid.Sources.Outside</a>
+Revised <code>Buildings.Fluid.Sources.Outside</code>
 to allow use of the room model with media that do not contain water vapor.
 </li>
 </ul>
@@ -7651,37 +7617,30 @@ are still being validated.
 <ul>
 <li>
 Added the package
-<a href=\"modelica://Buildings.ThermalZones.Detailed\">
-Buildings.ThermalZones.Detailed</a> to compute heat transfer in rooms
+<code>Buildings.ThermalZones.Detailed</code> to compute heat transfer in rooms
 and through the building envelope.
 Multiple instances of these models can be connected to create
 a multi-zone building model.
 </li>
 <li>
 Added the package
-<a href=\"modelica://Buildings.HeatTransfer.Windows\">
-Buildings.HeatTransfer.Windows</a>
+<code>Buildings.HeatTransfer.Windows</code>
 to compute heat transfer (solar radiation, infrared radiation,
 convection and conduction) through glazing systems.
 </li>
 <li>
 In package
-<a href=\"modelica://Buildings.Fluid.Chillers\">
-Buildings.Fluid.Chillers</a>, added the chiller models
-<a href=\"modelica://Buildings.Fluid.Chillers.ElectricReformulatedEIR\">
-Buildings.Fluid.Chillers.ElectricReformulatedEIR</a>
+<code>Buildings.Fluid.Chillers</code>, added the chiller models
+<code>Buildings.Fluid.Chillers.ElectricReformulatedEIR</code>
 and
-<a href=\"modelica://Buildings.Fluid.Chillers.ElectricEIR\">
-Buildings.Fluid.Cphillers.ElectricEIR</a>, and added
+<code>Buildings.Fluid.Cphillers.ElectricEIR</code>, and added
 the package
-<a href=\"modelica://Buildings.Fluid.Chillers.Data\">
-Buildings.Fluid.Chillers.Data</a>
+<code>Buildings.Fluid.Chillers.Data</code>
 that contains data sets of chiller performance data.
 </li>
 <li>
 Added package
-<a href=\"modelica://Buildings.BoundaryConditions\">
-Buildings.BoundaryConditions</a>
+<code>Buildings.BoundaryConditions</code>
 with models to compute boundary conditions, such as
 solar irradiation and sky temperature.
 </li>
@@ -7692,20 +7651,17 @@ with models to read weather data in the TMY3 format.
 </li>
 <li>
 Revised the package
-<a href=\"modelica://Buildings.Fluid.Sensors\">Buildings.Fluid.Sensors</a>.
+<code>Buildings.Fluid.Sensors</code>.
 </li>
 <li>
 Revised the package
-<a href=\"modelica://Buildings.Fluid.HeatExchangers.CoolingTowers\">
-Buildings.Fluid.HeatExchangers.CoolingTowers</a>.
+<code>Buildings.Fluid.HeatExchangers.CoolingTowers</code>.
 </li>
 <li>
 In
-<a href=\"modelica://Buildings.Fluid.Interfaces.StaticTwoPortHeatMassExchanger\">
-Buildings.Fluid.Interfaces.StaticFourPortHeatMassExchanger</a>
+<code>Buildings.Fluid.Interfaces.StaticFourPortHeatMassExchanger</code>
 and
-<a href=\"modelica://Buildings.Fluid.Interfaces.StaticTwoPortHeatMassExchanger\">
-Buildings.Fluid.Interfaces.StaticFourPortHeatMassExchanger</a>,
+<code>Buildings.Fluid.Interfaces.StaticFourPortHeatMassExchanger</code>,
 fixed bug in energy and moisture balance that affected results if a component
 adds or removes moisture to the air stream.
 In the old implementation, the enthalpy and species
@@ -7718,15 +7674,13 @@ With the new implementation, the energy and moisture balance is exact.
 </li>
 <li>
 In
-<a href=\"modelica://Buildings.Fluid.Interfaces.ConservationEquation\">
-Buildings.Fluid.Interfaces.ConservationEquation</a> and in
+<code>Buildings.Fluid.Interfaces.ConservationEquation</code> and in
 <code>Buildings.Media.Interfaces.PartialSimpleMedium</code>, set
 nominal attribute for medium to provide consistent normalization.
 Without this change, Dymola 7.4 uses different values for the nominal attribute
 based on the value of <code>Advanced.OutputModelicaCodeWithJacobians=true/false;</code>
 in the model
-<a href=\"modelica://Buildings.Examples.HydronicHeating\">
-Buildings.Examples.HydronicHeating</a>.
+<code>Buildings.Examples.HydronicHeating</code>.
 </li>
 <li>
 Fixed bug in energy balance of
@@ -7734,8 +7688,7 @@ Fixed bug in energy balance of
 </li>
 <li>
 Fixed bug in efficiency curves in package
-<a href=\"modelica://Buildings.Fluid.Movers.BaseClasses.Characteristics\">
-Buildings.Fluid.Movers.BaseClasses.Characteristics</a>.
+<code>Buildings.Fluid.Movers.BaseClasses.Characteristics</code>.
 </li>
 </ul>
 </html>"));
@@ -7748,29 +7701,24 @@ Buildings.Fluid.Movers.BaseClasses.Characteristics</a>.
 <ul>
 <li>
 Added package
-<a href=\"modelica://Buildings.Airflow.Multizone\">
-Buildings.Airflow.Multizone</a>
+<code>Buildings.Airflow.Multizone</code>
 with models for multizone airflow and contaminant transport.
 </li>
 <li>
 Added the model
-<a href=\"modelica://Buildings.Utilities.Comfort.Fanger\">
-Buildings.Utilities.Comfort.Fanger</a>
+<code>Buildings.Utilities.Comfort.Fanger</code>
 for thermal comfort calculations.
 </li>
 <li>
 Rewrote
-<a href=\"modelica://Buildings.Fluid.Storage.BaseClasses.ThirdOrderStratifier\">
-Buildings.Fluid.Storage.BaseClasses.ThirdOrderStratifier</a>, which is used in
-<a href=\"modelica://Buildings.Fluid.Storage.StratifiedEnhanced\">
-Buildings.Fluid.Storage.StratifiedEnhanced</a>,
+<code>Buildings.Fluid.Storage.BaseClasses.ThirdOrderStratifier</code>, which is used in
+<code>Buildings.Fluid.Storage.StratifiedEnhanced</code>,
 to avoid state events when the flow reverses.
 This leads to faster and more robust simulation.
 </li>
 <li>
 In models of package
-<a href=\"modelica://Buildings.Fluid.MixingVolumes\">
-Buildings.Fluid.MixingVolumes</a>,
+<code>Buildings.Fluid.MixingVolumes</code>,
 added nominal value for <code>mC</code> to avoid wrong trajectory
 when concentration is around 1E-7.
 See also <a href=\"https://trac.modelica.org/Modelica/ticket/393\">
@@ -7781,8 +7729,7 @@ Fixed bug in fan and pump models that led to too small an enthalpy
 increase across the flow device.
 </li>
 <li>
-In model <a href=\"modelica://Buildings.Fluid.Movers.FlowControlled_dp\">
-Buildings.Fluid.Movers.FlowControlled_dp</a>,
+In model <code>Buildings.Fluid.Movers.FlowControlled_dp</code>,
 changed <code>assert(dp_in &ge; 0, ...)</code> to <code>assert(dp_in &ge; -0.1, ...)</code>.
 The former implementation triggered the assert if <code>dp_in</code> was solved for
 in a nonlinear equation since the solution can be slightly negative while still being
@@ -7790,14 +7737,12 @@ within the solver tolerance.
 </li>
 <li>
 Added model
-<a href=\"modelica://Buildings.Controls.SetPoints.Table\">
-Buildings.Controls.SetPoints.Table</a>
+<code>Buildings.Controls.SetPoints.Table</code>
 that allows the specification of a floating setpoint using a table of values.
 </li>
 <li>
 Revised model
-<a href=\"modelica://Buildings.Fluid.HeatExchangers.Radiators.RadiatorEN442_2\">
-Buildings.Fluid.HeatExchangers.Radiators.RadiatorEN442_2</a>.
+<code>Buildings.Fluid.HeatExchangers.Radiators.RadiatorEN442_2</code>.
 The new version has exactly the same nominal power during the simulation as specified
 by the parameters. This also required a change in the parameters.
 </li>
@@ -7815,19 +7760,15 @@ that can lead to wrong simulation results):
 
 <table class=\"releaseTable\" summary=\"summary\" border=\"1\" cellspacing=\"0\" cellpadding=\"2\" style=\"border-collapse:collapse;\">
   <tr><td colspan=\"2\"><b>Buildings.Fluid.Storage.</b></td></tr>
-  <tr><td valign=\"top\"><a href=\"modelica://Buildings.Fluid.Storage.StratifiedEnhanced\">
-  Buildings.Fluid.Storage.StratifiedEnhanced</a></td>
+  <tr><td valign=\"top\"><code>Buildings.Fluid.Storage.StratifiedEnhanced</code></td>
       <td valign=\"top\">The model <code>Buildings.Fluid.Storage.BaseClasses.Stratifier</code>
       had a sign error that lead to a wrong energy balance.
       The model that was affected by this error is
-      <a href=\"modelica://Buildings.Fluid.Storage.StratifiedEnhanced\">
-      Buildings.Fluid.Storage.StratifiedEnhanced</a>.
+      <code>Buildings.Fluid.Storage.StratifiedEnhanced</code>.
       The model
-      <a href=\"modelica://Buildings.Fluid.Storage.Stratified\">
-      Buildings.Fluid.Storage.Stratified</a> was not affected.<br/>
+      <code>Buildings.Fluid.Storage.Stratified</code> was not affected.<br/>
       The bug has been fixed by using the newly introduced model
-      <a href=\"modelica://Buildings.Fluid.Storage.BaseClasses.ThirdOrderStratifier\">
-        Buildings.Fluid.Storage.BaseClasses.ThirdOrderStratifier</a>. This model
+      <code>Buildings.Fluid.Storage.BaseClasses.ThirdOrderStratifier</code>. This model
       uses a third-order upwind scheme to reduce the numerical dissipation instead of the
       correction term that was used in <code>Buildings.Fluid.Storage.BaseClasses.Stratifier</code>.
       The model <code>Buildings.Fluid.Storage.BaseClasses.Stratifier</code> has been removed since it
@@ -7852,26 +7793,22 @@ for a sensible heat exchanger that uses the <code>epsilon-NTU</code>
 relations to compute the heat transfer.
 </li>
 <li>
-<a href=\"modelica://Buildings.Fluid.HeatExchangers.DryCoilCounterFlow\">
-Buildings.Fluid.HeatExchangers.DryCoilCounterFlow</a> and
-<a href=\"modelica://Buildings.Fluid.HeatExchangers.WetCoilCounterFlow\">
-Buildings.Fluid.HeatExchangers.WetCoilCounterFlow</a>
+<code>Buildings.Fluid.HeatExchangers.DryCoilCounterFlow</code> and
+<code>Buildings.Fluid.HeatExchangers.WetCoilCounterFlow</code>
 to model a coil without and with water vapor condensation. These models
 approximate the coil as a counterflow heat exchanger.
 </li>
 </ul>
 <li>
 Revised air damper
-<a href=\"modelica://Buildings.Fluid.Actuators.BaseClasses.exponentialDamper\">
-Buildings.Fluid.Actuators.BaseClasses.exponentialDamper</a>.
+<code>Buildings.Fluid.Actuators.BaseClasses.exponentialDamper</code>.
 The new implementation avoids warnings and leads to faster convergence
 since the solver does not attempt anymore to solve for a variable that
 needs to be strictly positive.
 </li>
 <li>
 Revised package
-<a href=\"modelica://Buildings.Fluid.Movers\">
-Buildings.Fluid.Movers</a>
+<code>Buildings.Fluid.Movers</code>
 to allow zero flow for some pump or fan models.
 If the input to the model is the control signal <code>y</code>, then
 the flow is equal to zero if <code>y=0</code>. This change required rewriting
@@ -7879,15 +7816,13 @@ the package to avoid division by the rotational speed.
 </li>
 <li>
 Revised package
-<a href=\"modelica://Buildings.HeatTransfer\">
-Buildings.HeatTransfer</a>
+<code>Buildings.HeatTransfer</code>
 to include a model for a multi-layer construction, and to
 allow individual material layers to be computed steady-state or
 transient.
 </li>
 <li>
-In package  <a href=\"modelica://Buildings.Fluid\">
-Buildings.Fluid</a>, changed models so that
+In package  <code>Buildings.Fluid</code>, changed models so that
 if the parameter <code>dp_nominal</code> is set to zero,
 then the pressure drop equation is removed. This allows, for example,
 to model a heating and a cooling coil in series, and lump there pressure drops
@@ -7895,22 +7830,18 @@ into a single element, thereby reducing the dimension of the nonlinear system
 of equations.
 </li>
 <li>
-Added model <a href=\"modelica://Buildings.Controls.Continuous.LimPID\">
-Buildings.Controls.Continuous.LimPID</a>, which is identical to
-<a href=\"modelica://Modelica.Blocks.Continuous.LimPID\">
-Modelica.Blocks.Continuous.LimPID</a>, except that it
+Added model <code>Buildings.Controls.Continuous.LimPID</code>, which is identical to
+<code>Modelica.Blocks.Continuous.LimPID</code>, except that it
 allows reverse control action. This simplifies use of the controller
 for cooling applications.
 </li>
 <li>
-Added model <a href=\"modelica://Buildings.Fluid.Actuators.Dampers.MixingBox\">
-Buildings.Fluid.Actuators.Dampers.MixingBox</a> for an outside air
+Added model <code>Buildings.Fluid.Actuators.Dampers.MixingBox</code> for an outside air
 mixing box with air dampers.
 </li>
 <li>
 Changed implementation of flow resistance in
-<a href=\"modelica://Buildings.Fluid.Actuators.Dampers.MixingBoxMinimumFlow\">
-Buildings.Fluid.Actuators.Dampers.MixingBoxMinimumFlow</a>. Instead of using a
+<code>Buildings.Fluid.Actuators.Dampers.MixingBoxMinimumFlow</code>. Instead of using a
 fixed resistance and a damper model in series, only one model is used
 that internally adds these two resistances. This leads to smaller systems
 of nonlinear equations.
@@ -7937,15 +7868,13 @@ networks.
 </li>
 <li>
 In
-<a href=\"modelica://Buildings.Fluid.Actuators.BaseClasses.PartialDamperExponential\">
-Buildings.Fluid.Actuators.BaseClasses.PartialDamperExponential</a>,
+<code>Buildings.Fluid.Actuators.BaseClasses.PartialDamperExponential</code>,
 added default value for parameter <code>A</code> to avoid compilation error
 if the parameter is disabled but not specified.
 </li>
 <li>
 Simplified the mixing volumes in
-<a href=\"modelica://Buildings.Fluid.MixingVolumes\">
-Buildings.Fluid.MixingVolumes</a> by removing the port velocity,
+<code>Buildings.Fluid.MixingVolumes</code> by removing the port velocity,
 pressure drop and height.
 </li>
 </ul>
@@ -7959,8 +7888,7 @@ pressure drop and height.
 <ul>
 <li>
 In
-<a href=\"modelica://Buildings.Fluid.Interfaces.ConservationEquation\">
-Buildings.Fluid.Interfaces.ConservationEquation</a>,
+<code>Buildings.Fluid.Interfaces.ConservationEquation</code>,
 added to <code>Medium.BaseProperties</code> the initialization
 <code>X(start=X_start[1:Medium.nX])</code>. Previously, the initialization
 was only done for <code>Xi</code> but not for <code>X</code>, which caused the
@@ -7971,17 +7899,14 @@ Renamed <code>Buildings.Media.PerfectGases.MoistAirNonSaturated</code>
 to <code>Buildings.Media.PerfectGases.MoistAirUnsaturated</code>
 and <code>Buildings.Media.GasesPTDecoupled.MoistAirNoLiquid</code>
 to
-<a href=\"modelica://Buildings.Media.Air\">
-Buildings.Media.Air</a>,
+<code>Buildings.Media.Air</code>,
 and added <code>assert</code> statements if saturation occurs.
 </li>
 <li>
 Added regularizaation near zero flow to
-<a href=\"modelica://Buildings.Fluid.HeatExchangers.ConstantEffectiveness\">
-Buildings.Fluid.HeatExchangers.ConstantEffectiveness</a>
+<code>Buildings.Fluid.HeatExchangers.ConstantEffectiveness</code>
 and
-<a href=\"modelica://Buildings.Fluid.MassExchangers.ConstantEffectiveness\">
-Buildings.Fluid.MassExchangers.ConstantEffectiveness</a>.
+<code>Buildings.Fluid.MassExchangers.ConstantEffectiveness</code>.
 </li>
 <li>
 Fixed bug regarding temperature offset in
@@ -7989,8 +7914,7 @@ Fixed bug regarding temperature offset in
 </li>
 <li>
 Added implementation of function
-<a href=\"modelica://Buildings.Media.Air.enthalpyOfNonCondensingGas\">
-Buildings.Media.Air.enthalpyOfNonCondensingGas</a> and its derivative.
+<code>Buildings.Media.Air.enthalpyOfNonCondensingGas</code> and its derivative.
 </li>
 <li>
 In <code>Buildings.Media.PerfectGases.MoistAir</code>, fixed
@@ -7999,8 +7923,7 @@ In the previous version, it computed the inverse of its parent class,
 which gave slightly different results.
 </li>
 <li>
-In <a href=\"modelica://Buildings.Utilities.IO.BCVTB.BCVTB\">
-Buildings.Utilities.IO.BCVTB.BCVTB</a>, added parameter to specify
+In <code>Buildings.Utilities.IO.BCVTB.BCVTB</code>, added parameter to specify
 the value to be sent to the BCVTB at the first data exchange,
 and added parameter that deactivates the interface. Deactivating
 the interface is sometimes useful during debugging.
@@ -8010,27 +7933,22 @@ In <code>Buildings.Media.GasesPTDecoupled.MoistAir</code> and in
 <code>Buildings.Media.PerfectGases.MoistAir</code>, added function
 <code>enthalpyOfNonCondensingGas</code> and its derivative.
 <li>
-In <a href=\"modelica://Buildings.Media\">
-Buildings.Media</a>,
+In <code>Buildings.Media</code>,
 fixed bug in implementations of derivatives.
 </li>
 <li>
 Added model
-<a href=\"modelica://Buildings.Fluid.Storage.ExpansionVessel\">
-Buildings.Fluid.Storage.ExpansionVessel</a>.
+<code>Buildings.Fluid.Storage.ExpansionVessel</code>.
 </li>
 <li>
 Added Wrapper function <code>Buildings.Fluid.Movers.BaseClasses.Characteristics.solve</code>
-for <a href=\"modelica://Modelica.Math.Matrices.solve\">
-Modelica.Math.Matrices.solve</a>. This is currently needed since
-<a href=\"modelica://Modelica.Math.Matrices.solve\">
-Modelica.Math.Matrices.solve</a> does not specify a
+for <code>Modelica.Math.Matrices.solve</code>. This is currently needed since
+<code>Modelica.Math.Matrices.solve</code> does not specify a
 derivative.
 </li>
 <li>
 Fixed bug in
-<a href=\"Buildings.Fluid.Storage.Stratified\">
-Buildings.Fluid.Storage.Stratified</a>.
+<code>Buildings.Fluid.Storage.Stratified</code>.
 In the previous version,
 for computing the heat conduction between the top (or bottom) segment and
 the outside,
@@ -8046,31 +7964,25 @@ which contains the equation for the compressibility. The default setting will mo
 the flow as incompressible.
 </li>
 <li>
-In <a href=\"modelica://Buildings.Controls.Continuous.Examples.PIDHysteresis\">
-Buildings.Controls.Continuous.Examples.PIDHysteresis</a>
-and <a href=\"modelica://Buildings.Controls.Continuous.Examples.PIDHysteresisTimer\">
-Buildings.Controls.Continuous.Examples.PIDHysteresisTimer</a>,
+In <code>Buildings.Controls.Continuous.Examples.PIDHysteresis</code>
+and <code>Buildings.Controls.Continuous.Examples.PIDHysteresisTimer</code>,
 fixed error in default parameter <code>eOn</code>.
 Fixed error by introducing parameter <code>Td</code>,
 which used to be hard-wired in the PID controller.
 </li>
 <li>
 Added more models for fans and pumps to the package
-<a href=\"modelica://Buildings.Fluid.Movers\">
-Buildings.Fluid.Movers</a>.
+<code>Buildings.Fluid.Movers</code>.
 The models are similar to the ones in
-<a href=\"modelica://Modelica.Fluid.Machines\">
-Modelica.Fluid.Machines</a> but have been adapted for
+<code>Modelica.Fluid.Machines</code> but have been adapted for
 air-based systems, and to include more characteristic curves
 in
-<a href=\"modelica://Buildings.Fluid.Movers.BaseClasses.Characteristics\">
-Buildings.Fluid.Movers.BaseClasses.Characteristics</a>.
+<code>Buildings.Fluid.Movers.BaseClasses.Characteristics</code>.
 The new models are better suited than the existing fan model
 <code>Buildings.Fluid.Movers.FlowMachinePolynomial</code> for zero flow rate.
 </li>
 <li>
-Added an optional mixing volume to <a href=\"modelica://Buildings.Fluid.BaseClasses.PartialThreeWayResistance\">
-Buildings.Fluid.BaseClasses.PartialThreeWayResistance</a>
+Added an optional mixing volume to <code>Buildings.Fluid.BaseClasses.PartialThreeWayResistance</code>
 and hence to the flow splitter and to the three-way valves. This often breaks algebraic loops and provides a state for the temperature if the mass flow rate goes to zero.
 </li>
 </ul>
@@ -8089,10 +8001,8 @@ Updated library from Modelica_Fluid to Modelica.Fluid 1.0
 Merged sensor and source models from Modelica.Fluid to Buildings.Fluid.
 </li>
 <li> Added sensor for sensible and latent enthalpy flow rate,
-<a href=\"modelica://Buildings.Fluid.Sensors.SensibleEnthalpyFlowRate\">
-Buildings.Fluid.Sensors.SensibleEnthalpyFlowRate</a> and
-<a href=\"modelica://Buildings.Fluid.Sensors.LatentEnthalpyFlowRate\">
-Buildings.Fluid.Sensors.LatentEnthalpyFlowRate</a>.
+<code>Buildings.Fluid.Sensors.SensibleEnthalpyFlowRate</code> and
+<code>Buildings.Fluid.Sensors.LatentEnthalpyFlowRate</code>.
 These sensors are needed, for example, to interface air-conditioning
 systems that are modeled with Modelica with the Building Controls
 Virtual Test Bed.
@@ -8108,8 +8018,7 @@ Virtual Test Bed.
 <ul>
 <li>
 Added the package
-<a href=\"modelica://Buildings.Utilities.IO.BCVTB\">
-Buildings.Utilities.IO.BCVTB</a>
+<code>Buildings.Utilities.IO.BCVTB</code>
 which contains an interface to the
 <a href=\"http://simulationresearch.lbl.gov/bcvtb\">Building Controls Virtual Test Bed.</a>
 <li>
@@ -8127,32 +8036,26 @@ in Modelica 3.0.
 </li>
 <li>
 Changed the base class
-<a href=\"modelica://Buildings.Fluid.Interfaces.StaticTwoPortHeatMassExchanger\">
-Buildings.Fluid.Interfaces.StaticTwoPortHeatMassExchanger</a>
+<code>Buildings.Fluid.Interfaces.StaticTwoPortHeatMassExchanger</code>
 to enable computation of pressure drop of mechanical equipment.
 </li>
 <li>
 Introduced package
-<a href=\"modelica://Buildings.Fluid.BaseClasses.FlowModels\">
-Buildings.Fluid.BaseClasses.FlowModels</a> to model pressure drop,
+<code>Buildings.Fluid.BaseClasses.FlowModels</code> to model pressure drop,
 and rewrote
-<a href=\"modelica://Buildings.Fluid.BaseClasses.PartialResistance\">
-Buildings.Fluid.BaseClasses.PartialResistance</a>.
+<code>Buildings.Fluid.BaseClasses.PartialResistance</code>.
 </li>
 <li>
 Redesigned package
-<a href=\"modelica://Buildings.Utilities.Math\">
-Buildings.Utilities.Math</a> to allow having blocks and functions
+<code>Buildings.Utilities.Math</code> to allow having blocks and functions
 with the same name. Functions are now in
-<a href=\"modelica://Buildings.Utilities.Math.Functions\">
-Buildings.Utilities.Math.Functions</a>.
+<code>Buildings.Utilities.Math.Functions</code>.
 </li>
 <li>
 Fixed sign error in
 <code>Buildings.Fluid.Storage.BaseClasses.Stratifier</code>
 which caused a wrong energy balance in
-<a href=\"modelica://Buildings.Fluid.Storage.StratifiedEnhanced\">
-Buildings.Fluid.Storage.StratifiedEnhanced</a>.
+<code>Buildings.Fluid.Storage.StratifiedEnhanced</code>.
 </li>
 <li>
 Renamed
@@ -8163,8 +8066,7 @@ to have the same nomenclatures as is used for
 </li>
 <li>
 In
-<a href=\"modelica://Buildings.Fluid/Actuators/BaseClasses/PartialDamperExponential\">
-Buildings.Fluid/Actuators/BaseClasses/PartialDamperExponential</a>,
+<code>Buildings.Fluid/Actuators/BaseClasses/PartialDamperExponential</code>,
 added option to compute linearization near zero based on
 the fraction of nominal flow instead of the Reynolds number.
 This was set as the default, as it leads most reliably to a model
@@ -8177,23 +8079,18 @@ to allow specifying the nominal face velocity instead of the area.
 </li>
 <li>
 Set nominal attribute for pressure drop <code>dp</code> in
-<a href=\"modelica://Buildings.Fluid.BaseClasses.PartialResistance\">
-Buildings.Fluid.BaseClasses.PartialResistance</a> and in its
+<code>Buildings.Fluid.BaseClasses.PartialResistance</code> and in its
 child classes.
 </li>
 <li>
 Added models for chiller
 (<code>Buildings.Fluid.Chillers.Carnot</code>),
 for occupancy
-(<a href=\"modelica://Buildings.Controls.SetPoints.OccupancySchedule\">
-Buildings.Controls.SetPoints.OccupancySchedule</a>) and for
+(<code>Buildings.Controls.SetPoints.OccupancySchedule</code>) and for
 blocks that take a vector as an argument
-(<a href=\"modelica://Buildings.Utilities.Math.Min\">
-Buildings.Utilities.Math.Min</a>,
-<a href=\"modelica://Buildings.Utilities.Math.Max\">
-Buildings.Utilities.Math.Max</a>, and
-<a href=\"modelica://Buildings.Utilities.Math.Average\">
-Buildings.Utilities.Math.Average</a>).
+(<code>Buildings.Utilities.Math.Min</code>,
+<code>Buildings.Utilities.Math.Max</code>, and
+<code>Buildings.Utilities.Math.Average</code>).
 </li>
 <li>
 Changed various variable names to be consistent with naming
@@ -8212,9 +8109,8 @@ convention used in Modelica.Fluid 1.0.
 Updated library to Modelica.Fluid 1.0.
 </li>
 <li>
-Moved most examples from package <a href=\"modelica://Buildings.Fluid.Examples\">
-Buildings.Fluid.Examples</a> to the example directory in the package of the
-individual model.
+Moved most examples from package <code>Buildings.Fluid.Examples</code> to the
+example directory in the package of the individual model.
 </li>
 <li>
 Renamed package <code>Buildings.Utilites.Controls</code> to
@@ -8222,17 +8118,16 @@ Renamed package <code>Buildings.Utilites.Controls</code> to
 </li>
 <li>
 Introduced packages
-<a href=\"modelica://Buildings.Controls\">Buildings.Controls</a>,
-<a href=\"modelica://Buildings.HeatTransfer\">Buildings.HeatTransfer</a>
+<code>Buildings.Controls</code>,
+<code>Buildings.HeatTransfer</code>
 (which contains models for heat transfer that generally does not involve
 modeling of the fluid flow),
-<a href=\"modelica://Buildings.Fluid.Boilers\">Buildings.Fluid.Boilers</a> and
-<a href=\"modelica://Buildings.Fluid.HeatExchangers.Radiators\">
-Buildings.Fluid.HeatExchangers.Radiators</a>.
+<code>Buildings.Fluid.Boilers</code> and
+<code>Buildings.Fluid.HeatExchangers.Radiators</code>.
 </li>
 <li>
-Changed valve models in <a href=\"modelica://Buildings.Fluid.Actuators.Valves\">
-Buildings.Fluid.Actuators.Valves</a> so that <code>Kv</code> or <code>Cv</code> can
+Changed valve models in <code>Buildings.Fluid.Actuators.Valves</code> so that
+<code>Kv</code> or <code>Cv</code> can
 be used as the flow coefficient (in [m3/h] or [USG/min]).
 </li>
 </ul>
@@ -8245,14 +8140,12 @@ be used as the flow coefficient (in [m3/h] or [USG/min]).
                    "<html>
 <ul>
 <li>
-Added package <a href=\"modelica://Buildings.Fluid.Storage\">
-Buildings.Fluid.Storage</a>
+Added package <code>Buildings.Fluid.Storage</code>
 with models for thermal energy storage.
 <li>
 Added a steady-state model for a heat and moisture exchanger with
 constant effectiveness.
-See <a href=\"modelica://Buildings.Fluid.MassExchangers.ConstantEffectiveness\">
-Buildings.Fluid.MassExchangers.ConstantEffectiveness</a>
+See <code>Buildings.Fluid.MassExchangers.ConstantEffectiveness</code>
 </li>
 <li>
 Added package <code>Buildings.Utilities.Reports</code>.
@@ -8268,17 +8161,17 @@ The package contains models that facilitate reporting.
                    "<html>
 <ul>
 <li>
-Added package <a href=\"modelica://Buildings.Fluid.Sources\">Buildings.Fluid.Sources</a>.
+Added package <code>Buildings.Fluid.Sources</code>.
 The package contains models for modeling species that
 do not affect the medium balance of volumes. This can be used to track
 for example carbon dioxide or other species that have a small concentration.
 </li>
 <li>
-The package <a href=\"modelica://Buildings.Fluid.Actuators.Motors\">Buildings.Fluid.Actuators.Motors</a> has been added.
+The package <code>Buildings.Fluid.Actuators.Motors</code> has been added.
 The package contains a motor model for valves and dampers.
 </li>
 <li>
-The package <a href=\"modelica://Buildings.Media\">Buildings.Media</a> has been reorganized and
+The package <code>Buildings.Media</code> has been reorganized and
 the new medium model
 <code>Buildings.Media.GasesPTDecoupled.MoistAir</code>
 has been added.
@@ -8288,8 +8181,7 @@ The bugs are fixed by using a new
 base class
 <code>Buildings.Media.Interfaces.PartialSimpleIdealGasMedium</code>
  (that fixes the bugs) instead of
-<a href=\"modelica://Modelica.Media.Interfaces.PartialSimpleIdealGasMedium\">
-Modelica.Media.Interfaces.PartialSimpleIdealGasMedium</a>.
+<code>Modelica.Media.Interfaces.PartialSimpleIdealGasMedium</code>.
 In the original implementation, initial states of fluid volumes can be far away from
 the steady-state value because of an inconsistent implementation of the enthalpy
 and internal energy.
@@ -8297,7 +8189,7 @@ When the <code>Buildings</code> library is upgraded to
 to Modelica 3.0.0, it should be safe to remove this bug fix.
 </li>
 <li>
-The package <a href=\"modelica://Buildings.Fluid.HeatExchangers\">Buildings.Fluid.HeatExchangers</a>
+The package <code>Buildings.Fluid.HeatExchangers</code>
 has been revised and several models have been renamed.
 The heat exchanger models have been revised to allow computing the fluid volumes either
 dynamically, or in steady-state.
@@ -8344,12 +8236,12 @@ First release of the library.
 <p>
 This version contains basic models for modeling building HVAC systems.
 It also contains new medium models in the package
-<a href=\"modelica://Buildings.Media\">Buildings.Media</a>. These medium models
+<code>Buildings.Media</code>. These medium models
 have simpler property functions than the ones from
-<a href=\"modelica://Modelica.Media\">Modelica.Media</a>. For example,
+<code>Modelica.Media</code>. For example,
 there is medium model with constant heat capacity which is often sufficiently
 accurate for building HVAC simulation, in contrast to the more detailed models
-from <a href=\"modelica://Modelica.Media\">Modelica.Media</a> that are valid in
+from <code>Modelica.Media</code> that are valid in
 a larger temperature range, at the expense of introducing non-linearities due
 to the medium properties.
 </p>


### PR DESCRIPTION
This closes #2199. 

- [x] fixed broken links in release note,
- [x] in release notes, avoided using hyperlinks like`<a href=\"modelica://xxx` to refer class,
- [x] fixed broken link in single zone VAV controller.