### PR TITLE
Renamed parameter in MultiAnd and MultiOr

### DIFF
--- a/Buildings/Air/Systems/SingleZone/VAV/BaseClasses/ControllerChillerDXHeatingEconomizer.mo
+++ b/Buildings/Air/Systems/SingleZone/VAV/BaseClasses/ControllerChillerDXHeatingEconomizer.mo
@@ -217,7 +217,7 @@ model ControllerChillerDXHeatingEconomizer
     final uHigh=0.05)
     "Hysteresis for heating"
     annotation (Placement(transformation(extent={{-30,120},{-10,140}})));
-  Buildings.Controls.OBC.CDL.Logical.MultiOr orFan(nu=3)
+  Buildings.Controls.OBC.CDL.Logical.MultiOr orFan(nin=3)
     "Switch fan on if heating, cooling, or occupied"
     annotation (Placement(transformation(extent={{40,94},{60,114}})));
   Modelica.Blocks.Logical.And and1 "Logical and"

--- a/Buildings/Controls/OBC/ASHRAE/G36_PR1/Generic/SetPoints/GroupStatus.mo
+++ b/Buildings/Controls/OBC/ASHRAE/G36_PR1/Generic/SetPoints/GroupStatus.mo
@@ -161,11 +161,11 @@ protected
     "Longest warm up time"
     annotation (Placement(transformation(extent={{40,130},{60,150}})));
   Buildings.Controls.OBC.CDL.Logical.MultiOr mulOr(
-    final nu=numZon)
+    final nin=numZon)
     "Check if there is any zone that the zone temperature is lower than its occupied heating setpoint"
     annotation (Placement(transformation(extent={{40,90},{60,110}})));
   Buildings.Controls.OBC.CDL.Logical.MultiOr mulOr1(
-    final nu=numZon)
+    final nin=numZon)
     "Check if there is any zone that the zone temperature is higher than its occupied cooling setpoint"
     annotation (Placement(transformation(extent={{40,50},{60,70}})));
   Buildings.Controls.OBC.CDL.Continuous.MultiMax maxTem(
@@ -181,7 +181,7 @@ protected
     final nin=numZon) "Total number of cold zone"
     annotation (Placement(transformation(extent={{40,10},{60,30}})));
   Buildings.Controls.OBC.CDL.Logical.MultiAnd endSetBac(
-   final nu=numZon)
+   final nin=numZon)
     "Check if all zones have ended the setback mode"
     annotation (Placement(transformation(extent={{40,-70},{60,-50}})));
   Buildings.Controls.OBC.CDL.Conversions.BooleanToInteger booToInt1[numZon]
@@ -191,7 +191,7 @@ protected
     final nin=numZon) "Total number of hot zones"
     annotation (Placement(transformation(extent={{40,-100},{60,-80}})));
   Buildings.Controls.OBC.CDL.Logical.MultiAnd endSetUp(
-    final nu=numZon)
+    final nin=numZon)
     "Check if all zones have ended the setup mode"
     annotation (Placement(transformation(extent={{-2,-190},{18,-170}})));
   Buildings.Controls.OBC.CDL.Continuous.MultiSum sumUnoHea(
@@ -235,11 +235,11 @@ protected
     "Minimum time to next occupied period"
     annotation (Placement(transformation(extent={{-60,210},{-40,230}})));
   Buildings.Controls.OBC.CDL.Logical.MultiOr schOcc(
-    final nu=numZon)
+    final nin=numZon)
     "Check if the group should be in occupied mode according to the schedule"
     annotation (Placement(transformation(extent={{-60,250},{-40,270}})));
   Buildings.Controls.OBC.CDL.Logical.MultiOr oveRidOcc(
-    final nu=numZon)
+    final nin=numZon)
     "Check if the group should be in occupied mode according to the zone override"
     annotation (Placement(transformation(extent={{-60,290},{-40,310}})));
   Buildings.Controls.OBC.CDL.Logical.Or groOcc

--- a/Buildings/Controls/OBC/CDL/Interfaces/BooleanInput.mo
+++ b/Buildings/Controls/OBC/CDL/Interfaces/BooleanInput.mo
@@ -1,7 +1,24 @@
 within Buildings.Controls.OBC.CDL.Interfaces;
 connector BooleanInput=input Boolean
   "'input Boolean' as connector"
