### PR TITLE
Changed parameter declarations for case study

### DIFF
--- a/Buildings/Examples/VAVReheat/BaseClasses/Guideline36.mo
+++ b/Buildings/Examples/VAVReheat/BaseClasses/Guideline36.mo
@@ -16,7 +16,7 @@ model Guideline36
     "Minimum expected zone primary flow rate";
   parameter Modelica.SIunits.Time samplePeriod=120
     "Sample period of component, set to the same value as the trim and respond that process yPreSetReq";
-  parameter Modelica.SIunits.PressureDifference dpDisRetMax=40
+  parameter Modelica.SIunits.PressureDifference dpDisRetMax(displayUnit="Pa")=40
     "Maximum return fan discharge static pressure setpoint";
 
   Buildings.Controls.OBC.ASHRAE.G36_PR1.TerminalUnits.Controller conVAVCor(

--- a/Buildings/ThermalZones/EnergyPlus/Examples/SmallOffice/BaseClasses/Floor.mo
+++ b/Buildings/ThermalZones/EnergyPlus/Examples/SmallOffice/BaseClasses/Floor.mo
@@ -2,16 +2,16 @@ within Buildings.ThermalZones.EnergyPlus.Examples.SmallOffice.BaseClasses;
 model Floor
   "Model of a floor of the building"
   extends Buildings.Examples.VAVReheat.BaseClasses.PartialFloor(
-    final VRooCor=456.455,
-    final VRooSou=346.022,
-    final VRooNor=346.022,
-    final VRooEas=205.265,
-    final VRooWes=205.265,
-    final AFloCor=cor.AFlo,
-    final AFloSou=sou.AFlo,
-    final AFloNor=nor.AFlo,
-    final AFloEas=eas.AFlo,
-    final AFloWes=wes.AFlo,
+    VRooCor=456.455,
+    VRooSou=346.022,
+    VRooNor=346.022,
+    VRooEas=205.265,
+    VRooWes=205.265,
+    AFloCor=cor.AFlo,
+    AFloSou=sou.AFlo,
+    AFloNor=nor.AFlo,
+    AFloEas=eas.AFlo,
+    AFloWes=wes.AFlo,
     opeWesCor(
       wOpe=4),
     opeSouCor(
@@ -133,6 +133,29 @@ initial equation
     abs(
       wes.V-VRooWes) < 0.01,
     "Volumes don't match. These had to be entered manually to avoid using a non-literal value.");
+
+  // Other models may override the assignment for AFlo. Hence we check below for consistency.
+  assert(
+    abs(
+      cor.AFlo-AFloCor) < 0.01,
+    "Areas don't match. Make sure model that overrides these parameter defaults uses the same values as the idf file uses.");
+  assert(
+    abs(
+      sou.AFlo-AFloSou) < 0.01,
+    "Areas don't match. Make sure model that overrides these parameter defaults uses the same values as the idf file uses.");
+  assert(
+    abs(
+      nor.AFlo-AFloNor) < 0.01,
+    "Areas don't match. Make sure model that overrides these parameter defaults uses the same values as the idf file uses.");
+  assert(
+    abs(
+      eas.AFlo-AFloEas) < 0.01,
+    "Areas don't match. Make sure model that overrides these parameter defaults uses the same values as the idf file uses.");
+  assert(
+    abs(
+      wes.AFlo-AFloWes) < 0.01,
+    "Areas don't match. Make sure model that overrides these parameter defaults uses the same values as the idf file uses.");
+
   assert(
     abs(
       opeWesCor.wOpe-4) < 0.01,


### PR DESCRIPTION
This updates the VAV model so that parameters can be overridden for the OBC case study.