### PR TITLE
Made the exchange of data more robust by making sure that the outputs are always copied

### DIFF
--- a/Buildings/Resources/C-Sources/cfdExchangeData.c
+++ b/Buildings/Resources/C-Sources/cfdExchangeData.c
@@ -34,11 +34,12 @@
 int cfdExchangeData(double t0, double dt, const double *u, size_t nU, size_t nY,
                  double *t1, double *y) {
   size_t i, j, k;
+  int writeData = 1;
 
   /*check if current modelica time equals to last time*/
-  /*if yes, it means cfdExchangeData() was called multiple times at one synchronization point, then directly return*/
+  /*if yes, it means cfdExchangeData() was called multiple times at one synchronization point, then skip writing data to CFD (only copy result to outputs)*/
   if(fabs(cosim->modelica->lt - t0) < 1E-6){
-    return 0;
+    writeData = 0;
   }
 
   /*--------------------------------------------------------------------------
@@ -48,59 +49,63 @@ int cfdExchangeData(double t0, double dt, const double *u, size_t nU, size_t nY,
   |  0: data has been read by the other program
   |  1: data waiting for the other program to read
   --------------------------------------------------------------------------*/
-  /* If previous data hasn't been read, wait*/
-  while(cosim->modelica->flag==1) {
-    if(cosim->para->ffdError==1)
-      ModelicaError(cosim->ffd->msg);
-    else
-      Sleep(10);
-  }
-
-  cosim->modelica->t = t0;
-  cosim->modelica->dt = dt;
-  cosim->modelica->lt = t0;
-
-  /* Copy the Modelica data to shared memory*/
-  for(i=0; i<cosim->para->nSur; i++) {
-    cosim->modelica->temHea[i] = u[i];
-  }
-
-  if(cosim->para->sha==1) {
-    for(j=0; j<cosim->para->nConExtWin; j++) {
-      cosim->modelica->shaConSig[j] = u[i+j];
-      cosim->modelica->shaAbsRad[j] = u[i+j+cosim->para->nConExtWin];
-    }
-    i = i + 2*cosim->para->nConExtWin;
-  }
-
-  cosim->modelica->sensibleHeat = u[i];
-  i++;
-
-  cosim->modelica->latentHeat = u[i];
-  i++;
-
-  cosim->modelica->p = u[i];
-  i++;
-
-  for(j=0; j<cosim->para->nPorts; j++) {
-    cosim->modelica->mFloRatPor[j] = u[i+j];
-    cosim->modelica->TPor[j] = u[i+j+cosim->para->nPorts];
-  }
-
-  i = i + 2*cosim->para->nPorts;
-  for(j=0; j<cosim->para->nPorts; j++)
-    for(k=0; k<cosim->para->nXi; k++) {
-      cosim->modelica->XiPor[j][k] = u[i+j*cosim->para->nXi+k];
+  if (writeData) {
+    /* If previous data hasn't been read, wait*/
+    while(cosim->modelica->flag==1) {
+      if(cosim->para->ffdError==1)
+        ModelicaError(cosim->ffd->msg);
+      else
+        Sleep(10);
     }
 
-  i = i + cosim->para->nPorts*cosim->para->nXi;
-  for(j=0; j<cosim->para->nPorts; j++)
-    for(k=0; k<cosim->para->nC; k++) {
-      cosim->modelica->CPor[j][k] = u[i+j*cosim->para->nC+k];
+    cosim->modelica->t = t0;
+    cosim->modelica->dt = dt;
+    cosim->modelica->lt = t0;
+
+    /* Copy the Modelica data to shared memory*/
+    for(i=0; i<cosim->para->nSur; i++) {
+      cosim->modelica->temHea[i] = u[i];
     }
 
-  /* Set the flag to new data*/
-  cosim->modelica->flag = 1;
+    if(cosim->para->sha==1) {
+      for(j=0; j<cosim->para->nConExtWin; j++) {
+        cosim->modelica->shaConSig[j] = u[i+j];
+        cosim->modelica->shaAbsRad[j] = u[i+j+cosim->para->nConExtWin];
+      }
+      i = i + 2*cosim->para->nConExtWin;
+    }
+
+    cosim->modelica->sensibleHeat = u[i];
+    i++;
+
+    cosim->modelica->latentHeat = u[i];
+    i++;
+
+    cosim->modelica->p = u[i];
+    i++;
+
+    for(j=0; j<cosim->para->nPorts; j++) {
+      cosim->modelica->mFloRatPor[j] = u[i+j];
+      cosim->modelica->TPor[j] = u[i+j+cosim->para->nPorts];
+    }
+
+    i = i + 2*cosim->para->nPorts;
+    for(j=0; j<cosim->para->nPorts; j++)
+      for(k=0; k<cosim->para->nXi; k++) {
+        cosim->modelica->XiPor[j][k] = u[i+j*cosim->para->nXi+k];
+      }
+
+    i = i + cosim->para->nPorts*cosim->para->nXi;
+    for(j=0; j<cosim->para->nPorts; j++)
+      for(k=0; k<cosim->para->nC; k++) {
+        cosim->modelica->CPor[j][k] = u[i+j*cosim->para->nC+k];
+      }
+
+    /* Set the flag to new data*/
+    cosim->modelica->flag = 1;
+  } else {
+    cosim->ffd->flag = 1;
+  }
 
   /****************************************************************************
   | Copy data from CFD


### PR DESCRIPTION
If there are multiple calls to the cfdExchangeData methods (at the same time point), this method will early return without assigning values to its output. The method will return that it succeeded but there are no values in the outputs which is problematic as there is no indication to the Modelica tool that these values should not be used.

This pull request will make this method more robust by always assigning values to the outputs (at the cost of some additional work). Instead of an early return - I added a value to indicate if data should be written to CFD or not - If there are multiple calls to the method (at the same time) the data to CFD is skipped and only the outputs are assigned.