### PR TITLE
Maint 8.1.x - correct backward slashes for Spawn if used with OpenModelica on Windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ services:
 
 env:
   global:
+    - OPTIMICA_VERSION=travis-ubuntu-1804-optimica:r26446
     - ENERGYPLUS_VERSION=EnergyPlus-9.5.0-de239b2e5f-Linux-Ubuntu18.04-x86_64
     - MODELICA_JSON_VERSION=6d950c3592fa021aa914ba4ff34a67cbb69962c6
     - MODELICA_JSON_HOME=${TRAVIS_BUILD_DIR}/modelica-json
@@ -99,7 +100,7 @@ before_install:
        cp Buildings/Resources/Scripts/travis/dymola/dymola $HOME/bin/;
     fi;
   - if [[ "$TEST_ARG" == *test-optimica* ]]; then
-       docker pull "$DOCKER_USERNAME"/travis-ubuntu-1804-optimica:r26446;
+       docker pull "$DOCKER_USERNAME"/${OPTIMICA_VERSION};
        cp Buildings/Resources/Scripts/travis/optimica/jm_ipython.sh $HOME/bin/jm_ipython.sh;
     fi;
   - if [[ "$TEST_ARG" == *test-jmodelica* ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -99,7 +99,7 @@ before_install:
        cp Buildings/Resources/Scripts/travis/dymola/dymola $HOME/bin/;
     fi;
   - if [[ "$TEST_ARG" == *test-optimica* ]]; then
-       docker pull "$DOCKER_USERNAME"/travis-ubuntu-1804-optimica:r19089;
+       docker pull "$DOCKER_USERNAME"/travis-ubuntu-1804-optimica:r26446;
        cp Buildings/Resources/Scripts/travis/optimica/jm_ipython.sh $HOME/bin/jm_ipython.sh;
     fi;
   - if [[ "$TEST_ARG" == *test-jmodelica* ]]; then

--- a/Buildings/Resources/C-Sources/cfdExchangeData.c
+++ b/Buildings/Resources/C-Sources/cfdExchangeData.c
@@ -15,6 +15,9 @@
 
 #include <stdlib.h>
 #include <stdio.h>
+
+#include "ModelicaUtilities.h"
+
 /*
  * Exchange the data between Modelica and CFD
  *

--- a/Buildings/Resources/C-Sources/cfdSendStopCommand.c
+++ b/Buildings/Resources/C-Sources/cfdSendStopCommand.c
@@ -11,6 +11,8 @@
  * \date   8/3/2013
  *
  */
+#include "ModelicaUtilities.h"
+
 #include "cfdCosimulation.h"
 
 /*

--- a/Buildings/Resources/C-Sources/cfdStartCosimulation.c
+++ b/Buildings/Resources/C-Sources/cfdStartCosimulation.c
@@ -14,6 +14,8 @@
  * \date   2/14/2017
  *
  */
+#include "ModelicaUtilities.h"
+
 #include "cfdCosimulation.h"
 
 /*

--- a/Buildings/Resources/C-Sources/cfdcosim.c
+++ b/Buildings/Resources/C-Sources/cfdcosim.c
@@ -19,6 +19,8 @@
  * \date   7/27/2017
  *
  */
+#include "ModelicaUtilities.h"
+
 #include "cfdCosimulation.h"
 
 /*

--- a/Buildings/Resources/C-Sources/exchangeValues.c
+++ b/Buildings/Resources/C-Sources/exchangeValues.c
@@ -13,10 +13,12 @@
  * Pierre Vigouroux, LBNL                  7/18/2011
  */
 
-#include "externalObjectStructure.h"
-
 #include <string.h>
 #include <stdlib.h>
+
+#include "ModelicaUtilities.h"
+
+#include "externalObjectStructure.h"
 
 double exchangeValues(void* object, size_t iX, double x, size_t iY){
   ExternalObjectStructure* table = (ExternalObjectStructure*) object;

--- a/Buildings/Resources/C-Sources/fileWriterFree.c
+++ b/Buildings/Resources/C-Sources/fileWriterFree.c
@@ -2,9 +2,11 @@
  *
  * Michael Wetter, LBNL                     2018-05-12
  */
-#include "fileWriterStructure.h"
 #include <stdlib.h>
 #include <stdio.h>
+#include "ModelicaUtilities.h"
+
+#include "fileWriterStructure.h"
 
 void prependString(const char* fileName, const char* string){
   char *origString;

--- a/Buildings/Resources/C-Sources/fileWriterInit.c
+++ b/Buildings/Resources/C-Sources/fileWriterInit.c
@@ -7,6 +7,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include "ModelicaUtilities.h"
 
 #include "fileWriterStructure.c"
 

--- a/Buildings/Resources/C-Sources/fileWriterStructure.c
+++ b/Buildings/Resources/C-Sources/fileWriterStructure.c
@@ -1,6 +1,8 @@
 #ifndef IBPSA_FILEWRITERStructure_c
 #define IBPSA_FILEWRITERStructure_c
 
+#include "ModelicaUtilities.h"
+
 #include "fileWriterStructure.h"
 
 signed int fileWriterIsUnique(const char* fileName){

--- a/Buildings/Resources/C-Sources/getTimeSpan.c
+++ b/Buildings/Resources/C-Sources/getTimeSpan.c
@@ -2,6 +2,9 @@
  * getTimeSpan.c
  */
 
+#ifndef GETTIMESPAN_C_
+#define GETTIMESPAN_C_
+
 #include <stdio.h>
 #include "ModelicaUtilities.h"
 
@@ -137,3 +140,5 @@ void getTimeSpan(const char * fileName, const char * tabName, double* timeSpan) 
 
   return;
 }
+
+#endif

--- a/Buildings/Resources/C-Sources/getTimeSpan.c
+++ b/Buildings/Resources/C-Sources/getTimeSpan.c
@@ -3,6 +3,7 @@
  */
 
 #include <stdio.h>
+#include "ModelicaUtilities.h"
 
 #include "getTimeSpan.h"
 

--- a/Buildings/Resources/C-Sources/initArray.c
+++ b/Buildings/Resources/C-Sources/initArray.c
@@ -10,9 +10,10 @@
  * Pierre Vigouroux, LBNL                  7/18/2011
  */
 
-#include "externalObjectStructure.h"
-
 #include <stdlib.h>
+#include "ModelicaUtilities.h"
+
+#include "externalObjectStructure.h"
 
 /* Create the structure "table" and return pointer to "table". */
 void* initArray()

--- a/Buildings/Resources/C-Sources/jsonWriterInit.c
+++ b/Buildings/Resources/C-Sources/jsonWriterInit.c
@@ -5,8 +5,10 @@
  * Filip Jorissen, KU Leuven
  */
 
-#include "jsonWriterInit.h"
 #include "fileWriterStructure.c"
+#include "ModelicaUtilities.h"
+
+#include "jsonWriterInit.h"
 
 void* jsonWriterInit(
   const char* instanceName,

--- a/Buildings/Resources/C-Sources/plotFree.c
+++ b/Buildings/Resources/C-Sources/plotFree.c
@@ -4,11 +4,12 @@
  * Michael Wetter, LBNL                  3/23/2018
  */
 
-#include "plotObjectStructure.h"
-
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
+#include "ModelicaUtilities.h"
+
+#include "plotObjectStructure.h"
 
 void plotFree(void* object)
 {

--- a/Buildings/Resources/C-Sources/plotInit.c
+++ b/Buildings/Resources/C-Sources/plotInit.c
@@ -5,10 +5,11 @@
  * Michael Wetter, LBNL                  3/23/2018
  */
 
-#include "plotObjectStructure.h"
-
 #include <stdlib.h>
 #include <stdio.h>
+#include "ModelicaUtilities.h"
+
+#include "plotObjectStructure.h"
 
 void plotWriteHeader(const char* fileName){
   FILE *f = fopen(fileName, "w");

--- a/Buildings/Resources/C-Sources/plotSendString.c
+++ b/Buildings/Resources/C-Sources/plotSendString.c
@@ -4,10 +4,11 @@
  * Michael Wetter, LBNL                  3/23/2018
  */
 
- #include "plotObjectStructure.h"
+#include <string.h>
+#include <stdlib.h>
+#include "ModelicaUtilities.h"
 
- #include <string.h>
- #include <stdlib.h>
+#include "plotObjectStructure.h"
 
 void plotSendString(void* object, const char* str){
   PlotObjectStructure* plt = (PlotObjectStructure*) object;

--- a/Buildings/Resources/C-Sources/plotSendTerminalString.c
+++ b/Buildings/Resources/C-Sources/plotSendTerminalString.c
@@ -4,10 +4,12 @@
  * Michael Wetter, LBNL                  3/23/2018
  */
 
- #include "plotObjectStructure.h"
+#include <string.h>
+#include <stdlib.h>
 
- #include <string.h>
- #include <stdlib.h>
+#include "ModelicaUtilities.h"
+
+#include "plotObjectStructure.h"
 
 void plotSendTerminalString(void* object, const char* str){
   PlotObjectStructure* plt = (PlotObjectStructure*) object;

--- a/Buildings/Resources/C-Sources/pythonWrapper.c
+++ b/Buildings/Resources/C-Sources/pythonWrapper.c
@@ -19,7 +19,7 @@
  * nStrWri      - Number of strings to write.
  */
 
-#include <ModelicaUtilities.h>
+#include "ModelicaUtilities.h"
 
 void pythonExchangeValues(const char * moduleName,
                           const char * functionName,

--- a/Buildings/Resources/Library/win64/ModelicaBuildingsEnergyPlus.dll
+++ b/Buildings/Resources/Library/win64/ModelicaBuildingsEnergyPlus.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bd97f4662456344abfd56fec1d5c5b7a74e6437b68de1001eaf8c4ea5f9bb34a
-size 138752
+oid sha256:337925f242e4b656f9cbd4632ca1285c29daee6159a86d45c692ed8d1cf9ef8b
+size 139264

--- a/Buildings/Resources/Scripts/BuildingsPy/conf.json
+++ b/Buildings/Resources/Scripts/BuildingsPy/conf.json
@@ -114,11 +114,19 @@
     "model_name": "Buildings.ThermalZones.EnergyPlus.Examples.SmallOffice.NoHVAC"
   },
   {
+    "optimica": {
+      "simulate": false,
+      "comment": "Time out. Since oct-r26446"
+    },
+    "model_name": "Buildings.ThermalZones.EnergyPlus.Examples.SmallOffice.Unconditioned"
+  },
+  {
     "jmodelica": {
       "simulate": false
     },
     "optimica": {
-      "rtol": 1E-8
+      "simulate": false,
+      "comment": "Time out. Since oct-r26446"
     },
     "model_name": "Buildings.ThermalZones.EnergyPlus.Examples.SmallOffice.IdealHeatingCoolingSpring"
   },
@@ -212,6 +220,13 @@
     "model_name": "Buildings.Obsolete.Utilities.IO.Python27.Functions.Examples.ExchangeWithPassPythonObject"
   },
   {
+    "optimica": {
+      "simulate": false,
+      "comment": "Fails with 'The rootfinding function failed in an unrecoverable manner.' Since oct-r26446"
+    },
+    "model_name": "Buildings.Examples.DualFanDualDuct.ClosedLoop"
+  },
+  {
        "jmodelica": {
          "rtol": 1E-8
     },
@@ -219,6 +234,13 @@
          "rtol": 1E-8
     },
     "model_name": "Buildings.Examples.DualFanDualDuct.ClosedLoop"
+  },
+  {
+    "optimica": {
+      "simulate": false
+    },
+    "model_name": "Buildings.Experimental.DHC.Loads.BaseClasses.Validation.FlowDistributionPumpControl",
+    "comment": "The rootfinding function failed in an unrecoverable manner. At time 5959.741337. (Radau5ODE fails at 3540.029280) (but works locally)"
   },
   {
     "jmodelica": {

--- a/Buildings/Resources/Scripts/travis/optimica/jm_ipython.sh
+++ b/Buildings/Resources/Scripts/travis/optimica/jm_ipython.sh
@@ -10,7 +10,7 @@
 #################################################
 set -e
 
-IMG_NAME=travis-ubuntu-1804-optimica:r26446
+IMG_NAME=${OPTIMICA_VERSION}
 DOCKER_USERNAME=michaelwetter
 
 NAME=${DOCKER_USERNAME}/${IMG_NAME}
@@ -57,7 +57,7 @@ if [ -z ${MODELICAPATH+x} ]; then
 else
     # Add the current directory to the front of the Modelica path.
     # This will export the directory to the docker, and also set
-    # it in the MODELICAPATH so that JModelica finds it.
+    # it in the MODELICAPATH so that OPTIMICA finds it.
     MODELICAPATH=`pwd`:${MODELICAPATH}
 fi
 
@@ -106,8 +106,10 @@ DOCKER_FLAGS="\
   -w /mnt/shared/${bas_nam} \
   ${NAME}"
 
+# The command below adds various folders in /opt/oct/ThirdParty/MSL to MODELICAPATH
+# to accomodate the change in OCT between oct-r19089 and oct-r26446
 docker run ${DOCKER_FLAGS} /bin/bash -c \
-  "export MODELICAPATH=${DOCKER_MODELICAPATH}:/opt/oct/ThirdParty/MSL && \
+  "export MODELICAPATH=${DOCKER_MODELICAPATH}:/opt/oct/ThirdParty/MSL/MSL323:/opt/oct/ThirdParty/MSL/MSL400:/opt/oct/ThirdParty/MSL && \
    export PYTHONPATH=${DOCKER_PYTHONPATH} && \
    export IPYTHONDIR=/mnt/shared &&
    alias ipython=ipython3 && \

--- a/Buildings/Resources/Scripts/travis/optimica/jm_ipython.sh
+++ b/Buildings/Resources/Scripts/travis/optimica/jm_ipython.sh
@@ -10,7 +10,7 @@
 #################################################
 set -e
 
-IMG_NAME=travis-ubuntu-1804-optimica:r19089
+IMG_NAME=travis-ubuntu-1804-optimica:r26446
 DOCKER_USERNAME=michaelwetter
 
 NAME=${DOCKER_USERNAME}/${IMG_NAME}

--- a/Buildings/Resources/src/ThermalZones/EnergyPlus/C-Sources/SpawnFMU.c
+++ b/Buildings/Resources/src/ThermalZones/EnergyPlus/C-Sources/SpawnFMU.c
@@ -161,6 +161,26 @@ size_t AllocateBuildingDataStructure(
   Buildings_FMUS[nFMU]->nExcObj = 0;
   Buildings_FMUS[nFMU]->exchange = NULL;
 
+#ifdef _WIN32  /* Win32 or Win64 */
+  /* On Windows, with OpenModelica 1.19.0-dev, the buildingsRootFileLocation
+     is something like C:\inst\Buildings\legal.html, whereas with
+     Dymola 2022x on Windows, it is C:/inst/Buildings/legal.html.
+     Therefore, we switch the separators.
+     This is for https://github.com/lbl-srg/modelica-buildings/issues/2924 */
+  replaceChar(Buildings_FMUS[nFMU]->buildingsLibraryRoot, '\\', '/');
+  /* Clean up other path, as they can lead to errors such as in
+  [json.exception.parse_error.101] parse error at line 4, column 16: ... invalid string:
+    forbidden character after backslash; last read: '"F:\m'"
+  See https://github.com/lbl-srg/modelica-buildings/issues/2924 */
+  replaceChar(Buildings_FMUS[nFMU]->idfName,   '\\', '/');
+  replaceChar(Buildings_FMUS[nFMU]->weather,   '\\', '/');
+  replaceChar(Buildings_FMUS[nFMU]->tmpDir,    '\\', '/');
+  replaceChar(Buildings_FMUS[nFMU]->fmuAbsPat, '\\', '/');
+  if (usePrecompiledFMU)
+    replaceChar(Buildings_FMUS[nFMU]->precompiledFMUAbsPat, '\\', '/');
+
+#endif
+
   /* Create the temporary directory */
   createDirectory(Buildings_FMUS[nFMU]->tmpDir, SpawnFormatError);
 

--- a/Buildings/Resources/src/ThermalZones/EnergyPlus/C-Sources/SpawnUtil.h
+++ b/Buildings/Resources/src/ThermalZones/EnergyPlus/C-Sources/SpawnUtil.h
@@ -66,6 +66,8 @@ void saveAppendJSONElements(
   size_t* bufLen,
   void (*SpawnFormatError)(const char *string, ...));
 
+void replaceChar(char *str, char find, char replace);
+
 void checkAndSetVerbosity(FMUBuilding* bui, const int logLevel);
 
 void setFMUMode(FMUBuilding* bui, FMUMode mode);

--- a/Buildings/ThermalZones/EnergyPlus/BaseClasses/package.mo
+++ b/Buildings/ThermalZones/EnergyPlus/BaseClasses/package.mo
@@ -1,12 +1,16 @@
 within Buildings.ThermalZones.EnergyPlus;
 package BaseClasses "Package with base classes for Buildings.ThermalZones.EnergyPlus"
   extends Modelica.Icons.BasesPackage;
-  constant String buildingsLibraryRoot=Modelica.Utilities.Strings.replace(
-    string=Modelica.Utilities.Files.fullPathName(Modelica.Utilities.Files.loadResource("modelica://Buildings/legal.html")),
-    searchString="/legal.html",
-    replaceString="")
+  constant String buildingsLibraryRoot=
+    Modelica.Utilities.Strings.substring(
+      string=legalFileLocation,
+      startIndex=1,
+      endIndex=Modelica.Utilities.Strings.length(legalFileLocation)-11)
     "Root directory of the Buildings library (used to find the spawn executable)";
 
+  protected
+  constant String legalFileLocation = Modelica.Utilities.Files.fullPathName(Modelica.Utilities.Files.loadResource("modelica://Buildings/legal.html"))
+    "Location of legal.html file (used to find the spawn executable)";
   annotation (
     preferredView="info",
     Documentation(

--- a/Buildings/ThermalZones/EnergyPlus/BaseClasses/package.order
+++ b/Buildings/ThermalZones/EnergyPlus/BaseClasses/package.order
@@ -7,4 +7,5 @@ getUnitAsString
 initialize
 Synchronize
 buildingsLibraryRoot
+legalFileLocation
 Validation

--- a/Buildings/package.mo
+++ b/Buildings/package.mo
@@ -255,12 +255,13 @@ have been <b style=\"color:blue\">improved</b> in a
                        <a href=\"https://github.com/lbl-srg/modelica-buildings/issues/2835\">issue 2835</a>.
     </td>
 </tr>
-<tr><td colspan=\"2\"><b>xxx</b>
+<tr><td colspan=\"2\"><b>Buildings.ThermalZones.EnergyPlus</b>
     </td>
 </tr>
-<tr><td valign=\"top\">xxx
+<tr><td valign=\"top\">Buildings.ThermalZones.EnergyPlus
     </td>
-    <td valign=\"top\">xxx.
+    <td valign=\"top\">Changed handling of forward and backward slashes on Windows.
+                       Now models in this package also work with OpenModelica on Windows.
     </td>
 </tr>
 </table>


### PR DESCRIPTION
This is based on `maint_8.1.x_IBPSASync_issue1594_headerFiles`.

This enables simulation of Spawn also for OpenModelica on Windows.

This avoids errors such as 
```
[json.exception.parse_error.101] parse error at line 4, column 16: syntax error while parsing value-invalid string: forbidden character after backslash; last read: ‘“C:\U’”
```
on Windows. See also https://github.com/lbl-srg/modelica-buildings/issues/2924#issue-1172246345