### PR TITLE
Added documentation about leap year

### DIFF
--- a/Buildings/ThermalZones/EnergyPlus_9_6_0/UsersGuide.mo
+++ b/Buildings/ThermalZones/EnergyPlus_9_6_0/UsersGuide.mo
@@ -324,6 +324,10 @@ method can be used.
 The coupling time step is determined by EnergyPlus based on the zone time step,
 as declared in the idf file.
 </li>
+<li>
+In EnergyPlus, a year of simulation always has 365 days, i.e., leap years are not considered.
+This is done because in the Modelica Buildings Library, weather files are assumed to have a periodicity of 365 days.
+</li>
 </ul>
 </html>"));
   end Conventions;


### PR DESCRIPTION
This clarifies that in EnergyPlus, a year always has 365 days.