### PR TITLE
Hide results of synchronization

### DIFF
--- a/Buildings/ThermalZones/EnergyPlus/BaseClasses/Synchronize/ObjectSynchronizer.mo
+++ b/Buildings/ThermalZones/EnergyPlus/BaseClasses/Synchronize/ObjectSynchronizer.mo
@@ -1,7 +1,8 @@
 within Buildings.ThermalZones.EnergyPlus.BaseClasses.Synchronize;
 block ObjectSynchronizer "Block that synchronizes an object"
   outer Buildings.ThermalZones.EnergyPlus.Building building "Reference to outer building model";
-  SynchronizeBuilding synBui "Model that synchronize the Spawn objects";
+  SynchronizeBuilding synBui "Model that synchronize the Spawn objects"
+    annotation (HideResult=true);
 equation
   connect(building.synchronize, synBui.synchronize);
 

--- a/Buildings/ThermalZones/EnergyPlus/Building.mo
+++ b/Buildings/ThermalZones/EnergyPlus/Building.mo
@@ -36,15 +36,16 @@ model Building
     "Weather data bus"
     annotation (Placement(transformation(extent={{90,-10},{110,10}})));
 
-  Buildings.ThermalZones.EnergyPlus.BaseClasses.Synchronize.SynchronizeConnector
-    synchronize
-    "Connector that synchronizes all Spawn objects of this buildings";
 
-  Real synchronization_done = synchronize.done
-    "Intermediate variable as acausal connectors cannot be used in the algorithm section";
-  Real isSynchronized "Flag used to synchronize Spawn objects";
+  BaseClasses.Synchronize.SynchronizeConnector synchronize
+    "Connector that synchronizes all Spawn objects of this buildings"
+    annotation (HideResult=true);
+  Real isSynchronized "Flag used to synchronize Spawn objects"
+    annotation (HideResult=true);
 
 protected
+  Real synchronization_done = synchronize.done
+    "Intermediate variable as acausal connectors cannot be used in the algorithm section";
   Linux64Binaries linux64Binaries if generatePortableFMU
     "Record with binaries";
   record Linux64Binaries


### PR DESCRIPTION
This patch hides the results of the Spawn object synchronization as this is of no interest to users.