### PR TITLE
Remove parameter prefixes from record definition

### DIFF
--- a/Buildings/ThermalZones/Detailed/BaseClasses/CFDSurfaceIdentifier.mo
+++ b/Buildings/ThermalZones/Detailed/BaseClasses/CFDSurfaceIdentifier.mo
@@ -1,10 +1,10 @@
 within Buildings.ThermalZones.Detailed.BaseClasses;
 record CFDSurfaceIdentifier "Data record to identify surfaces in the CFD code"
     extends Modelica.Icons.Record;
- parameter String name "Name of the surface";
- parameter Modelica.SIunits.Area A "Area of the surface";
- parameter Modelica.SIunits.Angle til "Tilt of the surface";
- parameter Buildings.ThermalZones.Detailed.Types.CFDBoundaryConditions bouCon
+ String name "Name of the surface";
+ Modelica.SIunits.Area A "Area of the surface";
+ Modelica.SIunits.Angle til "Tilt of the surface";
+ Buildings.ThermalZones.Detailed.Types.CFDBoundaryConditions bouCon
     "Boundary condition used in the CFD simulation";
 
 annotation (


### PR DESCRIPTION
This commit fixes #7839 on the maint_8.0.x branch