### PR TITLE
Updated BuildingsPy to version that does not import matplotlib.pyplot

### DIFF
--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -40,7 +40,7 @@ jobs:
         run: pip3 install --upgrade pip wheel
 
       - name: "Install BuildingsPy"
-        run: pip3 install git+https://github.com/lbl-srg/BuildingsPy@1b4308545bc793718c2c7b5b25a3f0f9df12588e
+        run: pip3 install git+https://github.com/lbl-srg/BuildingsPy@e52684deb8c2c2846faaa21c426999fecf3ad58f
 
       - name: "Test html syntax"
         run : ../bin/runUnitTests.py --validate-html-only

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ services:
 
 env:
   global:
-    - BUILDINGSPY_VERSION=BuildingsPy@1b4308545bc793718c2c7b5b25a3f0f9df12588e
+    - BUILDINGSPY_VERSION=BuildingsPy@e52684deb8c2c2846faaa21c426999fecf3ad58f
     - OMC_VERSION=ubuntu-2004-omc:1.19.0_dev-613-gd6e04c0-1
     - OPTIMICA_VERSION=travis-ubuntu-1804-optimica:r26446
     - DYMOLA_VERSION=travis_ubuntu-2004_dymola:2022x-x86_64


### PR DESCRIPTION
This avoids issues on travis as the import sometimes fails with an error due to the headless setup