### PR TITLE
Updated set up of github actions

### DIFF
--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -29,9 +29,9 @@ jobs:
     steps:
       # Checks-out repository under $GITHUB_WORKSPACE, so job can access it
       - name: Checkout code
-        uses: nschloe/action-cached-lfs-checkout@v1
+        uses: actions/checkout@v3
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: '3.8.10' # Version range or exact version of a Python version to use, using SemVer's version range syntax
           architecture: 'x64' # optional x64 or x86. Defaults to x64 if not specified


### PR DESCRIPTION
This removes deprecated version (https://github.com/lbl-srg/modelica-buildings/actions/runs/3605039255) and git-lfs