### PR TITLE
Correct segmentation fault during debug logging (maint 8.0.x)

### DIFF
--- a/Buildings/Resources/Library/linux64/libModelicaBuildingsEnergyPlus.so
+++ b/Buildings/Resources/Library/linux64/libModelicaBuildingsEnergyPlus.so
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4b567880b2d07d90b8a9acd512ec127161a4d9db6c593d6c73eff1705eb7e1d2
+oid sha256:5e175865a0db5b7b460fe0c42f713db4e36be678a28b90fa41900e52ca37685b
 size 68520

--- a/Buildings/Resources/Library/win64/ModelicaBuildingsEnergyPlus.dll
+++ b/Buildings/Resources/Library/win64/ModelicaBuildingsEnergyPlus.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b44f71f4751d3664f4f364e15bca6a950dd041721c881a910e62d46a286d76d9
-size 138240
+oid sha256:bd97f4662456344abfd56fec1d5c5b7a74e6437b68de1001eaf8c4ea5f9bb34a
+size 138752

--- a/Buildings/Resources/src/ThermalZones/EnergyPlus/C-Sources/SpawnUtil.c
+++ b/Buildings/Resources/src/ThermalZones/EnergyPlus/C-Sources/SpawnUtil.c
@@ -134,9 +134,15 @@ void setVariables(
   /* If debug mode, write exchanged values to log file */
   if (bui->logLevel >= TIMESTEP){
     for(i = 0; i < ptrReals->n; i++){
-      bui->SpawnFormatMessage("%.3f %s: Sending to EnergyPlus, %s = %.6g [%s].\n",
-        bui->time, modelicaInstanceName, ptrReals->fmiNames[i], ptrReals->valsEP[i],
-        fmi2_import_get_unit_name(ptrReals->units[i]));
+      if (ptrReals->units[i]){ /* Units are defined */
+        bui->SpawnFormatMessage("%.3f %s: Sending to EnergyPlus, %s = %.6g [%s].\n",
+          bui->time, modelicaInstanceName, ptrReals->fmiNames[i], ptrReals->valsEP[i],
+          fmi2_import_get_unit_name(ptrReals->units[i]));
+      }
+      else{
+        bui->SpawnFormatMessage("%.3f %s: Sending to EnergyPlus, %s = %.6g (no units declared).\n",
+          bui->time, modelicaInstanceName, ptrReals->fmiNames[i], ptrReals->valsEP[i]);
+      }
     }
   }
 

--- a/Buildings/Resources/src/ThermalZones/EnergyPlus/C-Sources/SpawnUtil.c
+++ b/Buildings/Resources/src/ThermalZones/EnergyPlus/C-Sources/SpawnUtil.c
@@ -207,9 +207,15 @@ void getVariables(FMUBuilding* bui, const char* modelicaInstanceName, spawnReals
   /* If debug mode, write exchanged values to log file */
   if (bui->logLevel >= TIMESTEP){
     for(i = 0; i < ptrReals->n; i++){
-      bui->SpawnFormatMessage("%.3f %s: Received from EnergyPlus, %s = %.6g [%s].\n",
-        bui->time, modelicaInstanceName, ptrReals->fmiNames[i], ptrReals->valsEP[i],
-        fmi2_import_get_unit_name(ptrReals->units[i]));
+      if (ptrReals->units[i]){ /* Units are defined */
+        bui->SpawnFormatMessage("%.3f %s: Received from EnergyPlus, %s = %.6g [%s].\n",
+          bui->time, modelicaInstanceName, ptrReals->fmiNames[i], ptrReals->valsEP[i],
+          fmi2_import_get_unit_name(ptrReals->units[i]));
+      }
+      else{
+        bui->SpawnFormatMessage("%.3f %s: Received from EnergyPlus, %s = %.6g (no units declared).\n",
+          bui->time, modelicaInstanceName, ptrReals->fmiNames[i], ptrReals->valsEP[i]);
+      }
     }
   }
 


### PR DESCRIPTION
Correct segmentation fault if logging is set to debug and variable in E+ does not specify a unit.

This is also addressed on `issue2759_spawn_PATH` for the master.

Todo:
- [x] Recreate binaries.