### PR TITLE
Add type casts to malloc and realloc in C-Sources

### DIFF
--- a/Buildings/Resources/C-Sources/exchangeValues.c
+++ b/Buildings/Resources/C-Sources/exchangeValues.c
@@ -34,7 +34,7 @@ double exchangeValues(void* object, size_t iX, double x, size_t iY){
   /* Manage memory
    * At first call, initialize storage */
   if ( table->x == NULL ){
-    table->x= malloc( nNew * sizeof(double) );
+    table->x = (double *)malloc( nNew * sizeof(double) );
     if ( table->x == NULL )
       ModelicaError("Out of memory in storeValue.c when allocating memory for table.");
     table->n = nNew;
@@ -47,7 +47,7 @@ double exchangeValues(void* object, size_t iX, double x, size_t iY){
 
   if (iX > nTab){
     /* Assign more memory before storing the value */
-    tab2 = malloc( nTab * sizeof(double) );
+    tab2 = (double *)malloc( nTab * sizeof(double) );
     if ( tab2 == NULL )
       ModelicaError("Out of memory in storeValue.c when allocating memory for tab2.");
 
@@ -56,7 +56,7 @@ double exchangeValues(void* object, size_t iX, double x, size_t iY){
 
     /* Increase the size of x */
     free(table->x);
-    table->x = malloc(nNew * sizeof(double) );
+    table->x = (double *)malloc(nNew * sizeof(double) );
     if ( table->x == NULL )
       ModelicaError("Out of memory in storeValue.c when allocating memory for table->x.");
     table->n = nNew;

--- a/Buildings/Resources/C-Sources/fileWriterFree.c
+++ b/Buildings/Resources/C-Sources/fileWriterFree.c
@@ -22,7 +22,7 @@ void prependString(const char* fileName, const char* string){
   if(fseek(fr, 0, SEEK_SET)!=0)
     ModelicaFormatError("The file %s could not be read.", fileName);
 
-  origString = malloc(fsize + 1);
+  origString = (char *)malloc((fsize + 1) * sizeof(char));
   if ( origString == NULL ){
     /* not enough memory is available: file too large */
     ModelicaError("Not enough memory in fileWriterInit.c for prepending string.");

--- a/Buildings/Resources/C-Sources/fileWriterStructure.c
+++ b/Buildings/Resources/C-Sources/fileWriterStructure.c
@@ -23,8 +23,8 @@ void* allocateFileWriter(
 
   if ( FileWriterNames_n == 0 ){
     /* Allocate memory for array of file names */
-    FileWriterNames = malloc(sizeof(char*));
-    InstanceNames = malloc(sizeof(char*));
+    FileWriterNames = (char **)malloc(sizeof(char*));
+    InstanceNames = (char **)malloc(sizeof(char*));
     if ( FileWriterNames == NULL || InstanceNames == NULL)
       ModelicaError("Not enough memory in fileWriterStructure.c for allocating FileWriterNames and InstanceNames.");
   }
@@ -36,14 +36,14 @@ void* allocateFileWriter(
       instanceName, fileName, InstanceNames[index]);
     }
     /* Reallocate memory for array of file names */
-    FileWriterNames = realloc(FileWriterNames, (FileWriterNames_n+1) * sizeof(char*));
-    InstanceNames = realloc(InstanceNames, (FileWriterNames_n+1) * sizeof(char*));
+    FileWriterNames = (char **)realloc(FileWriterNames, (FileWriterNames_n+1) * sizeof(char*));
+    InstanceNames = (char **)realloc(InstanceNames, (FileWriterNames_n+1) * sizeof(char*));
     if ( FileWriterNames == NULL || InstanceNames == NULL )
       ModelicaError("Not enough memory in fileWriterStructure.c for reallocating FileWriterNames and InstanceNames.");
   }
   /* Allocate memory for this file name */
-  FileWriterNames[FileWriterNames_n] = malloc((strlen(fileName)+1) * sizeof(char));
-  InstanceNames[FileWriterNames_n] = malloc((strlen(instanceName)+1) * sizeof(char));
+  FileWriterNames[FileWriterNames_n] = (char *)malloc((strlen(fileName)+1) * sizeof(char));
+  InstanceNames[FileWriterNames_n] = (char *)malloc((strlen(instanceName)+1) * sizeof(char));
   if ( FileWriterNames[FileWriterNames_n] == NULL || InstanceNames[FileWriterNames_n] == NULL)
     ModelicaError("Not enough memory in fileWriterStructure.c for allocating FileWriterNames[] and InstanceNames[].");
   /* Copy the file name */
@@ -55,12 +55,12 @@ void* allocateFileWriter(
   if ( ID == NULL )
     ModelicaFormatError("Not enough memory in fileWriterStructure.c for allocating ID of FileWriter %s.", instanceName);
 
-  ID->fileWriterName = malloc((strlen(fileName)+1) * sizeof(char));
+  ID->fileWriterName = (char *)malloc((strlen(fileName)+1) * sizeof(char));
   if ( ID->fileWriterName == NULL )
     ModelicaFormatError("Not enough memory in fileWriterStructure.c for allocating ID->fileWriterName in FileWriter %s.", instanceName);
   strcpy(ID->fileWriterName, fileName);
 
-  ID->instanceName = malloc((strlen(instanceName)+1) * sizeof(char));
+  ID->instanceName = (char *)malloc((strlen(instanceName)+1) * sizeof(char));
   if ( ID->instanceName == NULL )
     ModelicaFormatError("Not enough memory in fileWriterStructure.c for allocating ID->instanceName in FileWriter %s.", instanceName);
   strcpy(ID->instanceName, instanceName);

--- a/Buildings/Resources/C-Sources/getTimeSpan.c
+++ b/Buildings/Resources/C-Sources/getTimeSpan.c
@@ -24,7 +24,7 @@
 char *concat(const char *s1, const char *s2) {
   const size_t len1 = strlen(s1);
   const size_t len2 = strlen(s2);
-  char *result = malloc(len1 + len2 + 1);
+  char *result = (char *)malloc((len1 + len2 + 1) * sizeof(char));
   if (result == NULL) {
     ModelicaError("Failed to allocate memory in getTimeSpan.c");
   }

--- a/Buildings/Resources/C-Sources/initArray.c
+++ b/Buildings/Resources/C-Sources/initArray.c
@@ -18,7 +18,7 @@
 /* Create the structure "table" and return pointer to "table". */
 void* initArray()
 {
-  ExternalObjectStructure* table = malloc(sizeof(ExternalObjectStructure));
+  ExternalObjectStructure* table = (ExternalObjectStructure *)malloc(sizeof(ExternalObjectStructure));
   if ( table == NULL )
     ModelicaError("Not enough memory in initArray.c.");
   /* Number of elements in the array */

--- a/Buildings/Resources/C-Sources/jsonWriterInit.c
+++ b/Buildings/Resources/C-Sources/jsonWriterInit.c
@@ -26,16 +26,16 @@ void* jsonWriterInit(
 
   ID->numKeys=numKeys;
 
-  ID-> varKeys = malloc(numKeys * sizeof(char*));
+  ID-> varKeys = (char **)malloc(numKeys * sizeof(char*));
   if ( ID->varKeys == NULL )
     ModelicaError("Not enough memory in jsonWriterInit.c for allocating varKeys[].");
-  ID-> varVals = malloc(numKeys * sizeof(double));
+  ID-> varVals = (double *)malloc(numKeys * sizeof(double));
   if ( ID->varVals == NULL )
     ModelicaError("Not enough memory in jsonWriterInit.c for allocating varVals[].");
 
   for (i = 0; i < numKeys; ++i)
   {
-    ID-> varKeys[i] = malloc((strlen(varKeys[i])+1) * sizeof(char*));
+    ID-> varKeys[i] = (char **)malloc((strlen(varKeys[i])+1) * sizeof(char*));
     if ( ID->varKeys[i] == NULL )
       ModelicaError("Not enough memory in jsonWriterInit.c for allocating varKeys.");
       strcpy(ID->varKeys[i], varKeys[i]);

--- a/Buildings/Resources/C-Sources/plotInit.c
+++ b/Buildings/Resources/C-Sources/plotInit.c
@@ -39,10 +39,10 @@ void plotRegister(const char* fileName){
   /* This is a new plot file */
   /* Reallocate memory for the new array */
   if (nPlotFileNames == 0){
-    plotFileNames = malloc(sizeof(char*));
-    plotFileNames[0] = malloc((strlen(fileName)+1) * sizeof(char));
+    plotFileNames = (char **)malloc(sizeof(char*));
+    plotFileNames[0] = (char *)malloc((strlen(fileName)+1) * sizeof(char));
     strcpy(plotFileNames[0], fileName);
-    nPlotsInFiles = malloc(sizeof(size_t));
+    nPlotsInFiles = (size_t *)malloc(sizeof(size_t));
     nPlotsInFiles[0] = 1;
   }
   else{
@@ -51,7 +51,7 @@ void plotRegister(const char* fileName){
     if (plotFileNames == NULL){
       ModelicaError("Failed to allocate memory for plotFileNames.");
     }
-    plotFileNames[nPlotFileNames] = malloc((strlen(fileName)+1) * sizeof(char));
+    plotFileNames[nPlotFileNames] = (char *)malloc((strlen(fileName)+1) * sizeof(char));
     if (plotFileNames[nPlotFileNames] == NULL){
       ModelicaError("Failed to allocate memory for plotFileNames.");
     }
@@ -77,7 +77,7 @@ void* plotInit(const char* fileName,
   int i;
   const size_t nStr = 100; /* Initial string size */
   const size_t nRow = 50; /* Initial double size */
-  PlotObjectStructure* plt = malloc(sizeof(PlotObjectStructure));
+  PlotObjectStructure* plt = (PlotObjectStructure *)malloc(sizeof(PlotObjectStructure));
   if ( plt == NULL )
     ModelicaError("Not enough memory in plotInit.c.");
 
@@ -96,13 +96,13 @@ void* plotInit(const char* fileName,
   plt->iStrTer = 1;
 
   /* Allocate file name */
-  plt->fileName = malloc((strlen(fileName)+1) * sizeof(char));
+  plt->fileName = (char *)malloc((strlen(fileName)+1) * sizeof(char));
   if (plt->fileName == NULL){
     ModelicaError("Failed to allocate memory for plt->fileName in plotInit.c");
   }
   strcpy(plt->fileName, fileName);
   /* Allocate instance name */
-  plt->instanceName = malloc((strlen(instanceName)+1) * sizeof(char));
+  plt->instanceName = (char *)malloc((strlen(instanceName)+1) * sizeof(char));
   if (plt->instanceName == NULL){
     ModelicaError("Failed to allocate memory for plt->instanceName in plotInit.c");
   }

--- a/Buildings/Resources/src/ThermalZones/EnergyPlus_9_6_0/C-Sources/SpawnFMU.c
+++ b/Buildings/Resources/src/ThermalZones/EnergyPlus_9_6_0/C-Sources/SpawnFMU.c
@@ -53,13 +53,13 @@ size_t AllocateBuildingDataStructure(
 
     /* Allocate memory */
   if (nFMU == 0)
-    Buildings_FMUS = malloc(sizeof(struct FMUBuilding*));
+    Buildings_FMUS = (FMUBuilding **)malloc(sizeof(struct FMUBuilding*));
   else
-    Buildings_FMUS = realloc(Buildings_FMUS, (nFMU+1) * sizeof(struct FMUBuilding*));
+    Buildings_FMUS = (FMUBuilding **)realloc(Buildings_FMUS, (nFMU+1) * sizeof(struct FMUBuilding*));
   if ( Buildings_FMUS == NULL )
     SpawnError("Not enough memory in SpawnFMU.c. to allocate array for Buildings_FMU.");
 
-  Buildings_FMUS[nFMU] = malloc(sizeof(FMUBuilding));
+  Buildings_FMUS[nFMU] = (FMUBuilding *)malloc(sizeof(FMUBuilding));
   if ( Buildings_FMUS[nFMU] == NULL )
     SpawnError("Not enough memory in SpawnFMU.c. to allocate array for Buildings_FMU[0].");
 
@@ -217,7 +217,7 @@ void AddSpawnObjectToBuilding(SpawnObject* ptrSpaObj, const int logLevel){
       bui->time, bui->modelicaNameBuilding, nExcObj, ptrSpaObj->modelicaName);
 
   if (nExcObj == 0){
-    bui->exchange=malloc(sizeof(SpawnObject *));
+    bui->exchange = (SpawnObject **)malloc(sizeof(SpawnObject *));
     if ( bui->exchange== NULL )
       SpawnError("Not enough memory in SpawnFMU.c. to allocate exc.");
   }
@@ -225,7 +225,7 @@ void AddSpawnObjectToBuilding(SpawnObject* ptrSpaObj, const int logLevel){
     /* We already have nExcObj > 0 exc */
 
     /* Increment size of vector that contains the exc. */
-    bui->exchange = realloc(bui->exchange, (nExcObj + 1) * sizeof(SpawnObject*));
+    bui->exchange = (SpawnObject **)realloc(bui->exchange, (nExcObj + 1) * sizeof(SpawnObject*));
     if (bui->exchange == NULL){
       SpawnError("Not enough memory in SpawnFMU.c. to allocate memory for bld->exc.");
     }

--- a/Buildings/Resources/src/ThermalZones/EnergyPlus_9_6_0/C-Sources/SpawnUtil.c
+++ b/Buildings/Resources/src/ThermalZones/EnergyPlus_9_6_0/C-Sources/SpawnUtil.c
@@ -22,7 +22,7 @@
 
 
 void mallocString(const size_t nChar, const char *error_message, char** str, void (*SpawnFormatError)(const char *string, ...)){
-  *str = malloc(nChar * sizeof(char));
+  *str = (char *)malloc(nChar * sizeof(char));
   if ( *str == NULL )
     SpawnFormatError("%s", error_message);
 }
@@ -400,7 +400,7 @@ void saveAppend(char* *buffer, const char *toAdd, size_t *bufLen, void (*SpawnFo
   /* reallocate memory if needed */
   if ( *bufLen < nNewCha + nBufCha + 1){
     *bufLen = *bufLen + nNewCha + minInc + 1;
-    *buffer = realloc(*buffer, *bufLen);
+    *buffer = (char *)realloc(*buffer, *bufLen * sizeof(char));
     if (*buffer == NULL) {
       SpawnFormatError("Realloc failed in saveAppend with bufLen = %lu.", *bufLen);
     }
@@ -595,7 +595,7 @@ void getSimulationTemporaryDirectory(
           "Temporary directories with names longer than %lu characters are not supported in SpawnFMU.c unless you change maxLenCurDir.",
           maxLenCurDir);
       }
-      curDir = realloc(curDir, lenCurDir * sizeof(char));
+      curDir = (char *)realloc(curDir, lenCurDir * sizeof(char));
       if (curDir == NULL)
         SpawnFormatError(
           "Failed to reallocate memory for current working directory in getSimulationTemporaryDirectory for %s.",

--- a/Buildings/Resources/src/ThermalZones/EnergyPlus_9_6_0/C-Sources/cryptographicsHash.c
+++ b/Buildings/Resources/src/ThermalZones/EnergyPlus_9_6_0/C-Sources/cryptographicsHash.c
@@ -299,7 +299,7 @@ const char* cryptographicsHash(const char* str, void (*SpawnError)(const char *s
 {
   char result[21];
   size_t offset;
-  char* hexresult = malloc(41*sizeof(char));
+  char* hexresult = (char *)malloc(41*sizeof(char));
 
   if (!hexresult){
     SpawnError("Failed to allocate memory in cryptographicHash.");


### PR DESCRIPTION
Numerous examples fail to compile with the OpenModelica C++ runtime for this reason, see
https://libraries.openmodelica.org/branches/cpp/Buildings_latest/Buildings_latest.html

So far some allocations do cast, some don't. It would be good if all did.
This is required if compiled with C++ to avoid errors like:
```
In file included from ./OMCppBuildings_latest_Buildings.BoundaryConditions.WeatherData.Examples.ReaderTMY3Functions.cpp:7:
Buildings 10.0.0-master/Resources/C-Sources/getTimeSpan.c:27:9: error: cannot initialize a variable of type 'char *' with an rvalue of type 'void *'
  char *result = malloc(len1 + len2 + 1);
        ^        ~~~~~~~~~~~~~~~~~~~~~~~
```
or
```
In file included from ./OMCppBuildings_latest_Buildings.Utilities.Plotters.Examples.ScatterFunctions.cpp:8:
Buildings 10.0.0-master/Resources/C-Sources/plotInit.c:42:21: error: assigning to 'char **' from incompatible type 'void *'
    plotFileNames = malloc(sizeof(char*));
                    ^~~~~~~~~~~~~~~~~~~~~
```