-  annotation (defaultComponentName="u",Icon(graphics={Polygon(lineColor={255,0,255},fillColor={255,0,255},fillPattern=FillPattern.Solid,points={{0,50},{100,0},{0,-50}})},coordinateSystem(extent={{-100,-100},{100,100}},preserveAspectRatio=true,initialScale=0.2)),Diagram(coordinateSystem(preserveAspectRatio=true,initialScale=0.2,extent={{-100,-100},{100,100}}),graphics={Polygon(points={{0,50},{100,0},{0,-50},{0,50}},lineColor={255,0,255},fillColor={255,0,255},fillPattern=FillPattern.Solid),Text(extent={{-10,85},{-10,60}},lineColor={255,0,255},textString="%name")}),Documentation(info="<html>
+annotation (defaultComponentName="u",
+ Icon(graphics={Polygon(lineColor={255,0,255},
+                        fillColor={255,0,255},
+                        fillPattern = FillPattern.Solid,
+                        points={{0,50},{100,0},{0,-50}})},
+      coordinateSystem(extent={{-100,-100},{100,100}},
+                       preserveAspectRatio=true,
+                       initialScale=0.2)),
+ Diagram(coordinateSystem(preserveAspectRatio=true,
+                          initialScale=0.2,
+                          extent={{-100,-100},{100,100}}),
+         graphics={Polygon(points={{0,50},{100,0},{0,-50},{0,50}},
+                           lineColor={255,0,255},
+                           fillColor={255,0,255},fillPattern = FillPattern.Solid),
+                   Text(extent={{-10,85},{-10,60}},
+                        lineColor={255,0,255},
+                        textString="%name")}),
+Documentation(info="<html>
 <p>
 Connector with one input signal of type Boolean.
 </p>

--- a/Buildings/Controls/OBC/CDL/Interfaces/BooleanOutput.mo
+++ b/Buildings/Controls/OBC/CDL/Interfaces/BooleanOutput.mo
@@ -1,7 +1,25 @@
 within Buildings.Controls.OBC.CDL.Interfaces;
 connector BooleanOutput=output Boolean
   "'output Boolean' as connector"
-  annotation (defaultComponentName="y",Icon(coordinateSystem(preserveAspectRatio=true,initialScale=0.2,extent={{-100,-100},{100,100}}),graphics={Polygon(lineColor={255,0,255},fillColor={255,255,255},fillPattern=FillPattern.Solid,points={{-100,50},{0,0},{-100,-50}})}),Diagram(coordinateSystem(preserveAspectRatio=true,initialScale=0.2,extent={{-100,-100},{100,100}}),graphics={Polygon(points={{-100,50},{0,0},{-100,-50},{-100,50}},lineColor={255,0,255},fillColor={255,255,255},fillPattern=FillPattern.Solid),Text(extent={{30,110},{30,60}},lineColor={255,0,255},textString="%name")}),Documentation(info="<html>
+annotation (defaultComponentName="y",
+ Icon(coordinateSystem(preserveAspectRatio=true,
+                       initialScale=0.2,
+                       extent={{-100,-100},{100,100}}),
+      graphics={Polygon(lineColor={255,0,255},
+                        fillColor={255,255,255},
+                        fillPattern= FillPattern.Solid,
+                        points={{-100,50},{0,0},{-100,-50}})}),
+ Diagram(coordinateSystem(preserveAspectRatio=true,
+                          initialScale=0.2,
+                          extent={{-100,-100},{100,100}}),
+         graphics={Polygon(points={{-100,50},{0,0},{-100,-50},{-100,50}},
+                           lineColor={255,0,255},
+                           fillColor={255,255,255},
+                           fillPattern= FillPattern.Solid),
+                   Text(extent={{30,110},{30,60}},
+                        lineColor={255,0,255},
+                        textString="%name")}),
+Documentation(info="<html>
 <p>
 Connector with one output signal of type Boolean.
 </p>

--- a/Buildings/Controls/OBC/CDL/Interfaces/DayTypeInput.mo
+++ b/Buildings/Controls/OBC/CDL/Interfaces/DayTypeInput.mo
@@ -1,7 +1,25 @@
 within Buildings.Controls.OBC.CDL.Interfaces;
 connector DayTypeInput=input Types.Day
   "Input connector for day types"
-  annotation (defaultComponentName="u",Icon(coordinateSystem(preserveAspectRatio=true,initialScale=0.2,extent={{-100.0,-100.0},{100.0,100.0}}),graphics={Polygon(lineColor={0,127,0},fillColor={0,127,0},fillPattern=FillPattern.Solid,points={{0,50},{100,0},{0,-50}})}),Diagram(coordinateSystem(preserveAspectRatio=true,initialScale=0.2,extent={{-100.0,-100.0},{100.0,100.0}}),graphics={Polygon(lineColor={0,127,0},fillColor={0,127,0},fillPattern=FillPattern.Solid,points={{0,50},{100,0},{0,-50}}),Text(lineColor={0,127,0},extent={{-10.0,60.0},{-10.0,85.0}},textString="%name")}),Documentation(info="<html>
+annotation (defaultComponentName="u",
+ Icon(coordinateSystem(preserveAspectRatio=true,
+                       initialScale=0.2,
+                       extent={{-100.0,-100.0},{100.0,100.0}}),
+      graphics={Polygon(lineColor={0,127,0},
+                        fillColor={0,127,0},
+                        fillPattern=FillPattern.Solid,
+                        points={{0,50},{100,0},{0,-50}})}),
+ Diagram(coordinateSystem(preserveAspectRatio=true,
+                          initialScale=0.2,
+                          extent={{-100.0,-100.0},{100.0,100.0}}),
+         graphics={Polygon(lineColor={0,127,0},
+                           fillColor={0,127,0},
+                           fillPattern=FillPattern.Solid,
+                           points={{0,50},{100,0},{0,-50}}),
+                   Text(lineColor={0,127,0},
+                        extent={{-10.0,60.0},{-10.0,85.0}},
+                        textString="%name")}),
+Documentation(info="<html>
 <p>
 Connector with one input signal of type
 <a href=\"modelica://Buildings.Controls.OBC.CDL.Types.Day\">

--- a/Buildings/Controls/OBC/CDL/Interfaces/DayTypeOutput.mo
+++ b/Buildings/Controls/OBC/CDL/Interfaces/DayTypeOutput.mo
@@ -1,7 +1,25 @@
 within Buildings.Controls.OBC.CDL.Interfaces;
 connector DayTypeOutput=output Types.Day
   "Output connector for day types"
-  annotation (defaultComponentName="y",Icon(coordinateSystem(preserveAspectRatio=true,initialScale=0.2,extent={{-100.0,-100.0},{100.0,100.0}}),graphics={Polygon(lineColor={0,127,0},fillColor={255,255,255},fillPattern=FillPattern.Solid,points={{-100,50},{0,0},{-100,-50}})}),Diagram(coordinateSystem(preserveAspectRatio=true,initialScale=0.2,extent={{-100.0,-100.0},{100.0,100.0}}),graphics={Polygon(lineColor={0,127,0},fillColor={255,255,255},fillPattern=FillPattern.Solid,points={{-100.0,50.0},{0.0,0.0},{-100.0,-50.0}}),Text(lineColor={0,127,0},extent={{30.0,60.0},{30.0,110.0}},textString="%name")}),Documentation(info="<html>
+annotation (defaultComponentName="y",
+ Icon(coordinateSystem(preserveAspectRatio=true,
+                       initialScale=0.2,
+                       extent={{-100.0,-100.0},{100.0,100.0}}),
+      graphics={Polygon(lineColor={0,127,0},
+                        fillColor={255,255,255},
+                        fillPattern=FillPattern.Solid,
+                        points={{-100,50},{0,0},{-100,-50}})}),
+ Diagram(coordinateSystem(preserveAspectRatio=true,
+                          initialScale=0.2,
+                          extent={{-100.0,-100.0},{100.0,100.0}}),
+         graphics={Polygon(lineColor={0,127,0},
+                           fillColor={255,255,255},
+                           fillPattern=FillPattern.Solid,
+                           points={{-100.0,50.0},{0.0,0.0},{-100.0,-50.0}}),
+                   Text(lineColor={0,127,0},
+                        extent={{30.0,60.0},{30.0,110.0}},
+                        textString="%name")}),
+Documentation(info="<html>
 <p>
 Connector with one output signal of type
 <a href=\"modelica://Buildings.Controls.OBC.CDL.Types.Day\">

--- a/Buildings/Controls/OBC/CDL/Interfaces/IntegerInput.mo
+++ b/Buildings/Controls/OBC/CDL/Interfaces/IntegerInput.mo
@@ -1,7 +1,25 @@
 within Buildings.Controls.OBC.CDL.Interfaces;
 connector IntegerInput=input Integer
   "'input Integer' as connector"
-  annotation (defaultComponentName="u",Icon(graphics={Polygon(lineColor={255,127,0},fillColor={255,127,0},fillPattern=FillPattern.Solid,points={{0,50},{100,0},{0,-50}})},coordinateSystem(extent={{-100,-100},{100,100}},preserveAspectRatio=true,initialScale=0.2)),Diagram(coordinateSystem(preserveAspectRatio=true,initialScale=0.2,extent={{-100,-100},{100,100}}),graphics={Polygon(points={{0,50},{100,0},{0,-50},{0,50}},lineColor={255,127,0},fillColor={255,127,0},fillPattern=FillPattern.Solid),Text(extent={{-10,85},{-10,60}},lineColor={255,127,0},textString="%name")}),Documentation(info="<html>
+annotation (defaultComponentName="u",
+ Icon(graphics={Polygon(lineColor={255,127,0},
+                        fillColor={255,127,0},
+                        fillPattern=FillPattern.Solid,
+                        points={{0,50},{100,0},{0,-50}})},
+      coordinateSystem(extent={{-100,-100},{100,100}},
+                       preserveAspectRatio=true,
+                       initialScale=0.2)),
+ Diagram(coordinateSystem(preserveAspectRatio=true,
+                          initialScale=0.2,
+                          extent={{-100,-100},{100,100}}),
+         graphics={Polygon(points={{0,50},{100,0},{0,-50},{0,50}},
+                           lineColor={255,127,0},
+                           fillColor={255,127,0},
+                           fillPattern=FillPattern.Solid),
+                   Text(extent={{-10,85},{-10,60}},
+                        lineColor={255,127,0},
+                        textString="%name")}),
+Documentation(info="<html>
 <p>
 Connector with one input signal of type Integer.
 </p>

--- a/Buildings/Controls/OBC/CDL/Interfaces/IntegerOutput.mo
+++ b/Buildings/Controls/OBC/CDL/Interfaces/IntegerOutput.mo
@@ -1,7 +1,25 @@
 within Buildings.Controls.OBC.CDL.Interfaces;
 connector IntegerOutput=output Integer
   "'output Integer' as connector"
-  annotation (defaultComponentName="y",Icon(coordinateSystem(preserveAspectRatio=true,initialScale=0.2,extent={{-100,-100},{100,100}}),graphics={Polygon(lineColor={255,127,0},fillColor={255,255,255},fillPattern=FillPattern.Solid,points={{-100,50},{0,0},{-100,-50}})}),Diagram(coordinateSystem(preserveAspectRatio=true,initialScale=0.2,extent={{-100,-100},{100,100}}),graphics={Polygon(points={{-100,50},{0,0},{-100,-50},{-100,50}},lineColor={255,127,0},fillColor={255,255,255},fillPattern=FillPattern.Solid),Text(extent={{30,110},{30,60}},lineColor={255,127,0},textString="%name")}),Documentation(info="<html>
+annotation (defaultComponentName="y",
+ Icon(coordinateSystem(preserveAspectRatio=true,
+                       initialScale=0.2,
+                       extent={{-100,-100},{100,100}}),
+      graphics={Polygon(lineColor={255,127,0},
+                        fillColor={255,255,255},
+                        fillPattern=FillPattern.Solid,
+                        points={{-100,50},{0,0},{-100,-50}})}),
+ Diagram(coordinateSystem(preserveAspectRatio=true,
+                          initialScale=0.2,
+                          extent={{-100,-100},{100,100}}),
+         graphics={Polygon(points={{-100,50},{0,0},{-100,-50},{-100,50}},
+                           lineColor={255,127,0},
+                           fillColor={255,255,255},
+                           fillPattern=FillPattern.Solid),
+                   Text(extent={{30,110},{30,60}},
+                        lineColor={255,127,0},
+                        textString="%name")}),
+Documentation(info="<html>
 <p>
 Connector with one output signal of type Integer.
 </p>

--- a/Buildings/Controls/OBC/CDL/Interfaces/RealInput.mo
+++ b/Buildings/Controls/OBC/CDL/Interfaces/RealInput.mo
@@ -1,7 +1,25 @@
 within Buildings.Controls.OBC.CDL.Interfaces;
 connector RealInput=input Real
   "'input Real' as connector"
-  annotation (defaultComponentName="u",Icon(graphics={Polygon(lineColor={0,0,127},fillColor={0,0,127},fillPattern=FillPattern.Solid,points={{0,50},{100,0},{0,-50}})},coordinateSystem(extent={{-100.0,-100.0},{100.0,100.0}},preserveAspectRatio=true,initialScale=0.2)),Diagram(coordinateSystem(preserveAspectRatio=true,initialScale=0.2,extent={{-100.0,-100.0},{100.0,100.0}}),graphics={Polygon(lineColor={0,0,127},fillColor={0,0,127},fillPattern=FillPattern.Solid,points={{0.0,50.0},{100.0,0.0},{0.0,-50.0},{0.0,50.0}}),Text(lineColor={0,0,127},extent={{-10.0,60.0},{-10.0,85.0}},textString="%name")}),Documentation(info="<html>
+annotation (defaultComponentName="u",
+ Icon(graphics={Polygon(lineColor={0,0,127},
+                        fillColor={0,0,127},
+                        fillPattern=FillPattern.Solid,
+                        points={{0,50},{100,0},{0,-50}})},
+      coordinateSystem(extent={{-100.0,-100.0},{100.0,100.0}},
+                       preserveAspectRatio=true,
+                       initialScale=0.2)),
+ Diagram(coordinateSystem(preserveAspectRatio=true,
+                          initialScale=0.2,
+                          extent={{-100.0,-100.0},{100.0,100.0}}),
+         graphics={Polygon(lineColor={0,0,127},
+                           fillColor={0,0,127},
+                           fillPattern=FillPattern.Solid,
+                           points={{0.0,50.0},{100.0,0.0},{0.0,-50.0},{0.0,50.0}}),
+                   Text(lineColor={0,0,127},
+                        extent={{-10.0,60.0},{-10.0,85.0}},
+                        textString="%name")}),
+Documentation(info="<html>
 <p>
 Connector with one input signal of type Real.
 </p>

--- a/Buildings/Controls/OBC/CDL/Interfaces/RealOutput.mo
+++ b/Buildings/Controls/OBC/CDL/Interfaces/RealOutput.mo
@@ -1,7 +1,25 @@
 within Buildings.Controls.OBC.CDL.Interfaces;
 connector RealOutput=output Real
   "'output Real' as connector"
-  annotation (defaultComponentName="y",Icon(coordinateSystem(preserveAspectRatio=true,initialScale=0.2,extent={{-100.0,-100.0},{100.0,100.0}}),graphics={Polygon(lineColor={0,0,127},fillColor={255,255,255},fillPattern=FillPattern.Solid,points={{-100,50},{0,0},{-100,-50}})}),Diagram(coordinateSystem(preserveAspectRatio=true,initialScale=0.2,extent={{-100.0,-100.0},{100.0,100.0}}),graphics={Polygon(lineColor={0,0,127},fillColor={255,255,255},fillPattern=FillPattern.Solid,points={{-100.0,50.0},{0.0,0.0},{-100.0,-50.0}}),Text(lineColor={0,0,127},extent={{30.0,60.0},{30.0,110.0}},textString="%name")}),Documentation(info="<html>
+annotation (defaultComponentName="y",
+ Icon(coordinateSystem(preserveAspectRatio=true,
+                       initialScale=0.2,
+                       extent={{-100.0,-100.0},{100.0,100.0}}),
+      graphics={Polygon(lineColor={0,0,127},
+                        fillColor={255,255,255},
+                        fillPattern=FillPattern.Solid,
+                        points={{-100,50},{0,0},{-100,-50}})}),
+ Diagram(coordinateSystem(preserveAspectRatio=true,
+                          initialScale=0.2,
+                          extent={{-100.0,-100.0},{100.0,100.0}}),
+         graphics={Polygon(lineColor={0,0,127},
+                           fillColor={255,255,255},
+                           fillPattern=FillPattern.Solid,
+                           points={{-100.0,50.0},{0.0,0.0},{-100.0,-50.0}}),
+                   Text(lineColor={0,0,127},
+                        extent={{30.0,60.0},{30.0,110.0}},
+                        textString="%name")}),
+Documentation(info="<html>
 <p>
 Connector with one output signal of type Real.
 </p>

--- a/Buildings/Controls/OBC/CDL/Logical/MultiAnd.mo
+++ b/Buildings/Controls/OBC/CDL/Logical/MultiAnd.mo
@@ -83,8 +83,13 @@ Buildings.Controls.OBC.CDL.Logical.Validation.MultiAnd</a>
 for an example.
 </p>
 </html>",
-      revisions="<html>
+revisions="<html>
 <ul>
+<li>
+July 26, 2021, by Jianjun Hu:<br/>
+Renamed parameter <code>nu</code> to <code>nin</code>. This is for
+<a href=\"https://github.com/lbl-srg/modelica-buildings/issues/2580\">issue 2580</a>.
+</li>
 <li>
 June 28, 2017, by Jianjun Hu:<br/>
 First implementation. This is for

--- a/Buildings/Controls/OBC/CDL/Logical/MultiAnd.mo
+++ b/Buildings/Controls/OBC/CDL/Logical/MultiAnd.mo
@@ -1,11 +1,11 @@
 within Buildings.Controls.OBC.CDL.Logical;
 block MultiAnd
   "Logical MultiAnd, y = u[1] and u[2] and u[3] and ..."
-  parameter Integer nu(
+  parameter Integer nin(
     min=0)=0
     "Number of input connections"
     annotation (Dialog(connectorSizing=true),HideResult=true);
-  Interfaces.BooleanInput u[nu]
+  Interfaces.BooleanInput u[nin]
     "Connector of Boolean input signals"
     annotation (Placement(transformation(extent={{-140,70},{-100,-70}})));
   Interfaces.BooleanOutput y
@@ -13,7 +13,7 @@ block MultiAnd
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 protected
-  Boolean uTemp[nu]
+  Boolean uTemp[nin]
     "Temporary variable";
 
 equation
@@ -26,8 +26,9 @@ equation
       1) loop
       uTemp[i]=u[i] and uTemp[i-1];
     end for;
-    y=uTemp[nu];
-  elseif(size(
+    y=uTemp[nin];
+  elseif
+        (size(
     u,
     1) == 1) then
     uTemp[1]=u[1];

--- a/Buildings/Controls/OBC/CDL/Logical/MultiOr.mo
+++ b/Buildings/Controls/OBC/CDL/Logical/MultiOr.mo
@@ -83,8 +83,13 @@ Buildings.Controls.OBC.CDL.Logical.Validation.MultiOr</a>
 for an example.
 </p>
 </html>",
-      revisions="<html>
+revisions="<html>
 <ul>
+<li>
+July 26, 2021, by Jianjun Hu:<br/>
+Renamed parameter <code>nu</code> to <code>nin</code>. This is for
+<a href=\"https://github.com/lbl-srg/modelica-buildings/issues/2580\">issue 2580</a>.
+</li>
 <li>
 June 6, 2019, by Milica Grahovac:<br/>
 First implementation.

--- a/Buildings/Controls/OBC/CDL/Logical/MultiOr.mo
+++ b/Buildings/Controls/OBC/CDL/Logical/MultiOr.mo
@@ -1,11 +1,11 @@
 within Buildings.Controls.OBC.CDL.Logical;
 block MultiOr
   "Logical MultiOr, y = u[1] or u[2] or u[3] or ..."
-  parameter Integer nu(
+  parameter Integer nin(
     min=0)=0
     "Number of input connections"
     annotation (Dialog(connectorSizing=true),HideResult=true);
-  Interfaces.BooleanInput u[nu]
+  Interfaces.BooleanInput u[nin]
     "Connector of Boolean input signals"
     annotation (Placement(transformation(extent={{-140,70},{-100,-70}})));
   Interfaces.BooleanOutput y
@@ -13,7 +13,7 @@ block MultiOr
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 protected
-  Boolean uTemp[nu]
+  Boolean uTemp[nin]
     "Temporary variable";
 
 equation
@@ -26,8 +26,9 @@ equation
       1) loop
       uTemp[i]=u[i] or uTemp[i-1];
     end for;
-    y=uTemp[nu];
-  elseif(size(
+    y=uTemp[nin];
+  elseif
+        (size(
     u,
     1) == 1) then
     uTemp[1]=u[1];

--- a/Buildings/Controls/OBC/CDL/Logical/Validation/MultiAnd.mo
+++ b/Buildings/Controls/OBC/CDL/Logical/Validation/MultiAnd.mo
@@ -5,15 +5,15 @@ model MultiAnd
     "Logical and with multiple inputs: 0 input"
     annotation (Placement(transformation(extent={{40,60},{60,80}})));
   Buildings.Controls.OBC.CDL.Logical.MultiAnd mulAnd1(
-    nu=1)
+    nin=1)
     "Logical 'MultiAnd': 1 input connection y=u"
     annotation (Placement(transformation(extent={{40,20},{60,40}})));
   Buildings.Controls.OBC.CDL.Logical.MultiAnd mulAnd2(
-    nu=2)
+    nin=2)
     "Logical 'MultiAnd': 2 input connections y=and(u1, u2)"
     annotation (Placement(transformation(extent={{40,-10},{60,10}})));
   Buildings.Controls.OBC.CDL.Logical.MultiAnd mulAnd5(
-    nu=5)
+    nin=5)
     "Logical 'MultiAnd': 5 input connections y=and(u1, u2, ..., u5)"
     annotation (Placement(transformation(extent={{40,-40},{60,-20}})));
   Buildings.Controls.OBC.CDL.Logical.Sources.Pulse booPul1(
@@ -50,7 +50,8 @@ equation
   connect(booPul3.y,mulAnd5.u[3])
     annotation (Line(points={{-38,0},{0,0},{0,-30},{38,-30}},color={255,0,255}));
   connect(booPul4.y,mulAnd5.u[4])
-    annotation (Line(points={{-38,-30},{-38,-30},{-4,-30},{-4,-32},{-4,-32},{-4,-32.8},{38,-32.8}},color={255,0,255}));
+    annotation (Line(points={{-38,-30},{-38,-30},{-4,-30},{-4,-32},{-4,-32},{-4,
+          -32.8},{38,-32.8}},                                                                      color={255,0,255}));
   connect(booPul5.y,mulAnd5.u[5])
     annotation (Line(points={{-38,-60},{-38,-60},{20,-60},{20,-35.6},{38,-35.6}},color={255,0,255}));
   connect(booPul1.y,mulAnd2.u[1])

--- a/Buildings/Controls/OBC/CDL/Logical/Validation/MultiOr.mo
+++ b/Buildings/Controls/OBC/CDL/Logical/Validation/MultiOr.mo
@@ -5,15 +5,15 @@ model MultiOr
     "Logical 'MultiOr': 1 input connection y=u"
     annotation (Placement(transformation(extent={{40,60},{60,80}})));
   Buildings.Controls.OBC.CDL.Logical.MultiOr mulOr1(
-    nu=1)
+    nin=1)
     "Logical 'MultiOr': 1 input connection y=u"
     annotation (Placement(transformation(extent={{40,20},{60,40}})));
   Buildings.Controls.OBC.CDL.Logical.MultiOr mulOr2(
-    nu=2)
+    nin=2)
     "Logical 'MultiOr': 2 input connections y=and(u1, u2)"
     annotation (Placement(transformation(extent={{40,-10},{60,10}})));
   Buildings.Controls.OBC.CDL.Logical.MultiOr mulOr5(
-    nu=5)
+    nin=5)
     "Logical 'MultiOr': 5 input connections y=and(u1, u2, ..., u5)"
     annotation (Placement(transformation(extent={{40,-40},{60,-20}})));
   Buildings.Controls.OBC.CDL.Logical.Sources.Pulse booPul1(
@@ -44,21 +44,22 @@ model MultiOr
 
 equation
   connect(booPul1.y,mulOr5.u[1])
-    annotation (Line(points={{-39,60},{-39,60},{20,60},{20,-24.4},{38,-24.4}},color={255,0,255}));
+    annotation (Line(points={{-38,60},{-38,60},{20,60},{20,-24.4},{38,-24.4}},color={255,0,255}));
   connect(booPul2.y,mulOr5.u[2])
-    annotation (Line(points={{-39,30},{14,30},{14,-27.2},{38,-27.2}},color={255,0,255}));
+    annotation (Line(points={{-38,30},{14,30},{14,-27.2},{38,-27.2}},color={255,0,255}));
   connect(booPul3.y,mulOr5.u[3])
-    annotation (Line(points={{-39,0},{0,0},{0,-30},{38,-30}},color={255,0,255}));
+    annotation (Line(points={{-38,0},{0,0},{0,-30},{38,-30}},color={255,0,255}));
   connect(booPul4.y,mulOr5.u[4])
-    annotation (Line(points={{-39,-30},{-39,-30},{-4,-30},{-4,-32},{-4,-32},{-4,-32.8},{38,-32.8}},color={255,0,255}));
+    annotation (Line(points={{-38,-30},{-38,-30},{-4,-30},{-4,-32},{-4,-32},{-4,
+          -32.8},{38,-32.8}},                                                                      color={255,0,255}));
   connect(booPul5.y,mulOr5.u[5])
-    annotation (Line(points={{-39,-60},{-39,-60},{20,-60},{20,-35.6},{38,-35.6}},color={255,0,255}));
+    annotation (Line(points={{-38,-60},{-38,-60},{20,-60},{20,-35.6},{38,-35.6}},color={255,0,255}));
   connect(booPul1.y,mulOr2.u[1])
-    annotation (Line(points={{-39,60},{-39,60},{20,60},{20,3.5},{38,3.5}},color={255,0,255}));
+    annotation (Line(points={{-38,60},{-38,60},{20,60},{20,3.5},{38,3.5}},color={255,0,255}));
   connect(booPul2.y,mulOr2.u[2])
-    annotation (Line(points={{-39,30},{-39,30},{14,30},{14,-3.5},{38,-3.5}},color={255,0,255}));
+    annotation (Line(points={{-38,30},{-38,30},{14,30},{14,-3.5},{38,-3.5}},color={255,0,255}));
   connect(booPul1.y,mulOr1.u[1])
-    annotation (Line(points={{-39,60},{20,60},{20,30},{38,30}},color={255,0,255}));
+    annotation (Line(points={{-38,60},{20,60},{20,30},{38,30}},color={255,0,255}));
   annotation (
     experiment(
       StopTime=10.0,

--- a/Buildings/Experimental/DHC/EnergyTransferStations/Combined/Generation5/Controls/SideHot.mo
+++ b/Buildings/Experimental/DHC/EnergyTransferStations/Combined/Generation5/Controls/SideHot.mo
@@ -124,7 +124,7 @@ block SideHot
     "At least one signal is non zero"
     annotation (Placement(transformation(extent={{-160,-130},{-140,-110}})));
   Buildings.Controls.OBC.CDL.Logical.MultiAnd mulAnd(
-    nu=3)
+    nin=3)
     annotation (Placement(transformation(extent={{-40,-90},{-20,-70}})));
   Buildings.Controls.OBC.CDL.Continuous.AddParameter addDea(
     p=dTDea,

--- a/Buildings/Resources/Scripts/Dymola/ConvertBuildings_from_8_to_9.0.0.mos
+++ b/Buildings/Resources/Scripts/Dymola/ConvertBuildings_from_8_to_9.0.0.mos
@@ -4,3 +4,11 @@
 clear
 
 convertClear();
+
+// Conversion for https://github.com/lbl-srg/modelica-buildings/issues/2580
+convertElement(
+    "Buildings.Controls.OBC.CDL.Logical.MultiAnd",
+    "nu", "nin");
+convertElement(
+    "Buildings.Controls.OBC.CDL.Logical.MultiOr",
+    "nu", "nin");

--- a/Buildings/package.mo
+++ b/Buildings/package.mo
@@ -312,8 +312,8 @@ have been <b style=\"color:blue\">improved</b> in a
                        Buildings.Controls.OBC.CDL.Logical.MultiOr
     </td>
     <td valign=\"top\">Renamed parameter <code>nu</code> to <code>nin</code>.
-                 This is for <a href=\"https://github.com/lbl-srg/modelica-buildings/issues/2580\">issue 2580</a>.
-    </td>
+                 This is for <a href=\"https://github.com/lbl-srg/modelica-buildings/issues/2580\">issue 2580</a>.<br/>
+                 For Dymola, a conversion script makes this change.</td>
 </tr>
 </table>
 <!-- Errors that have been fixed -->

--- a/Buildings/package.mo
+++ b/Buildings/package.mo
@@ -249,10 +249,10 @@ have been <b style=\"color:blue\">improved</b> in a
     </td>
 </tr>
 <tr><td valign=\"top\">Buildings.Applications.DataCenters.ChillerCooled.Equipment.BaseClasses.AHUParameters<br/>
-                 Buildings.Applications.DataCenters.ChillerCooled.Equipment.BaseClasses.PartialCoolingCoilHumidifyingHeating
+                Buildings.Applications.DataCenters.ChillerCooled.Equipment.BaseClasses.PartialCoolingCoilHumidifyingHeating
     </td>
     <td valign=\"top\">Changed cooling coil model and removed unused parameters.<br/>
-                 This is for <a href=\"https://github.com/lbl-srg/modelica-buildings/issues/2549\">issue #2549</a>.
+                This is for <a href=\"https://github.com/lbl-srg/modelica-buildings/issues/2549\">issue #2549</a>.
     </td>
 </tr>
 <tr><td colspan=\"2\"><b>Buildings.Examples</b>
@@ -269,7 +269,7 @@ have been <b style=\"color:blue\">improved</b> in a
                  Buildings.Examples.VAVReheat.BaseClasses.PartialOpenLoop
     </td>
     <td valign=\"top\">Changed cooling coil model.<br/>
-                  This is for <a href=\"https://github.com/lbl-srg/modelica-buildings/issues/2549\">issue #2549</a>.
+                This is for <a href=\"https://github.com/lbl-srg/modelica-buildings/issues/2549\">issue #2549</a>.
     </td>
 </tr>
 <tr><td colspan=\"2\"><b>Buildings.Fluid.FMI</b>
@@ -278,7 +278,7 @@ have been <b style=\"color:blue\">improved</b> in a
 <tr><td valign=\"top\">Buildings.Fluid.FMI.ExportContainers.Validation.RoomHVAC
     </td>
     <td valign=\"top\">Changed cooling coil model.<br/>
-                 This is for <a href=\"https://github.com/lbl-srg/modelica-buildings/issues/2549\">issue #2549</a>.
+                This is for <a href=\"https://github.com/lbl-srg/modelica-buildings/issues/2549\">issue #2549</a>.
     </td>
 </tr>
 <tr><td colspan=\"2\"><b>xxx</b>
@@ -312,8 +312,8 @@ have been <b style=\"color:blue\">improved</b> in a
                        Buildings.Controls.OBC.CDL.Logical.MultiOr
     </td>
     <td valign=\"top\">Renamed parameter <code>nu</code> to <code>nin</code>.
-                 This is for <a href=\"https://github.com/lbl-srg/modelica-buildings/issues/2580\">issue 2580</a>.<br/>
-                 For Dymola, a conversion script makes this change.</td>
+                This is for <a href=\"https://github.com/lbl-srg/modelica-buildings/issues/2580\">issue 2580</a>.<br/>
+                For Dymola, a conversion script makes this change.</td>
 </tr>
 </table>
 <!-- Errors that have been fixed -->

--- a/Buildings/package.mo
+++ b/Buildings/package.mo
@@ -249,10 +249,10 @@ have been <b style=\"color:blue\">improved</b> in a
     </td>
 </tr>
 <tr><td valign=\"top\">Buildings.Applications.DataCenters.ChillerCooled.Equipment.BaseClasses.AHUParameters<br/>
-	          Buildings.Applications.DataCenters.ChillerCooled.Equipment.BaseClasses.PartialCoolingCoilHumidifyingHeating
+                 Buildings.Applications.DataCenters.ChillerCooled.Equipment.BaseClasses.PartialCoolingCoilHumidifyingHeating
     </td>
     <td valign=\"top\">Changed cooling coil model and removed unused parameters.<br/>
-	          This is for <a href=\"https://github.com/lbl-srg/modelica-buildings/issues/2549\">issue #2549</a>.
+                 This is for <a href=\"https://github.com/lbl-srg/modelica-buildings/issues/2549\">issue #2549</a>.
     </td>
 </tr>
 <tr><td colspan=\"2\"><b>Buildings.Examples</b>
@@ -265,11 +265,11 @@ have been <b style=\"color:blue\">improved</b> in a
     </td>
 </tr>
 <tr><td valign=\"top\">Buildings.Examples.DualFanDualDuct.ClosedLoop<br/>
-	          Buildings.Examples.ScalableBenchmarks.BuildingVAV.Examples.OneFloor_OneZone<br/>
-	          Buildings.Examples.VAVReheat.BaseClasses.PartialOpenLoop
+                 Buildings.Examples.ScalableBenchmarks.BuildingVAV.Examples.OneFloor_OneZone<br/>
+                 Buildings.Examples.VAVReheat.BaseClasses.PartialOpenLoop
     </td>
     <td valign=\"top\">Changed cooling coil model.<br/>
-	          This is for <a href=\"https://github.com/lbl-srg/modelica-buildings/issues/2549\">issue #2549</a>.
+                  This is for <a href=\"https://github.com/lbl-srg/modelica-buildings/issues/2549\">issue #2549</a>.
     </td>
 </tr>
 <tr><td colspan=\"2\"><b>Buildings.Fluid.FMI</b>
@@ -278,7 +278,7 @@ have been <b style=\"color:blue\">improved</b> in a
 <tr><td valign=\"top\">Buildings.Fluid.FMI.ExportContainers.Validation.RoomHVAC
     </td>
     <td valign=\"top\">Changed cooling coil model.<br/>
-	          This is for <a href=\"https://github.com/lbl-srg/modelica-buildings/issues/2549\">issue #2549</a>.
+                 This is for <a href=\"https://github.com/lbl-srg/modelica-buildings/issues/2549\">issue #2549</a>.
     </td>
 </tr>
 <tr><td colspan=\"2\"><b>xxx</b>
@@ -303,6 +303,16 @@ have been <b style=\"color:blue\">improved</b> in a
 <tr><td valign=\"top\">Buildings.Obsolete.Utilities.IO.Python27
     </td>
     <td valign=\"top\">Removed support for Python 27. Use instead <code>Buildings.Utilities.IO.Python36</code>.
+    </td>
+</tr>
+ <tr><td colspan=\"2\"><b>Buildings.Controls.OBC.CDL</b>
+    </td>
+</tr>
+<tr><td valign=\"top\">Buildings.Controls.OBC.CDL.Logical.MultiAnd<br/>
+                       Buildings.Controls.OBC.CDL.Logical.MultiOr
+    </td>
+    <td valign=\"top\">Renamed parameter <code>nu</code> to <code>nin</code>.
+                 This is for <a href=\"https://github.com/lbl-srg/modelica-buildings/issues/2580\">issue 2580</a>.
     </td>
 </tr>
 </table>


### PR DESCRIPTION
This closes #2580.

- [x] renamed the parameter `nu` to `nin` in `CDL.Logical.MultiAnd` and `CDL.Logical.MultiOr`
- [x] created dymola conversion script
- [x] refactored text to avoid long line  