### PR TITLE
Revised implementation to consistently use the parameter startTime

### DIFF
--- a/Buildings/ThermalZones/EnergyPlus/Actuator.mo
+++ b/Buildings/ThermalZones/EnergyPlus/Actuator.mo
@@ -43,7 +43,7 @@ initial equation
     "Use of pre-compiled FMU is not supported for block Actuator.");
   Buildings.ThermalZones.EnergyPlus.BaseClasses.inputVariableInitialize(
     adapter=adapter,
-    startTime=time);
+    startTime=startTime);
 equation
   y=Buildings.ThermalZones.EnergyPlus.BaseClasses.inputVariableExchange(
     adapter,

--- a/Buildings/ThermalZones/EnergyPlus/BaseClasses/FMUZoneAdapter.mo
+++ b/Buildings/ThermalZones/EnergyPlus/BaseClasses/FMUZoneAdapter.mo
@@ -146,7 +146,7 @@ initial equation
   counter=0;
   (AFlo,V,mSenFac)=Buildings.ThermalZones.EnergyPlus.BaseClasses.zoneInitialize(
     adapter=adapter,
-    startTime=time);
+    startTime=startTime);
   TAveInlet=293.15;
   m_flow_small=V*3*1.2/3600*1E-10;
 

--- a/Buildings/ThermalZones/EnergyPlus/OutputVariable.mo
+++ b/Buildings/ThermalZones/EnergyPlus/OutputVariable.mo
@@ -45,13 +45,13 @@ initial equation
     "Use of pre-compiled FMU is not supported for block OutputVariable.");
   Buildings.ThermalZones.EnergyPlus.BaseClasses.outputVariableInitialize(
     adapter=adapter,
-    startTime=time);
+    startTime=startTime);
    Buildings.ThermalZones.EnergyPlus.BaseClasses.outputVariableExchange(
        adapter,
        true,
        directDependency_in_internal,
        round(
-         time,
+         startTime,
          1E-3));
 
   counter=0;


### PR DESCRIPTION
This uses the same assignments for all classes that assign `startTime` for the Spawn coupling.