### PR TITLE
Issue2905 steam dhs full sys patch single boiler

### DIFF
--- a/Buildings/Experimental/DHC/Networks/BaseClasses/PartialConnection2Pipe2Medium.mo
+++ b/Buildings/Experimental/DHC/Networks/BaseClasses/PartialConnection2Pipe2Medium.mo
@@ -9,16 +9,18 @@ partial model PartialConnection2Pipe2Medium "Partial model for connecting an
     "Medium model for return fluid";
 
   replaceable model Model_pipDisSup =
-      Buildings.Fluid.Interfaces.PartialTwoPortInterface (
-    redeclare final package Medium = MediumSup,
-    final m_flow_nominal=mDis_flow_nominal,
-    final allowFlowReversal=allowFlowReversal)
+      Buildings.Fluid.Interfaces.PartialTwoPortInterface
+      constrainedby Buildings.Fluid.Interfaces.PartialTwoPortInterface(
+        redeclare final package Medium = MediumSup,
+        final m_flow_nominal=mDis_flow_nominal,
+        final allowFlowReversal=allowFlowReversal)
     "Interface for inlet pipe for the distribution supply";
   replaceable model Model_pipDisRet =
-      Buildings.Fluid.Interfaces.PartialTwoPortInterface (
-    redeclare final package Medium = MediumRet,
-    final m_flow_nominal=mDis_flow_nominal,
-    final allowFlowReversal=allowFlowReversal)
+      Buildings.Fluid.Interfaces.PartialTwoPortInterface
+      constrainedby Buildings.Fluid.Interfaces.PartialTwoPortInterface (
+        redeclare final package Medium = MediumRet,
+        final m_flow_nominal=mDis_flow_nominal,
+        final allowFlowReversal=allowFlowReversal)
     "Interface for outlet pipe for the distribution return";
 
   parameter Modelica.Units.SI.MassFlowRate mDis_flow_nominal

--- a/Buildings/Experimental/DHC/Networks/BaseClasses/PartialDistribution2Pipe2Medium.mo
+++ b/Buildings/Experimental/DHC/Networks/BaseClasses/PartialDistribution2Pipe2Medium.mo
@@ -4,9 +4,10 @@ partial model PartialDistribution2Pipe2Medium
   extends
     Buildings.Experimental.DHC.Networks.BaseClasses.PartialDistribution2Medium;
   replaceable model Model_pipDis =
-      Buildings.Fluid.Interfaces.PartialTwoPortInterface (
-    redeclare final package Medium=MediumSup,
-    final allowFlowReversal=allowFlowReversal)
+      Buildings.Fluid.Interfaces.PartialTwoPortInterface
+      constrainedby Buildings.Fluid.Interfaces.PartialTwoPortInterface(
+        redeclare final package Medium=MediumSup,
+        final allowFlowReversal=allowFlowReversal)
     "Model for distribution pipe";
   parameter Boolean show_heaFlo=false
     "Set to true to output the heat flow rate transferred to each connected load"
@@ -63,7 +64,10 @@ partial model PartialDistribution2Pipe2Medium
   // COMPONENTS
   replaceable
     Buildings.Experimental.DHC.Networks.BaseClasses.PartialConnection2Pipe2Medium
-    con[nCon](
+    con[nCon]
+    constrainedby Buildings.Experimental.DHC.Networks.BaseClasses.PartialConnection2Pipe2Medium(
+    redeclare each final package MediumSup = MediumSup,
+    redeclare each final package MediumRet = MediumRet,
     final mDis_flow_nominal=mDisCon_flow_nominal,
     final mCon_flow_nominal=mCon_flow_nominal,
     each final allowFlowReversal=allowFlowReversal,

--- a/Buildings/Experimental/DHC/Plants/Steam/SingleBoiler.mo
+++ b/Buildings/Experimental/DHC/Plants/Steam/SingleBoiler.mo
@@ -64,7 +64,7 @@ model SingleBoiler "A generic steam plant with a single boiler that discharges
   parameter Modelica.Media.Interfaces.Types.AbsolutePressure pBoi_start=pSteSet
     "Start value of boiler pressure"
     annotation(Dialog(tab = "Initialization"));
-parameter Real yPum_start=0.7 "Initial value of output"
+  parameter Real yPum_start=0.7 "Initial value of output"
     annotation(Dialog(tab="Initialization"));
 
   // Dynamics
@@ -211,7 +211,7 @@ parameter Real yPum_start=0.7 "Initial value of output"
   Buildings.Fluid.Storage.ExpansionVessel tanFW(
     redeclare final package Medium = Medium,
     final V_start=VTanFW_start,
-    final p=pTanFW)
+    final p_start=pTanFW)
     "Feedwater tank"
     annotation (Placement(transformation(extent={{-80,20},{-60,40}})));
   Buildings.Fluid.FixedResistances.CheckValve cheVal(


### PR DESCRIPTION
@dhblum @khinkelman : This allows `Buildings.Experimental.DHC.Plants.Steam.Examples.SingleBoiler` to compile in OpenModelica.
Note that the `constrainedby` clause was missing. Without it, the parameter assignments are not preserved (some tools preserve the medium assignment, but it is not required without the `constrainedby` clause).

Simulation fails with `division by zero at time 0, (a=0) / (b=0), where divisor b expression is: 0.0`. I think this is an open issue in OpenModelica as we have other fluid models with this behavior.

I also changed the expansion vessel pressure assignment from `p` to `p_start`, as `p` turns out to be not used and will be removed.

@dhblum : Please go ahead and merge it to your development branch if you agree with the changes, and delete this branch `issue2905_steamDHS_fullSys...issue2905_steamDHS_fullSys_patch_SingleBoiler`