### PR TITLE
Renamed parameters for #2889

### DIFF
--- a/Buildings/HeatTransfer/Convection/Exterior.mo
+++ b/Buildings/HeatTransfer/Convection/Exterior.mo
@@ -35,9 +35,9 @@ protected
     "Small value for wind velocity below which equations are regularized";
   final parameter Real cosTil=Modelica.Math.cos(til) "Cosine of window tilt";
   final parameter Real sinTil=Modelica.Math.sin(til) "Sine of window tilt";
-  final parameter Boolean isCeiling = abs(sinTil) < 10E-10 and cosTil > 0
+  final parameter Boolean is_ceiling = abs(sinTil) < 10E-10 and cosTil > 0
     "Flag, true if the surface is a ceiling";
-  final parameter Boolean isFloor = abs(sinTil) < 10E-10 and cosTil < 0
+  final parameter Boolean is_floor = abs(sinTil) < 10E-10 and cosTil < 0
     "Flag, true if the surface is a floor";
 
   parameter Real R(fixed=false) "Surface roughness";
@@ -70,9 +70,9 @@ equation
     // Even if hCon is a step function with a step at zero,
     // the product hCon*dT is differentiable at zero with
     // a continuous first derivative
-    if isCeiling then
+    if is_ceiling then
        qN_flow = Buildings.HeatTransfer.Convection.Functions.HeatFlux.ceiling(dT=dT);
-    elseif isFloor then
+    elseif is_floor then
        qN_flow = Buildings.HeatTransfer.Convection.Functions.HeatFlux.floor(dT=dT);
     else
        qN_flow = Buildings.HeatTransfer.Convection.Functions.HeatFlux.wall(dT=dT);
@@ -230,6 +230,12 @@ Engineering Research Laboratory, Champaign, IL.
 </p>
 </html>", revisions="<html>
 <ul>
+<li>
+February 11, 2022, by Michael Wetter:<br/>
+Change parameter <code>isFloor</code> to <code>is_floor</code>,
+and <code>isCeiling</code> to <code>is_ceiling</code>,
+for consistency with naming convention.
+</li>
 <li>
 May 7, 2020, by Michael Wetter:<br/>
 Set wind direction modifier to a constant as wind velocity approaches zero.<br/>

--- a/Buildings/HeatTransfer/Convection/Interior.mo
+++ b/Buildings/HeatTransfer/Convection/Interior.mo
@@ -23,9 +23,9 @@ protected
 
   final parameter Real cosTil=Modelica.Math.cos(til) "Cosine of window tilt";
   final parameter Real sinTil=Modelica.Math.sin(til) "Sine of window tilt";
-  final parameter Boolean isCeiling = abs(sinTil) < 10E-10 and cosTil > 0
+  final parameter Boolean is_ceiling = abs(sinTil) < 10E-10 and cosTil > 0
     "Flag, true if the surface is a ceiling";
-  final parameter Boolean isFloor = abs(sinTil) < 10E-10 and cosTil < 0
+  final parameter Boolean is_floor = abs(sinTil) < 10E-10 and cosTil < 0
     "Flag, true if the surface is a floor";
 
 initial equation
@@ -41,10 +41,10 @@ equation
     // the product hCon*dT is differentiable at zero with
     // a continuous first derivative
     if homotopyInitialization then
-      if isCeiling then
+      if is_ceiling then
          q_flow = homotopy(actual=Buildings.HeatTransfer.Convection.Functions.HeatFlux.ceiling(dT=dT),
                     simplified=dT/dT0*Buildings.HeatTransfer.Convection.Functions.HeatFlux.ceiling(dT=dT0));
-      elseif isFloor then
+      elseif is_floor then
          q_flow = homotopy(actual=Buildings.HeatTransfer.Convection.Functions.HeatFlux.floor(dT=dT),
                     simplified=dT/dT0*Buildings.HeatTransfer.Convection.Functions.HeatFlux.floor(dT=dT0));
       else
@@ -52,9 +52,9 @@ equation
                     simplified=dT/dT0*Buildings.HeatTransfer.Convection.Functions.HeatFlux.wall(dT=dT0));
       end if;
     else
