### PR TITLE
Added Plants.Cooling.Examples.ElectricChillerParallel

### DIFF
--- a/Buildings/Resources/Scripts/BuildingsPy/conf.yml
+++ b/Buildings/Resources/Scripts/BuildingsPy/conf.yml
@@ -159,9 +159,6 @@
   openmodelica:
     comment: 'division by zero at time 0, (a=0) / (b=0), where divisor b expression is: 0.0'
     simulate: false
-  optimica:
-    comment: Time out, but simulates fast with Dymola and CVOde
-    simulate: false
 - model_name: Buildings.Fluid.Examples.FlowSystem.Basic
   openmodelica:
     comment: '''omc'' caused ''simulation terminated by an assertion at initialization''.'


### PR DESCRIPTION
This adds Buildings.Experimental.DHC.Plants.Cooling.Examples.ElectricChillerParallel to the list of models simulated with OCT. It works locally and in Modelon's CI tests.