### PR TITLE
Handle spaces in paths when installing Spawn

### DIFF
--- a/Buildings/Resources/src/ThermalZones/install.py
+++ b/Buildings/Resources/src/ThermalZones/install.py
@@ -21,9 +21,9 @@ if __name__ == '__main__':
   # Parse the arguments
   args = parser.parse_args()
 
-  proc= os.path.join(os.path.dirname(os.path.realpath(__file__)),  "EnergyPlus_9_6_0", "install.py")
+  proc=[os.path.join(os.path.dirname(os.path.realpath(__file__)),  "EnergyPlus_9_6_0", "install.py")]
 
   if args.binaries_for_os_only:
-    proc = f"{proc} --binaries-for-os-only"
+    proc += ["--binaries-for-os-only"]
 
   subprocess.run(proc, shell=True)


### PR DESCRIPTION
Note: `shell=True` could probably be changed to `False` since no shell interpretation should be needed anymore. I created a minimal fix instead.

```
modelica-buildings$ cp -a Buildings/ Buildings\ blabla
modelica-buildings$ Buildings\ blabla/Resources/src/ThermalZones/install.py
/bin/sh: 1: /home/marsj/modelica-buildings/Buildings: Permission denied
```

Should probably also be fixed for 9.x maintenance