-      if isCeiling then
+      if is_ceiling then
          q_flow = Buildings.HeatTransfer.Convection.Functions.HeatFlux.ceiling(dT=dT);
-      elseif isFloor then
+      elseif is_floor then
          q_flow = Buildings.HeatTransfer.Convection.Functions.HeatFlux.floor(dT=dT);
       else
          q_flow = Buildings.HeatTransfer.Convection.Functions.HeatFlux.wall(dT=dT);
@@ -139,6 +139,12 @@ Buildings.HeatTransfer.Convection.Functions.HeatFlux.wall</a>
 </ul>
 </html>", revisions="<html>
 <ul>
+<li>
+February 11, 2022, by Michael Wetter:<br/>
+Change parameter <code>isFloor</code> to <code>is_floor</code>,
+and <code>isCeiling</code> to <code>is_ceiling</code>,
+for consistency with naming convention.
+</li>
 <li>
 April 14, 2020, by Michael Wetter:<br/>
 Changed <code>homotopyInitialization</code> to a constant.<br/>

--- a/Buildings/HeatTransfer/Data/OpaqueSurfaces.mo
+++ b/Buildings/HeatTransfer/Data/OpaqueSurfaces.mo
@@ -10,7 +10,7 @@ package OpaqueSurfaces
       "Surface tilt (0: ceiling, pi/2: wall, pi: floor";
     parameter Modelica.Units.SI.Emissivity absIR=0.84 "Infrared absorptivity";
     parameter Modelica.Units.SI.Emissivity absSol=0.84 "Solar absorptivity";
-   final parameter Boolean isFloor=til > 2.74889125 and til < 3.53428875
+   final parameter Boolean is_floor=til > 2.74889125 and til < 3.53428875
       "Flag, true if construction is a floor" annotation (Evaluate=true);
 
    annotation (
@@ -29,6 +29,12 @@ is used to compute solar heat radiation (in the solar spectrum).
 </html>",
   revisions="<html>
 <ul>
+<li>
+February 11, 2022, by Michael Wetter:<br/>
+Change parameter <code>isFloor</code> to <code>is_floor</code>,
+and <code>isCeiling</code> to <code>is_ceiling</code>,
+for consistency with naming convention.
+</li>
 <li>
 November 16, 2010, by Michael Wetter:<br/>
 First implementation.

--- a/Buildings/HeatTransfer/Windows/BaseClasses/InteriorConvection.mo
+++ b/Buildings/HeatTransfer/Windows/BaseClasses/InteriorConvection.mo
@@ -29,9 +29,9 @@ protected
 
   final parameter Real cosTil=Modelica.Math.cos(til) "Cosine of window tilt";
   final parameter Real sinTil=Modelica.Math.sin(til) "Sine of window tilt";
-  final parameter Boolean isCeiling = abs(sinTil) < 10E-10 and cosTil > 0
+  final parameter Boolean is_ceiling = abs(sinTil) < 10E-10 and cosTil > 0
     "Flag, true if the surface is a ceiling";
-  final parameter Boolean isFloor = abs(sinTil) < 10E-10 and cosTil < 0
+  final parameter Boolean is_floor = abs(sinTil) < 10E-10 and cosTil < 0
     "Flag, true if the surface is a floor";
 
 initial equation
@@ -47,10 +47,10 @@ equation
     // the product hCon*dT is differentiable at zero with
     // a continuous first derivative
     if homotopyInitialization then
-      if isCeiling then
+      if is_ceiling then
          q_flow = u*homotopy(actual=Buildings.HeatTransfer.Convection.Functions.HeatFlux.ceiling(dT=dT),
                       simplified=dT/dT0*Buildings.HeatTransfer.Convection.Functions.HeatFlux.ceiling(dT=dT0));
-      elseif isFloor then
+      elseif is_floor then
          q_flow = u*homotopy(actual=Buildings.HeatTransfer.Convection.Functions.HeatFlux.floor(dT=dT),
                       simplified=dT/dT0*Buildings.HeatTransfer.Convection.Functions.HeatFlux.floor(dT=dT0));
       else
@@ -58,9 +58,9 @@ equation
                       simplified=dT/dT0*Buildings.HeatTransfer.Convection.Functions.HeatFlux.wall(dT=dT0));
       end if;
     else
