### PR TITLE
Maint 8.1.x patch default component prefix boiler

### DIFF
--- a/Buildings/Fluid/Boilers/Data/Lochinvar/Crest/FBdash2501.mo
+++ b/Buildings/Fluid/Boilers/Data/Lochinvar/Crest/FBdash2501.mo
@@ -12,7 +12,10 @@ record FBdash2501 "Specifications for Lochinvar Crest FB-2501 boiler"
     mDry = 1168.907537,
     m_flow_nominal = 15.141647,
     dp_nominal = 25107.43);
-  annotation (Documentation(info="<html>
+    annotation (
+  defaultComponentName = "per",
+  defaultComponentPrefixes = "parameter",
+  Documentation(info="<html>
 <p>
 Performance data for boiler model.
 See the documentation of

--- a/Buildings/Fluid/Boilers/Data/Lochinvar/Crest/FBdash3001.mo
+++ b/Buildings/Fluid/Boilers/Data/Lochinvar/Crest/FBdash3001.mo
@@ -6,7 +6,10 @@ record FBdash3001 "Specifications for Lochinvar Crest FB-3001 boiler"
     mDry = 1306.799618,
     m_flow_nominal = 18.169977,
     dp_nominal = 23911.84);
-  annotation (Documentation(info="<html>
+    annotation (
+  defaultComponentName = "per",
+  defaultComponentPrefixes = "parameter",
+  Documentation(info="<html>
 <p>
 Performance data for boiler model.
 See the documentation of

--- a/Buildings/Fluid/Boilers/Data/Lochinvar/Crest/FBdash3501.mo
+++ b/Buildings/Fluid/Boilers/Data/Lochinvar/Crest/FBdash3501.mo
@@ -6,7 +6,10 @@ record FBdash3501 "Specifications for Lochinvar Crest FB-3501 boiler"
     mDry = 1459.660247,
     m_flow_nominal = 21.198306,
     dp_nominal = 29590.90);
-  annotation (Documentation(info="<html>
+    annotation (
+  defaultComponentName = "per",
+  defaultComponentPrefixes = "parameter",
+  Documentation(info="<html>
 <p>
 Performance data for boiler model.
 See the documentation of

--- a/Buildings/Fluid/Boilers/Data/Lochinvar/Crest/FBdash4001.mo
+++ b/Buildings/Fluid/Boilers/Data/Lochinvar/Crest/FBdash4001.mo
@@ -7,7 +7,10 @@ record FBdash4001 "Specifications for Lochinvar Crest FB-4001 boiler"
     m_flow_nominal = 22.081569,
     dp_nominal = 32579.88);
     // Data of this model are based on 22F of dT instead of 20F.
-  annotation (Documentation(info="<html>
+    annotation (
+  defaultComponentName = "per",
+  defaultComponentPrefixes = "parameter",
+  Documentation(info="<html>
 <p>
 Performance data for boiler model.
 See the documentation of

--- a/Buildings/Fluid/Boilers/Data/Lochinvar/Crest/FBdash5001.mo
+++ b/Buildings/Fluid/Boilers/Data/Lochinvar/Crest/FBdash5001.mo
@@ -6,7 +6,10 @@ record FBdash5001 "Specifications for Lochinvar Crest FB-5001 boiler"
     mDry = 1860.182309,
     m_flow_nominal = 30.283294,
     dp_nominal = 41546.82);
-  annotation (Documentation(info="<html>
+    annotation (
+  defaultComponentName = "per",
+  defaultComponentPrefixes = "parameter",
+  Documentation(info="<html>
 <p>
 Performance data for boiler model.
 See the documentation of

--- a/Buildings/Fluid/Boilers/Data/Lochinvar/Crest/FBdash6001.mo
+++ b/Buildings/Fluid/Boilers/Data/Lochinvar/Crest/FBdash6001.mo
@@ -6,7 +6,10 @@ record FBdash6001 "Specifications for Lochinvar Crest FB-6001 boiler"
     mDry = 2136.873655,
     m_flow_nominal = 36.339953,
     dp_nominal = 51410.46);
-  annotation (Documentation(info="<html>
+    annotation (
+  defaultComponentName = "per",
+  defaultComponentPrefixes = "parameter",
+  Documentation(info="<html>
 <p>
 Performance data for boiler model.
 See the documentation of

--- a/Buildings/Fluid/Boilers/Data/Lochinvar/FTXL/FTX400.mo
+++ b/Buildings/Fluid/Boilers/Data/Lochinvar/FTXL/FTX400.mo
@@ -12,7 +12,10 @@ record FTX400 "Specifications for Lochinvar FTXL FTX400 boiler"
     mDry=216.8171529,
     m_flow_nominal=2.460518,
     dp_nominal=10461.43);
-  annotation (Documentation(info="<html>
+    annotation (
+  defaultComponentName = "per",
+  defaultComponentPrefixes = "parameter",
+  Documentation(info="<html>
 <p>
 Performance data for boiler model.
 See the documentation of

--- a/Buildings/Fluid/Boilers/Data/Lochinvar/FTXL/FTX500.mo
+++ b/Buildings/Fluid/Boilers/Data/Lochinvar/FTXL/FTX500.mo
@@ -6,7 +6,10 @@ record FTX500 "Specifications for Lochinvar FTXL FTX500 boiler"
     mDry=228.6105545,
     m_flow_nominal=3.091420,
     dp_nominal=3.091420);
-  annotation (Documentation(info="<html>
+    annotation (
+  defaultComponentName = "per",
+  defaultComponentPrefixes = "parameter",
+  Documentation(info="<html>
 <p>
 Performance data for boiler model.
 See the documentation of

--- a/Buildings/Fluid/Boilers/Data/Lochinvar/FTXL/FTX600.mo
+++ b/Buildings/Fluid/Boilers/Data/Lochinvar/FTXL/FTX600.mo
@@ -6,7 +6,10 @@ record FTX600 "Specifications for Lochinvar FTXL FTX600 boiler"
     mDry=228.6105545,
     m_flow_nominal=3.722322,
     dp_nominal=13151.51);
-  annotation (Documentation(info="<html>
+    annotation (
+  defaultComponentName = "per",
+  defaultComponentPrefixes = "parameter",
+  Documentation(info="<html>
 <p>
 Performance data for boiler model.
 See the documentation of

--- a/Buildings/Fluid/Boilers/Data/Lochinvar/FTXL/FTX725.mo
+++ b/Buildings/Fluid/Boilers/Data/Lochinvar/FTXL/FTX725.mo
@@ -6,7 +6,10 @@ record FTX725 "Specifications for Lochinvar FTXL FTX725 boiler"
     mDry=260.8156128,
     m_flow_nominal=4.479404,
     dp_nominal=14646.00);
-  annotation (Documentation(info="<html>
+    annotation (
+  defaultComponentName = "per",
+  defaultComponentPrefixes = "parameter",
+  Documentation(info="<html>
 <p>
 Performance data for boiler model.
 See the documentation of

--- a/Buildings/Fluid/Boilers/Data/Lochinvar/FTXL/FTX850.mo
+++ b/Buildings/Fluid/Boilers/Data/Lochinvar/FTXL/FTX850.mo
@@ -6,7 +6,10 @@ record FTX850 "Specifications for Lochinvar FTXL FTX850 boiler"
     mDry=273.9697915,
     m_flow_nominal=5.236486,
     dp_nominal=17037.19);
-  annotation (Documentation(info="<html>
+    annotation (
+  defaultComponentName = "per",
+  defaultComponentPrefixes = "parameter",
+  Documentation(info="<html>
 <p>
 Performance data for boiler model.
 See the documentation of

--- a/Buildings/Fluid/Boilers/Data/Lochinvar/KnightXL/KBXdash0400.mo
+++ b/Buildings/Fluid/Boilers/Data/Lochinvar/KnightXL/KBXdash0400.mo
@@ -11,7 +11,10 @@ record KBXdash0400 "Specifications for Lochinvar Knight XL KBX-0400 boiler"
     VWat = 0.016655812,
     m_flow_nominal= 2.397427,
     dp_nominal = 29889.80);
-  annotation (Documentation(info="<html>
+    annotation (
+  defaultComponentName = "per",
+  defaultComponentPrefixes = "parameter",
+  Documentation(info="<html>
 <p>
 Performance data for boiler model.
 See the documentation of

--- a/Buildings/Fluid/Boilers/Data/Lochinvar/KnightXL/KBXdash0500.mo
+++ b/Buildings/Fluid/Boilers/Data/Lochinvar/KnightXL/KBXdash0500.mo
@@ -5,7 +5,10 @@ record KBXdash0500 "Specifications for Lochinvar Knight XL KBX-0500 boiler"
     VWat = 0.018548518,
     m_flow_nominal = 3.028329,
     dp_nominal = 41845.72);
-  annotation (Documentation(info="<html>
+    annotation (
+  defaultComponentName = "per",
+  defaultComponentPrefixes = "parameter",
+  Documentation(info="<html>
 <p>
 Performance data for boiler model.
 See the documentation of

--- a/Buildings/Fluid/Boilers/Data/Lochinvar/KnightXL/KBXdash0650.mo
+++ b/Buildings/Fluid/Boilers/Data/Lochinvar/KnightXL/KBXdash0650.mo
@@ -5,7 +5,10 @@ record KBXdash0650 "Specifications for Lochinvar Knight XL KBX-0650 boiler"
     VWat = 0.023469553,
     m_flow_nominal = 3.911592,
     dp_nominal = 47823.68);
-  annotation (Documentation(info="<html>
+    annotation (
+  defaultComponentName = "per",
+  defaultComponentPrefixes = "parameter",
+  Documentation(info="<html>
 <p>
 Performance data for boiler model.
 See the documentation of

--- a/Buildings/Fluid/Boilers/Data/Lochinvar/KnightXL/KBXdash0800.mo
+++ b/Buildings/Fluid/Boilers/Data/Lochinvar/KnightXL/KBXdash0800.mo
@@ -5,7 +5,10 @@ record KBXdash0800 "Specifications for Lochinvar Knight XL KBX-0800 boiler"
     VWat = 0.027633506,
     m_flow_nominal = 4.794855,
     dp_nominal = 50812.66);
-  annotation (Documentation(info="<html>
+    annotation (
+  defaultComponentName = "per",
+  defaultComponentPrefixes = "parameter",
+  Documentation(info="<html>
 <p>
 Performance data for boiler model.
 See the documentation of

--- a/Buildings/Fluid/Boilers/Data/Lochinvar/KnightXL/KBXdash1000.mo
+++ b/Buildings/Fluid/Boilers/Data/Lochinvar/KnightXL/KBXdash1000.mo
@@ -5,7 +5,10 @@ record KBXdash1000 "Specifications for Lochinvar Knight XL KBX-1000 boiler"
     VWat = 0.033311624,
     m_flow_nominal = 6.056659,
     dp_nominal = 53801.64);
-  annotation (Documentation(info="<html>
+    annotation (
+  defaultComponentName = "per",
+  defaultComponentPrefixes = "parameter",
+  Documentation(info="<html>
 <p>
 Performance data for boiler model.
 See the documentation of

--- a/Buildings/package.mo
+++ b/Buildings/package.mo
@@ -248,6 +248,11 @@ have been <b style=\"color:blue\">improved</b> in a
 <tr><td colspan=\"2\"><b>Buildings.Fluid</b>
   </td>
 </tr>
+<tr><td valign=\"top\">Buildings.Fluid.Boilers.Data.Lochinvar
+  </td>
+  <td valign=\"top\">Added annotation <code>defaultComponentPrefixes = \"parameter\"</code>.
+  </td>
+</tr>
 <tr><td valign=\"top\">Buildings.Fluid.HeatPumps.Data.EquationFitReversible.Generic
   </td>
   <td valign=\"top\">Removed <code>protected</code> declaration inside the record as the Modelica Language Specification

--- a/Buildings/package.mo
+++ b/Buildings/package.mo
@@ -204,6 +204,122 @@ Each class (i.e., model, block and function) must be used in an example or valid
   package ReleaseNotes "Release notes"
     extends Modelica.Icons.ReleaseNotes;
 
+class Version_8_1_2 "Version 8.1.2"
+  extends Modelica.Icons.ReleaseNotes;
+    annotation (Documentation(info="<html>
+<div class=\"release-summary\">
+<p>
+Version 8.1.2 is ... xxx
+</p>
+</div>
+<!-- New libraries -->
+<p>
+The following <b style=\"color:blue\">new libraries</b> have been added:
+</p>
+<table class=\"releaseTable\" summary=\"summary\" border=\"1\" cellspacing=\"0\" cellpadding=\"2\">
+<tr><td valign=\"top\">xxx
+    </td>
+    <td valign=\"top\">xxx.
+    </td>
+    </tr>
+</table>
+<!-- New components for existing libraries -->
+<p>
+The following <b style=\"color:blue\">new components</b> have been added
+to <b style=\"color:blue\">existing</b> libraries:
+</p>
+<table class=\"releaseTable\" summary=\"summary\" border=\"1\" cellspacing=\"0\" cellpadding=\"2\" style=\"border-collapse:collapse;\">
+<tr><td colspan=\"2\"><b>xxx</b>
+    </td>
+</tr>
+<tr><td valign=\"top\">xxx
+    </td>
+    <td valign=\"top\">xxx.
+    </td>
+    </tr>
+</table>
+<!-- Backward compatible changes -->
+<p>
+The following <b style=\"color:blue\">existing components</b>
+have been <b style=\"color:blue\">improved</b> in a
+<b style=\"color:blue\">backward compatible</b> way:
+</p>
+<table class=\"releaseTable\" summary=\"summary\" border=\"1\" cellspacing=\"0\" cellpadding=\"2\" style=\"border-collapse:collapse;\">
+<tr><td colspan=\"2\"><b>xxx</b>
+    </td>
+</tr>
+<tr><td valign=\"top\">xxx
+    </td>
+    <td valign=\"top\">xxx.
+    </td>
+</tr>
+<tr><td colspan=\"2\"><b>xxx</b>
+    </td>
+</tr>
+<tr><td valign=\"top\">xxx
+    </td>
+    <td valign=\"top\">xxx.
+    </td>
+</tr>
+</table>
+<!-- Non-backward compatible changes to existing components -->
+<p>
+The following <b style=\"color:blue\">existing components</b>
+have been <b style=\"color:blue\">improved</b> in a
+<b style=\"color:blue\">non-backward compatible</b> way:
+</p>
+<table class=\"releaseTable\" summary=\"summary\" border=\"1\" cellspacing=\"0\" cellpadding=\"2\" style=\"border-collapse:collapse;\">
+ <tr><td colspan=\"2\"><b>xxx</b>
+    </td>
+</tr>
+<tr><td valign=\"top\">xxx
+    </td>
+    <td valign=\"top\">xxx.
+    </td>
+</tr>
+</table>
+<!-- Errors that have been fixed -->
+<p>
+The following <b style=\"color:red\">critical errors</b> have been fixed (i.e., errors
+that can lead to wrong simulation results):
+</p>
+<table class=\"releaseTable\" summary=\"summary\" border=\"1\" cellspacing=\"0\" cellpadding=\"2\" style=\"border-collapse:collapse;\">
+<tr><td colspan=\"2\"><b>xxx</b>
+    </td>
+</tr>
+<tr><td valign=\"top\">xxx
+    </td>
+    <td valign=\"top\">xxx.
+    </td>
+</tr>
+</table>
+<!-- Uncritical errors -->
+<p>
+The following <b style=\"color:red\">uncritical errors</b> have been fixed (i.e., errors
+that do <b style=\"color:red\">not</b> lead to wrong simulation results, e.g.,
+units are wrong or errors in documentation):
+</p>
+<table class=\"releaseTable\" summary=\"summary\" border=\"1\" cellspacing=\"0\" cellpadding=\"2\" style=\"border-collapse:collapse;\">
+<tr><td colspan=\"2\"><b>xxx</b>
+    </td>
+</tr>
+<tr><td valign=\"top\">xxx
+    </td>
+    <td valign=\"top\">xxx.
+    </td>
+</tr>
+</table>
+<p>
+Note:
+</p>
+<ul>
+<li>
+xxx
+</li>
+</ul>
+</html>"));
+end Version_8_1_2;
+
   class Version_8_1_1 "Version 8.1.1"
     extends Modelica.Icons.ReleaseNotes;
     annotation (Documentation(info="<html>
@@ -211,6 +327,12 @@ Each class (i.e., model, block and function) must be used in an example or valid
 <p>
 Version 8.1.1 is a patch that has backward compatible bug fixes.
 It is backwards compatible with version 8.0.0 and 8.1.0.
+</p>
+<p>
+The library has been tested with Dymola 2022,
+JModelica (revision 14023),
+OpenModelica 1.19.0-dev (449+g4f16e6af22),
+OPTIMICA (revision OCT-dev-r26446_JM-r14295) and recent versions of Impact.
 </p>
 </div>
   <!-- New libraries -->
@@ -9443,6 +9565,9 @@ on the Buildings library.
 </p>
 <ul>
 <li>
+<a href=\"modelica://Buildings.UsersGuide.ReleaseNotes.Version_8_1_2\">Version 8.1.2</a> (xxx)
+</li>
+<li>
 <a href=\"modelica://Buildings.UsersGuide.ReleaseNotes.Version_8_1_1\">Version 8.1.1</a> (May 12, 2022)
 </li>
 <li>
@@ -9964,13 +10089,14 @@ end UsersGuide;
 
 annotation (
 preferredView="info",
-version="8.1.1",
+version="8.1.2",
 versionDate="2021-06-08",
 dateModified="2022-05-12",
 uses(Modelica(version="3.2.3")),
 conversion(
   noneFromVersion="8.0.0",
   noneFromVersion="8.1.0",
+  noneFromVersion="8.1.1",
   from(version={"7.0.0", "7.0.1"},
       script="modelica://Buildings/Resources/Scripts/Dymola/ConvertBuildings_from_7_to_8.1.0.mos")),
 preferredView="info",


### PR DESCRIPTION
This adds `defaultComponentPrefixes = "parameter"` to the maintenance branch.
It contains https://github.com/lbl-srg/modelica-buildings/pull/3011