### PR TITLE
Updated BuildingsPy to use colored output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ services:
 
 env:
   global:
-    - BUILDINGSPY_VERSION=BuildingsPy@5e12126041d0abc3e7898d5cd2552d05e1325ec8
+    - BUILDINGSPY_VERSION=BuildingsPy@dec3decca31fcd84aecbe3a83f8c060ada7f6156
     - OMC_VERSION=ubuntu-2004-omc:1.19.0_dev-470-g5085945-1
     - OPTIMICA_VERSION=travis-ubuntu-1804-optimica:r26446
     - DYMOLA_VERSION=travis_ubuntu-2004_dymola:2022x-x86_64

--- a/bin/runUnitTests.py
+++ b/bin/runUnitTests.py
@@ -74,10 +74,10 @@ def _setEnvironmentVariables(var, value):
         os.environ[var] = value
 
 
-def _runUnitTests(batch, tool, package, path, n_pro, show_gui, skip_verification, debug):
+def _runUnitTests(batch, tool, package, path, n_pro, show_gui, skip_verification, debug, color):
     import buildingspy.development.regressiontest as u
 
-    ut = u.Tester(tool=tool, skip_verification=skip_verification)
+    ut = u.Tester(tool=tool, skip_verification=skip_verification, color=color)
     ut.batchMode(batch)
     ut.setLibraryRoot(path)
     if package is not None:
@@ -212,7 +212,8 @@ if __name__ == '__main__':
                            n_pro=args.number_of_processors,
                            show_gui=args.show_gui,
                            skip_verification=args.skip_verification,
-                           debug=args.debug
+                           debug=args.debug,
+                           color=True
                            )
     exit(retVal)
 


### PR DESCRIPTION
This updates the BuildingsPy version, and enables by default colored output when running the regression tests.