### PR TITLE
Moved allocation of the ModelicaError message to the constructor and destructor

### DIFF
--- a/Buildings/Resources/C-Sources/cfdSendStopCommand.c
+++ b/Buildings/Resources/C-Sources/cfdSendStopCommand.c
@@ -135,6 +135,9 @@ void cfdSendStopCommand(void *thread) {
   if (cosim->ffd->temHea != NULL){
     free(cosim->ffd->temHea);
   }
+  if (cosim->ffd->msg != NULL){
+    free(cosim->ffd->msg);
+  }
   if (cosim->para != NULL){
     free(cosim->para);
   }

--- a/Buildings/Resources/C-Sources/cfdStartCosimulation.c
+++ b/Buildings/Resources/C-Sources/cfdStartCosimulation.c
@@ -206,6 +206,11 @@ int cfdStartCosimulation(const char *cfdFilNam, const char **name, const double 
     }
   }
 
+  cosim->ffd->msg = (char *) malloc(1000*sizeof(char));
+  if (cosim->ffd->msg == NULL){
+    ModelicaError("Failed to allocate memory for cosim->ffd->msg in cfdStartCosimulation.c");
+  }
+
   cosim->ffd->temHea = (double *) malloc(nSur*sizeof(double));
   if (cosim->ffd->temHea == NULL){
     ModelicaError("Failed to allocate memory for cosim->ffd->temHea in cfdStartCosimulation.c");

--- a/Buildings/Resources/src/FastFluidDynamics/ffd.c
+++ b/Buildings/Resources/src/FastFluidDynamics/ffd.c
@@ -229,19 +229,10 @@ int ffd(int cosimulation) {
 		* @return no return
 		*/
 void modelicaError(char *msg) {
-	/*Allocate memory for cosim->ffd->msg*/
-	para.cosim->ffd->msg = (char *) malloc(400*sizeof(char));
-  if (para.cosim->ffd->msg == NULL){
-		ffd_log("ffd(): Failed to allocate memory for cosim->ffd->msg", FFD_ERROR);
-  }
-	
   strcpy(para.cosim->ffd->msg, msg);
   /* Write the command to stop the cosimulation*/
   para.cosim->para->flag = 2;
   /* Indicate there is an error*/
   para.cosim->para->ffdError = 1;
 
-	/*Free memory for cosim->ffd->msg*/	
-	free(para.cosim->ffd->msg);
-	
 } /* End of modelicaError*/


### PR DESCRIPTION
As highlighted in https://github.com/lbl-srg/modelica-buildings/issues/3274 the logging to a Modelica tool is problematic as the error messages are deallocated almost instantaneously. 

In this pull request I moved the allocation of the memory for the msg to the constructor / destructor instead. 