### PR TITLE
Made the sci_reader.c robust for data stored with carriage return

### DIFF
--- a/Buildings/Resources/src/FastFluidDynamics/sci_reader.c
+++ b/Buildings/Resources/src/FastFluidDynamics/sci_reader.c
@@ -221,7 +221,7 @@ int read_sci_input(PARA_DATA *para, REAL **var, int **BINDEX) {
       .......................................................................*/
       fgets(string, 400, file_params);
       /* Get the length of name (The name may contain white space)*/
-      for(j=0; string[j] != '\n'; j++) {
+      for(j=0; string[j] != '\n' && string[j] != '\r'; j++) {
         continue;
       }
 
@@ -319,7 +319,7 @@ int read_sci_input(PARA_DATA *para, REAL **var, int **BINDEX) {
       .......................................................................*/
       fgets(string, 400, file_params);
       /* Get the length of name (The name may contain white space)*/
-      for(j=0; string[j] != '\n'; j++) {
+      for(j=0; string[j] != '\n' && string[j] != '\r'; j++) {
         continue;
       }
 
@@ -562,7 +562,7 @@ int read_sci_input(PARA_DATA *para, REAL **var, int **BINDEX) {
       .......................................................................*/
       fgets(string, 400, file_params);
       /* Get the length of name (The name may contain white space)*/
-      for(j=0; string[j] != '\n'; j++) {
+      for(j=0; string[j] != '\n' && string[j] != '\r'; j++) {
         continue;
       }
 
@@ -714,7 +714,7 @@ int read_sci_input(PARA_DATA *para, REAL **var, int **BINDEX) {
       .......................................................................*/
       fgets(string, 400, file_params);
       /* Get the length of name (The name may contain white space)*/
-      for(j=0; string[j] != '\n'; j++) {
+      for(j=0; string[j] != '\n' && string[j] != '\r'; j++) {
         continue;
       }
 


### PR DESCRIPTION
If the CFD resource files (for example https://github.com/lbl-srg/modelica-buildings/blob/master/Buildings/Resources/Data/ThermalZones/Detailed/Examples/FFD/WindowWithShade.cfd ) are stored on Windows with Windows line endings that includes the carriage return character (\r), the data will fail to load due to that the names read in the sci_reader file will contain an additional character (\r) appended to their names.

This was seen when running the example Buildings.ThermalZones.Detailed.Examples.FFD.WindowWithShade when the Buildings library was copied from a Windows machine to a Linux machine.

This pull request will make the reading of the names more robust and will handle data stored with Windows line endings.