### PR TITLE
unified boolean flag names

### DIFF
--- a/Buildings/Experimental/DHC/CentralPlants/BaseClasses/PartialPlant.mo
+++ b/Buildings/Experimental/DHC/CentralPlants/BaseClasses/PartialPlant.mo
@@ -44,7 +44,7 @@ partial model PartialPlant
     redeclare package Medium = Medium,
     m_flow(min=if allowFlowReversal then -Modelica.Constants.inf else 0),
     h_outflow(start=Medium.h_default, nominal=Medium.h_default)) if
-    have_ambientPort
+    have_serAmb
     "Fluid connector for ambient water service supply line"
     annotation (
       Placement(transformation(extent={{-310,30},{-290,50}}),
@@ -53,7 +53,7 @@ partial model PartialPlant
     redeclare package Medium = Medium,
     m_flow(max=if allowFlowReversal then +Modelica.Constants.inf else 0),
     h_outflow(start=Medium.h_default, nominal=Medium.h_default)) if
-    have_ambientPort
+    have_serAmb
     "Fluid connector for ambient water service return line"
     annotation (
       Placement(transformation(extent={{290,30},{310,50}}),
@@ -61,7 +61,7 @@ partial model PartialPlant
   Modelica.Fluid.Interfaces.FluidPort_a port_aSerHea(
     redeclare package Medium = Medium,
     m_flow(min=if allowFlowReversal then -Modelica.Constants.inf else 0),
-    h_outflow(start=Medium.h_default, nominal=Medium.h_default)) if have_heatingPort
+    h_outflow(start=Medium.h_default, nominal=Medium.h_default)) if have_hea
     "Fluid connector for heating service supply line"
     annotation (Placement(
       transformation(extent={{-310,-10},{-290,10}}),    iconTransformation(
@@ -69,7 +69,7 @@ partial model PartialPlant
   Modelica.Fluid.Interfaces.FluidPort_b port_bSerHea(
     redeclare package Medium = MediumHea_b,
     m_flow(max=if allowFlowReversal then +Modelica.Constants.inf else 0),
-    h_outflow(start=MediumHea_b.h_default, nominal=MediumHea_b.h_default)) if have_heatingPort
+    h_outflow(start=MediumHea_b.h_default, nominal=MediumHea_b.h_default)) if have_hea
     "Fluid connector for heating service return line"
     annotation (Placement(
         transformation(extent={{290,-10},{310,10}}),    iconTransformation(
@@ -78,14 +78,14 @@ partial model PartialPlant
     redeclare package Medium = Medium,
     m_flow(min=if allowFlowReversal then -Modelica.Constants.inf else 0),
     h_outflow(start=Medium.h_default, nominal=Medium.h_default)) if
-    have_coolingPort
+    have_coo
     "Fluid connector for cooling service supply line"
     annotation (Placement(transformation(extent={{-310,-50},{-290,-30}})));
   Modelica.Fluid.Interfaces.FluidPort_b port_bSerCoo(
     redeclare package Medium = Medium,
     m_flow(max=if allowFlowReversal then +Modelica.Constants.inf else 0),
     h_outflow(start=Medium.h_default, nominal=Medium.h_default)) if
-    have_coolingPort
+    have_coo
     "Fluid connector for cooling service return line"
     annotation (Placement(
       transformation(extent={{290,-50},{310,-30}}),   iconTransformation(
@@ -121,14 +121,14 @@ partial model PartialPlant
       Placement(transformation(extent={{300,100},{340,140}}),
         iconTransformation(extent={{300,80},{380,160}})));
 protected
-  final parameter Boolean have_heatingPort=typ <> Buildings.Experimental.DHC.Types.DistrictSystemType.Cooling and
+  final parameter Boolean have_hea=typ <> Buildings.Experimental.DHC.Types.DistrictSystemType.Cooling and
   typ <> Buildings.Experimental.DHC.Types.DistrictSystemType.CombinedGeneration5
   "Boolean flag to enable fluid connectors for heating service line";
-  final parameter Boolean have_coolingPort=typ == Buildings.Experimental.DHC.Types.DistrictSystemType.CombinedGeneration1 or
+  final parameter Boolean have_coo=typ == Buildings.Experimental.DHC.Types.DistrictSystemType.CombinedGeneration1 or
   typ == Buildings.Experimental.DHC.Types.DistrictSystemType.CombinedGeneration2to4 or
   typ == Buildings.Experimental.DHC.Types.DistrictSystemType.Cooling
   "Boolean flag to enable fluid connectors for cooling service line";
-  final parameter Boolean have_ambientPort=typ == Buildings.Experimental.DHC.Types.DistrictSystemType.CombinedGeneration5
+  final parameter Boolean have_serAmb=typ == Buildings.Experimental.DHC.Types.DistrictSystemType.CombinedGeneration5
   "Boolean flag to enable fluid connector for ambient water service line";
   annotation (
     defaultComponentName="plan",
@@ -193,28 +193,28 @@ First implementation.
           pattern=LinePattern.None,
           fillColor={0,0,255},
           fillPattern=FillPattern.Solid,
-          visible=have_heatingPort),
+          visible=have_hea),
         Rectangle(
           extent={{140,-48},{300,-32}},
           lineColor={0,0,255},
           pattern=LinePattern.None,
           fillColor={0,0,255},
           fillPattern=FillPattern.Solid,
-          visible=have_coolingPort),
+          visible=have_coo),
         Rectangle(
           extent={{-300,32},{-140,48}},
           lineColor={0,0,255},
           pattern=LinePattern.None,
           fillColor={0,255,255},
           fillPattern=FillPattern.Solid,
-          visible=have_ambientPort),
+          visible=have_serAmb),
         Rectangle(
           extent={{140,32},{300,48}},
           lineColor={0,0,255},
           pattern=LinePattern.None,
           fillColor={0,255,255},
           fillPattern=FillPattern.Solid,
-          visible=have_ambientPort),
+          visible=have_serAmb),
         Rectangle(
           extent={{-140,140},{140,-142}},
           lineColor={27,0,55},
@@ -226,14 +226,14 @@ First implementation.
           pattern=LinePattern.None,
           fillColor={238,46,47},
           fillPattern=FillPattern.Solid,
-          visible=have_heatingPort),
+          visible=have_hea),
         Rectangle(
           extent={{-300,-48},{-140,-32}},
           lineColor={0,0,255},
           pattern=LinePattern.None,
           fillColor={238,46,47},
           fillPattern=FillPattern.Solid,
-          visible=have_coolingPort)}),
+          visible=have_coo)}),
     Diagram(
       coordinateSystem(
         preserveAspectRatio=false,


### PR DESCRIPTION
This PR added additional modification based on https://github.com/lbl-srg/modelica-buildings/pull/2643#discussion_r716287583, which unified Boolean flag names of fluid ports to keep consistent with the naming convention.