-      if isCeiling then
+      if is_ceiling then
          q_flow = u*Buildings.HeatTransfer.Convection.Functions.HeatFlux.ceiling(dT=dT);
-      elseif isFloor then
+      elseif is_floor then
          q_flow = u*Buildings.HeatTransfer.Convection.Functions.HeatFlux.floor(dT=dT);
       else
          q_flow = u*Buildings.HeatTransfer.Convection.Functions.HeatFlux.wall(dT=dT);
@@ -156,6 +156,12 @@ control signal.
 </p>
 </html>", revisions="<html>
 <ul>
+<li>
+February 11, 2022, by Michael Wetter:<br/>
+Change parameter <code>isFloor</code> to <code>is_floor</code>,
+and <code>isCeiling</code> to <code>is_ceiling</code>,
+for consistency with naming convention.
+</li>
 <li>
 April 14, 2020, by Michael Wetter:<br/>
 Changed <code>homotopyInitialization</code> to a constant.<br/>

--- a/Buildings/ThermalZones/Detailed/BaseClasses/PartialParameterConstruction.mo
+++ b/Buildings/ThermalZones/Detailed/BaseClasses/PartialParameterConstruction.mo
@@ -13,9 +13,9 @@ record PartialParameterConstruction "Partial record for constructions"
 
   parameter Modelica.Units.SI.Angle til "Surface tilt";
   parameter Modelica.Units.SI.Angle azi "Surface azimuth";
-  final parameter Boolean isFloor=til > 2.74889125 and til < 3.53428875
+  final parameter Boolean is_floor=til > 2.74889125 and til < 3.53428875
     "Flag, true if construction is a floor" annotation (Evaluate=true);
-  final parameter Boolean isCeiling=til > -0.392699 and til < 0.392699
+  final parameter Boolean is_ceiling=til > -0.392699 and til < 0.392699
     "Flag, true if construction is a floor" annotation (Evaluate=true);
 //  final parameter Integer nLay(min=1, fixed=true) = size(layers.material, 1)
 //    "Number of layers";
@@ -59,6 +59,12 @@ Buildings.Types.Tilt</a>
 </p>
 </html>", revisions="<html>
 <ul>
+<li>
+February 11, 2022, by Michael Wetter:<br/>
+Change parameter <code>isFloor</code> to <code>is_floor</code>,
+and <code>isCeiling</code> to <code>is_ceiling</code>,
+for consistency with naming convention.
+</li>
 <li>
 December 8, 2016, by Michael Wetter:<br/>
 Added parameters <code>stateAtSurface_a</code> and

--- a/Buildings/ThermalZones/Detailed/BaseClasses/RoomHeatMassBalance.mo
+++ b/Buildings/ThermalZones/Detailed/BaseClasses/RoomHeatMassBalance.mo
@@ -211,12 +211,12 @@ partial model RoomHeatMassBalance "Base model for a room"
     final datConPar = datConPar,
     final datConBou = datConBou,
     final surBou = surBou,
-    final isFloorConExt=isFloorConExt,
-    final isFloorConExtWin=isFloorConExtWin,
-    final isFloorConPar_a=isFloorConPar_a,
-    final isFloorConPar_b=isFloorConPar_b,
-    final isFloorConBou=isFloorConBou,
-    final isFloorSurBou=isFloorSurBou,
+    final is_floorConExt=is_floorConExt,
+    final is_floorConExtWin=is_floorConExtWin,
+    final is_floorConPar_a=is_floorConPar_a,
+    final is_floorConPar_b=is_floorConPar_b,
+    final is_floorConBou=is_floorConBou,
+    final is_floorSurBou=is_floorSurBou,
     final tauGla={datConExtWin[i].glaSys.glass[size(datConExtWin[i].glaSys.glass, 1)].tauSol[1] for i in 1:NConExtWin})
     if haveConExtWin "Solar radiative heat exchange"
     annotation (Placement(transformation(extent={{-100,40},{-80,60}})));
