### PR TITLE
Include ModelicaUtilities.h for crypto hash

### DIFF
--- a/Buildings/Resources/C-Sources/cryptographicsHash.c
+++ b/Buildings/Resources/C-Sources/cryptographicsHash.c
@@ -24,6 +24,7 @@ A million repetitions of "a"
 /* for uint32_t */
 #include <stdint.h>
 #include "cryptographicsHash.h"
+#include "ModelicaUtilities.h"
 
 
 #define rol(value, bits) (((value) << (bits)) | ((value) >> (32 - (bits))))


### PR DESCRIPTION
The default prototype for ModelicaAllocateString will be int32, which
does not fit a whole pointer causing crashes in models using the
function.

Note: This should probably be ported to maintenance branches as well. It was reported in https://github.com/OpenModelica/OpenModelica/issues/8219