### PR TITLE
Configure sensor to avoid warning

### DIFF
--- a/Buildings/ThermalZones/EnergyPlus/Validation/ThermalZone/TwoIdenticalZones.mo
+++ b/Buildings/ThermalZones/EnergyPlus/Validation/ThermalZone/TwoIdenticalZones.mo
@@ -89,7 +89,8 @@ model TwoIdenticalZones
       "Latent heat gain"
       annotation (Placement(transformation(extent={{-90,0},{-70,20}})));
     Fluid.Sensors.RelativeHumidity senRelHum(
-      redeclare package Medium=Medium)
+      redeclare package Medium=Medium,
+      warnAboutOnePortConnection=false)
       "Relative humidity in the room as computed by Modelica"
       annotation (Placement(transformation(extent={{50,-50},{70,-30}})));
     Modelica.Blocks.Interfaces.RealOutput TAir(


### PR DESCRIPTION
This configuration does not cause any issue, hence the warning can be removed