@@ -313,19 +313,19 @@ protected
     Modelica.Math.BooleanVectors.anyTrue(haveInteriorShade[:])
     "Set to true if the windows have a shade";
 
-  final parameter Boolean isFloorConExt[NConExt]=
-    datConExt.isFloor "Flag to indicate if floor for exterior constructions";
-  final parameter Boolean isFloorConExtWin[NConExtWin]=
-    datConExtWin.isFloor "Flag to indicate if floor for constructions";
-  final parameter Boolean isFloorConPar_a[NConPar]=
-    datConPar.isFloor "Flag to indicate if floor for constructions";
-  final parameter Boolean isFloorConPar_b[NConPar]=
-    datConPar.isCeiling "Flag to indicate if floor for constructions";
-  final parameter Boolean isFloorConBou[NConBou]=
-    datConBou.isFloor
+  final parameter Boolean is_floorConExt[NConExt]=
+    datConExt.is_floor "Flag to indicate if floor for exterior constructions";
+  final parameter Boolean is_floorConExtWin[NConExtWin]=
+    datConExtWin.is_floor "Flag to indicate if floor for constructions";
+  final parameter Boolean is_floorConPar_a[NConPar]=
+    datConPar.is_floor "Flag to indicate if floor for constructions";
+  final parameter Boolean is_floorConPar_b[NConPar]=
+    datConPar.is_ceiling "Flag to indicate if floor for constructions";
+  final parameter Boolean is_floorConBou[NConBou]=
+    datConBou.is_floor
     "Flag to indicate if floor for constructions with exterior boundary conditions exposed to outside of room model";
