### PR TITLE
Patch spawn search debug message

### DIFF
--- a/Buildings/Resources/Library/linux64/libModelicaBuildingsEnergyPlus.so
+++ b/Buildings/Resources/Library/linux64/libModelicaBuildingsEnergyPlus.so
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3b778d6aa2474d76f4ddae9686c24497feb56c57955402681f10ff28380a4f7d
-size 72712
+oid sha256:074e4253b4cc69000e630b221f31b001babd8f24886dcb1f22e7e27469a62e04
+size 77008

--- a/Buildings/Resources/Library/win64/ModelicaBuildingsEnergyPlus.dll
+++ b/Buildings/Resources/Library/win64/ModelicaBuildingsEnergyPlus.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a3164dbf808feb713e8dc22bb463733bc26f521e787f70b655d0ed218809f1ed
+oid sha256:b7b0a3b10c5f511ee6467441cec23ae89e4ee1831a1da56c04b8554136ae6b69
 size 142336

--- a/Buildings/Resources/src/ThermalZones/EnergyPlus/C-Sources/BuildingInstantiate.c
+++ b/Buildings/Resources/src/ThermalZones/EnergyPlus/C-Sources/BuildingInstantiate.c
@@ -339,14 +339,14 @@ char* returnSpawnExecutable(FMUBuilding* bui, const char* path, const char* spaw
   else{
     found = false;
     if (bui->logLevel >= MEDIUM){
-      SpawnFormatMessage("%.3f %s: File '%s' does not exists: '%s.",
+      SpawnFormatMessage("%.3f %s: File '%s' does not exists: '%s'.\n",
         bui->time, bui->modelicaNameBuilding, spawnFullPath, strerror(errno));
     }
   }
   /* Make sure the file is executable */
   /* Windows has no mode X_OK = 1, see https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/access-waccess?view=vs-2019 */
 #ifndef _WIN32
-  if( !(found && access(spawnFullPath, X_OK ) == 0) ) {
+  if( found && (! access(spawnFullPath, X_OK ) == 0) ) {
     found = false;
     if (bui->logLevel >= MEDIUM)
       SpawnFormatMessage("%.3f %s: File '%s' exists, but fails to have executable flag set: '%s.",
@@ -906,7 +906,7 @@ void generateAndInstantiateBuilding(FMUBuilding* bui){
         spawnFullPath = findSpawnExe(bui, env, bui->spawnExe);
     }
     if (spawnFullPath == NULL){
-      SpawnFormatError("%s", "Failed to find spawn executable '%s' in Buildings Library installation, on SPAWNPATH and on PATH.");
+      SpawnFormatError("%s", "Failed to find spawn executable in Buildings Library installation, on SPAWNPATH and on PATH.");
     }
     terminateIfSpacesInInstallation(bui);
     /* Generate FMU using spawnFullPath */


### PR DESCRIPTION
This improves logging messages for searching the `PATH` and `SPAWNPATH` for the spawn executable.
(It only applies for the master as 8.1.0 does not implement this search.)