### PR TITLE
Added constrained by clause

### DIFF
--- a/Buildings/ThermalZones/EnergyPlus/Examples/SmallOffice/ASHRAE2006Winter.mo
+++ b/Buildings/ThermalZones/EnergyPlus/Examples/SmallOffice/ASHRAE2006Winter.mo
@@ -2,7 +2,9 @@ within Buildings.ThermalZones.EnergyPlus.Examples.SmallOffice;
 model ASHRAE2006Winter
   "Variable air volume flow system with terminal reheat and five thermal zones using a control sequence published by ASHRAE in 2006"
   extends Buildings.Examples.VAVReheat.ASHRAE2006(
-    redeclare replaceable Buildings.ThermalZones.EnergyPlus.Examples.SmallOffice.BaseClasses.Floor flo,
+    redeclare replaceable Buildings.ThermalZones.EnergyPlus.Examples.SmallOffice.BaseClasses.Floor flo
+      constrainedby
+      Buildings.ThermalZones.EnergyPlus.Examples.SmallOffice.BaseClasses.Floor,
     ACHCor=4,
     ACHSou=4,
     ACHEas=6,

--- a/Buildings/ThermalZones/EnergyPlus/Examples/SmallOffice/Guideline36Winter.mo
+++ b/Buildings/ThermalZones/EnergyPlus/Examples/SmallOffice/Guideline36Winter.mo
@@ -2,7 +2,9 @@ within Buildings.ThermalZones.EnergyPlus.Examples.SmallOffice;
 model Guideline36Winter
   "Variable air volume flow system with terminal reheat and five thermal zones controlled using an ASHRAE G36 controller"
   extends Buildings.Examples.VAVReheat.Guideline36(
-    redeclare replaceable Buildings.ThermalZones.EnergyPlus.Examples.SmallOffice.BaseClasses.Floor flo,
+    redeclare replaceable Buildings.ThermalZones.EnergyPlus.Examples.SmallOffice.BaseClasses.Floor flo
+    constrainedby
+      Buildings.ThermalZones.EnergyPlus.Examples.SmallOffice.BaseClasses.Floor,
     ACHCor=4,
     ACHSou=4,
     ACHEas=6,


### PR DESCRIPTION
This avoids the warning 'Access to component cor not recommended, it is not present in constraining type of declaration' in OCT.