-  parameter Boolean isFloorSurBou[NSurBou]=
-    surBou.isFloor
+  parameter Boolean is_floorSurBou[NSurBou]=
+    surBou.is_floor
     "Flag to indicate if floor for constructions that are modeled outside of this room";
 
   HeatTransfer.Windows.BaseClasses.ShadingSignal shaSig[NConExtWin](
@@ -869,6 +869,12 @@ for detailed explanations.
 </p>
 </html>",   revisions="<html>
 <ul>
+<li>
+February 11, 2022, by Michael Wetter:<br/>
+Change parameter <code>isFloor</code> to <code>is_floor</code>,
+and <code>isCeiling</code> to <code>is_ceiling</code>,
+for consistency with naming convention.
+</li>
 <li>
 September 16, 2021, by Michael Wetter:<br/>
 Removed parameter <code>lat</code> because the latitude is now obtained from the weather data bus.<br/>

--- a/Buildings/ThermalZones/Detailed/BaseClasses/SolarRadiationExchange.mo
+++ b/Buildings/ThermalZones/Detailed/BaseClasses/SolarRadiationExchange.mo
@@ -22,17 +22,17 @@ model SolarRadiationExchange
   // the model assumes diffuse reflection, whereas in reality, reflection of the solar
   // radiation at the floor is likely specular, and therefore less radiation would hit
   // the window from the room-side.
-  parameter Boolean isFloorConExt[NConExt]
+  parameter Boolean is_floorConExt[NConExt]
     "Flag to indicate if floor for exterior constructions";
-  parameter Boolean isFloorConExtWin[NConExtWin]
+  parameter Boolean is_floorConExtWin[NConExtWin]
     "Flag to indicate if floor for constructions";
-  parameter Boolean isFloorConPar_a[NConPar]
+  parameter Boolean is_floorConPar_a[NConPar]
     "Flag to indicate if floor for constructions";
-  parameter Boolean isFloorConPar_b[NConPar]
+  parameter Boolean is_floorConPar_b[NConPar]
     "Flag to indicate if floor for constructions";
-  parameter Boolean isFloorConBou[NConBou]
+  parameter Boolean is_floorConBou[NConBou]
     "Flag to indicate if floor for constructions with exterior boundary conditions exposed to outside of room model";
-  parameter Boolean isFloorSurBou[NSurBou]
+  parameter Boolean is_floorSurBou[NSurBou]
     "Flag to indicate if floor for constructions that are modeled outside of this room";
 
   parameter Modelica.Units.SI.Emissivity tauGla[NConExtWin]
@@ -63,7 +63,7 @@ protected
     "Number of opaque surfaces, including the window frame";
   final parameter Integer NWin = NConExtWin "Number of window surfaces";
   final parameter Integer NTot = NOpa + NWin "Total number of surfaces";
-  final parameter Boolean isFlo[NTot](each fixed=false)
+  final parameter Boolean is_flo[NTot](each fixed=false)
     "Flag, true if a surface is a floor";
   final parameter Real eps[NTot](each min=0, each max=1, each fixed=false)
     "Solar absorptivity";
@@ -95,36 +95,36 @@ initial equation
   for i in 1:NConExt loop
     eps[i] = epsConExt[i];
     A[i]      = AConExt[i];
-    isFlo[i]  = isFloorConExt[i];
+    is_flo[i]  = is_floorConExt[i];
   end for;
   for i in 1:NConPar loop
     eps[i+NConExt]           = epsConPar_a[i];
     A[i+NConExt]             = AConPar[i];
-    isFlo[i+NConExt]         = isFloorConPar_a[i];
+    is_flo[i+NConExt]         = is_floorConPar_a[i];
     eps[i+NConExt+NConPar]   = epsConPar_b[i];
     A[i+NConExt+NConPar]     = AConPar[i];
-    isFlo[i+NConExt+NConPar] = isFloorConPar_b[i];
+    is_flo[i+NConExt+NConPar] = is_floorConPar_b[i];
   end for;
   for i in 1:NConBou loop
     eps[i+NConExt+2*NConPar]   = epsConBou[i];
     A[i+NConExt+2*NConPar]     = AConBou[i];
-    isFlo[i+NConExt+2*NConPar] = isFloorConBou[i];
+    is_flo[i+NConExt+2*NConPar] = is_floorConBou[i];
   end for;
   for i in 1:NSurBou loop
     eps[i+NConExt+2*NConPar+NConBou]   = epsSurBou[i];
     A[i+NConExt+2*NConPar+NConBou]     = ASurBou[i];
-    isFlo[i+NConExt+2*NConPar+NConBou] = isFloorSurBou[i];
+    is_flo[i+NConExt+2*NConPar+NConBou] = is_floorSurBou[i];
   end for;
 
   for i in 1:NConExtWin loop
     // Opaque part of construction that has a window embedded
     eps[i+NConExt+2*NConPar+NConBou+NSurBou]   = epsConExtWinOpa[i];
     A[i+NConExt+2*NConPar+NConBou+NSurBou]     = AConExtWinOpa[i];
-    isFlo[i+NConExt+2*NConPar+NConBou+NSurBou] = isFloorConExtWin[i];
+    is_flo[i+NConExt+2*NConPar+NConBou+NSurBou] = is_floorConExtWin[i];
     // Window frame
     eps[i+NConExt+2*NConPar+NConBou+NSurBou+NConExtWin]   = epsConExtWinFra[i];
     A[i+NConExt+2*NConPar+NConBou+NSurBou+NConExtWin]     = AConExtWinFra[i];
-    isFlo[i+NConExt+2*NConPar+NConBou+NSurBou+NConExtWin] = isFloorConExtWin[i];
+    is_flo[i+NConExt+2*NConPar+NConBou+NSurBou+NConExtWin] = is_floorConExtWin[i];
   end for;
   // Window glass
   for i in 1:NConExtWin loop
@@ -139,7 +139,7 @@ initial equation
     // This simplification allows lumping the solar distribution into
     // a parameter.
     eps[i+NConExt+2*NConPar+NConBou+NSurBou+2*NConExtWin] = epsConExtWinUns[i];
-    isFlo[i+NConExt+2*NConPar+NConBou+NSurBou+2*NConExtWin] = isFloorConExtWin[i];
+    is_flo[i+NConExt+2*NConPar+NConBou+NSurBou+2*NConExtWin] = is_floorConExtWin[i];
     A[i+NConExt+2*NConPar+NConBou+NSurBou+2*NConExtWin] = AConExtWinGla[i];
   end for;
   // Vector with all surface areas.
@@ -159,7 +159,7 @@ initial equation
   end for;
 
   // Sum of surface areas and products of emmissivity, transmissivity and area
-  AFlo = sum( (if isFlo[i] then A[i] else 0) for i in 1:NTot);
+  AFlo = sum( (if is_flo[i] then A[i] else 0) for i in 1:NTot);
   epsTauA = (eps .+ tau).*A;
   sumEpsTauA = sum(epsTauA[i] for i in 1:NTot);
 
@@ -173,15 +173,15 @@ initial equation
   // Coefficient that is used for non-floor areas.
   // The expression  max(1E-20, AFlo) is used to prevent a division by zero in case AFlo=0.
   // The situation for AFlo=0 is caught by the assert statement.
-  kDir1 = sum((if isFlo[i] then (A[i]*(1 - eps[i] - tau[i])) else 0) for i in 1:
+  kDir1 = sum((if is_flo[i] then (A[i]*(1 - eps[i] - tau[i])) else 0) for i in 1:
     NTot)/max(1E-20, AFlo);
 
-  kDir2 = sum((if isFlo[i] then 0 else epsTauA[i]) for i in 1:NTot);
+  kDir2 = sum((if is_flo[i] then 0 else epsTauA[i]) for i in 1:NTot);
 
 
   if (kDir2 > 1E-10) then
     for i in 1:NTot loop
-      if isFlo[i] then
+      if is_flo[i] then
         kDir[i] = epsTauA[i]/AFlo;
       else
         kDir[i] =kDir1/kDir2*epsTauA[i];
@@ -190,7 +190,7 @@ initial equation
   else
         // This branch only happens if k2=0, i.e., there is no surface other than floors
     for i in 1:NTot loop
-      if isFlo[i] then
+      if is_flo[i] then
         kDir[i] = A[i]/AFlo;
       else
         kDir[i] = 0;
@@ -415,6 +415,12 @@ which it is diffusely distributed to the other surfaces.
 </html>",
         revisions="<html>
 <ul>
+<li>
+February 11, 2022, by Michael Wetter:<br/>
+Change parameter <code>isFloor</code> to <code>is_floor</code>,
+and <code>isCeiling</code> to <code>is_ceiling</code>,
+for consistency with naming convention.
+</li>
 <li>
 June 7, 2016, by Michael Wetter:<br/>
 Removed <code>HTot</code> as this is not needed, and refactored

--- a/Buildings/ThermalZones/Detailed/Constructions/BaseClasses/PartialConstruction.mo
+++ b/Buildings/ThermalZones/Detailed/Constructions/BaseClasses/PartialConstruction.mo
@@ -15,9 +15,9 @@ partial model PartialConstruction
 
   parameter Modelica.Units.SI.Angle til "Surface tilt";
 
-  final parameter Boolean isFloor=til > 2.74889125 and til < 3.53428875
+  final parameter Boolean is_floor=til > 2.74889125 and til < 3.53428875
     "Flag, true if construction is a floor" annotation (Evaluate=true);
-  final parameter Boolean isCeiling=til > -0.392699 and til < 0.392699
+  final parameter Boolean is_ceiling=til > -0.392699 and til < 0.392699
     "Flag, true if construction is a floor" annotation (Evaluate=true);
 
   Modelica.Thermal.HeatTransfer.Interfaces.HeatPort_a opa_a
@@ -114,6 +114,12 @@ Buildings.Types.Tilt</a>
 </p>
 </html>", revisions="<html>
 <ul>
+<li>
+February 11, 2022, by Michael Wetter:<br/>
+Change parameter <code>isFloor</code> to <code>is_floor</code>,
+and <code>isCeiling</code> to <code>is_ceiling</code>,
+for consistency with naming convention.
+</li>
 <li>
 October 29, 2016, by Michael Wetter:<br/>
 Propagated parameters for optionally adding states at the surface.<br/>


### PR DESCRIPTION
This closes #2889.
The changes are to protected or final parameters, and to a base class for solar radiation exchange that is only meaningful within the thermal zone model. Hence, the conversion script is not updated.