### PR TITLE
Issue2948 motor drive

### DIFF
--- a/Buildings/Electrical/AC/ThreePhasesBalanced/Loads/MotorDrive/Coupled/Chiller.mo
+++ b/Buildings/Electrical/AC/ThreePhasesBalanced/Loads/MotorDrive/Coupled/Chiller.mo
@@ -63,7 +63,6 @@ model Chiller "Motor coupled chiller"
 
   //Motor parameters
   parameter Integer pole=4 "Number of pole pairs";
-  parameter Integer n=3 "Number of phases";
   parameter Modelica.Units.SI.Resistance R_s=0.641
     "Electric resistance of stator";
   parameter Modelica.Units.SI.Resistance R_r=0.332
@@ -105,7 +104,6 @@ model Chiller "Motor coupled chiller"
     annotation (Placement(transformation(extent={{0,40},{-20,60}})));
   Buildings.Electrical.AC.ThreePhasesBalanced.Loads.MotorDrive.InductionMotors.SquirrelCageDrive simMot(
     final pole=pole,
-    final n=n,
     final J=JMotor,
     final R_s=R_s,
     final R_r=R_r,

--- a/Buildings/Electrical/AC/ThreePhasesBalanced/Loads/MotorDrive/Coupled/Chiller.mo
+++ b/Buildings/Electrical/AC/ThreePhasesBalanced/Loads/MotorDrive/Coupled/Chiller.mo
@@ -133,9 +133,6 @@ model Chiller "Motor coupled chiller"
     annotation (Placement(transformation(extent={{100,-40},{120,-20}}),
     iconTransformation(extent={{100,-40}, {120,-20}})));
 
-initial equation
-  assert(QEva_flow_nominal < 0, "Parameter QEva_flow_nominal must be negative.");
-
 protected
   constant Boolean COP_is_for_cooling = true
     "Set to true if the specified COP is for cooling";

--- a/Buildings/Electrical/AC/ThreePhasesBalanced/Loads/MotorDrive/Coupled/Examples/Chiller.mo
+++ b/Buildings/Electrical/AC/ThreePhasesBalanced/Loads/MotorDrive/Coupled/Examples/Chiller.mo
@@ -59,7 +59,7 @@ model Chiller "This example shows how to use the motor coupled chiller model"
     X_r=0.464,
     X_m=26.3) "Chiller" annotation (Placement(transformation(
     extent={{-10,-10},{10,10}})));
-  Buildings.Electrical.AC.OnePhase.Sources.Grid Sou(f=60, V=120)
+  Buildings.Electrical.AC.ThreePhasesBalanced.Sources.Grid Sou(f=60, V=480)
     "Voltage source"
     annotation (Placement(transformation(extent={{0,60},{20,80}})));
   Buildings.Fluid.Sensors.TemperatureTwoPort senTem(redeclare package Medium = MediumW,

--- a/Buildings/Electrical/AC/ThreePhasesBalanced/Loads/MotorDrive/Coupled/Examples/HeatPump.mo
+++ b/Buildings/Electrical/AC/ThreePhasesBalanced/Loads/MotorDrive/Coupled/Examples/HeatPump.mo
@@ -37,7 +37,7 @@ model HeatPump "This example shows how to use the motor coupled heat pump model"
     T=291.15,
     nPorts=1) "Water source 2"
     annotation (Placement(transformation(extent={{60,-20},{40,0}})));
-  Buildings.Electrical.AC.OnePhase.Sources.Grid Sou(f=60, V=120)
+  Buildings.Electrical.AC.ThreePhasesBalanced.Sources.Grid Sou(f=60, V=480)
     "Voltage source"
     annotation (Placement(transformation(extent={{0,60},{20,80}})));
   Buildings.Fluid.Sensors.TemperatureTwoPort senTem(redeclare package Medium = MediumW,

--- a/Buildings/Electrical/AC/ThreePhasesBalanced/Loads/MotorDrive/Coupled/Examples/Pump.mo
+++ b/Buildings/Electrical/AC/ThreePhasesBalanced/Loads/MotorDrive/Coupled/Examples/Pump.mo
@@ -26,7 +26,7 @@ model Pump "This example shows how to use the motor coupled pump model"
     reverseActing=true))) "Pump"
     annotation (Placement(transformation(extent={{0,10},{20,30}})));
 
-  Buildings.Electrical.AC.OnePhase.Sources.Grid gri(f=60, V=120)
+  Buildings.Electrical.AC.ThreePhasesBalanced.Sources.Grid gri(f=60, V=480)
     "Voltage source"
     annotation (Placement(transformation(extent={{0,60},{20,80}})));
   Buildings.Fluid.Sensors.MassFlowRate senMasFlo(redeclare package Medium = MediumW)

--- a/Buildings/Electrical/AC/ThreePhasesBalanced/Loads/MotorDrive/Coupled/HeatPump.mo
+++ b/Buildings/Electrical/AC/ThreePhasesBalanced/Loads/MotorDrive/Coupled/HeatPump.mo
@@ -128,9 +128,6 @@ model HeatPump "Motor coupled heat pump"
     annotation (Placement(transformation(extent={{100,-40},{120,-20}}),
         iconTransformation(extent={{100,-40},{120,-20}})));
 
-initial equation
-  assert(QEva_flow_nominal < 0, "Parameter QEva_flow_nominal must be negative.");
-
 protected
   constant Boolean COP_is_for_cooling = false
     "Set to true if the specified COP is for cooling";

--- a/Buildings/Electrical/AC/ThreePhasesBalanced/Loads/MotorDrive/Coupled/HeatPump.mo
+++ b/Buildings/Electrical/AC/ThreePhasesBalanced/Loads/MotorDrive/Coupled/HeatPump.mo
@@ -63,7 +63,6 @@ model HeatPump "Motor coupled heat pump"
 
   //Motor parameters
   parameter Integer pole=4 "Number of pole pairs";
-  parameter Integer n=3 "Number of phases";
   parameter Modelica.Units.SI.Resistance R_s=0.641
     "Electric resistance of stator";
   parameter Modelica.Units.SI.Resistance R_r=0.332
@@ -102,7 +101,6 @@ model HeatPump "Motor coupled heat pump"
     annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
   Buildings.Electrical.AC.ThreePhasesBalanced.Loads.MotorDrive.InductionMotors.SquirrelCageDrive simMot(
     final pole=pole,
-    final n=n,
     final J=JMotor,
     final R_s=R_s,
     final R_r=R_r,

--- a/Buildings/Electrical/AC/ThreePhasesBalanced/Loads/MotorDrive/Coupled/Pump.mo
+++ b/Buildings/Electrical/AC/ThreePhasesBalanced/Loads/MotorDrive/Coupled/Pump.mo
@@ -18,7 +18,6 @@ model Pump "Motor coupled chiller"
 
   //Motor parameters
   parameter Integer pole=4 "Number of pole pairs";
-  parameter Integer n=3 "Number of phases";
   parameter Modelica.Units.SI.Resistance R_s=0.013
     "Electric resistance of stator";
   parameter Modelica.Units.SI.Resistance R_r=0.009
@@ -42,7 +41,6 @@ model Pump "Motor coupled chiller"
     annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
   Buildings.Electrical.AC.ThreePhasesBalanced.Loads.MotorDrive.InductionMotors.SquirrelCageDrive simMot(
     final pole=pole,
-    final n=n,
     final J=JMotor,
     final R_s=R_s,
     final R_r=R_r,

--- a/Buildings/Electrical/AC/ThreePhasesBalanced/Loads/MotorDrive/InductionMotors/BaseClasses/MotorMachineInterface.mo
+++ b/Buildings/Electrical/AC/ThreePhasesBalanced/Loads/MotorDrive/InductionMotors/BaseClasses/MotorMachineInterface.mo
@@ -3,7 +3,6 @@ model MotorMachineInterface
   "Calculates the electromagnetic torque based on voltage and frequency"
 
   parameter Integer pole=2 "Number of pole pairs";
-  parameter Integer n=3 "Number of phases";
   parameter Modelica.Units.SI.Resistance R_s=0.013 "Electric resistance of stator";
   parameter Modelica.Units.SI.Resistance R_r=0.009 "Electric resistance of rotor";
   parameter Modelica.Units.SI.Reactance X_s=0.14 "Complex component of the impedance of stator";
@@ -61,13 +60,13 @@ protected
 equation
   // check if omega_s > 0 with hysteresis
   y_internal = noEvent(not pre(y_internal) and omega_s > omegaHys
-                        or pre(y_internal) and omega >= (omegaHys-0.5*omegaHys));
+                        or pre(y_internal) and omega_s >= (omegaHys-0.5*omegaHys));
 
   omega_s = 4*Modelica.Constants.pi*f/pole;
   s = if y_internal then 1-omega_r/omega_s else 0;
   ratio = X_m/(X_m+X_s);
   tau_e = if y_internal
-  then n*R_r*s*(V_rms*ratio)^2/(omega_s*(((s*R_s*ratio^2+R_r)^2)+s^2*(X_s+X_r)^2))
+  then 3*R_r*s*(V_rms*ratio)^2/(omega_s*(((s*R_s*ratio^2+R_r)^2)+s^2*(X_s+X_r)^2))
   else 0;
 
   annotation (Icon(coordinateSystem(preserveAspectRatio=true), graphics={

--- a/Buildings/Electrical/AC/ThreePhasesBalanced/Loads/MotorDrive/InductionMotors/BaseClasses/MotorMachineInterface.mo
+++ b/Buildings/Electrical/AC/ThreePhasesBalanced/Loads/MotorDrive/InductionMotors/BaseClasses/MotorMachineInterface.mo
@@ -59,7 +59,7 @@ protected
 
 equation
   // check if omega_s > 0 with hysteresis
-  y_internal = noEvent(not pre(y_internal) and omega_s > omegaHys
+  y_internal = (not pre(y_internal) and omega_s > omegaHys
                         or pre(y_internal) and omega_s >= (omegaHys-0.5*omegaHys));
 
   omega_s = 4*Modelica.Constants.pi*f/pole;

--- a/Buildings/Electrical/AC/ThreePhasesBalanced/Loads/MotorDrive/InductionMotors/Examples/SquirrelCage.mo
+++ b/Buildings/Electrical/AC/ThreePhasesBalanced/Loads/MotorDrive/InductionMotors/Examples/SquirrelCage.mo
@@ -8,7 +8,7 @@ model SquirrelCage "This example shows how to use the squirrel cage induction mo
   parameter Modelica.Units.SI.Reactance X_r=0.464 "Complex component of the impedance of rotor";
   parameter Modelica.Units.SI.Reactance X_m=26.3 "Complex component of the magnetizing reactance";
 
-  Buildings.Electrical.AC.OnePhase.Sources.Grid sou(f=60, V=120)
+  Buildings.Electrical.AC.ThreePhasesBalanced.Sources.Grid sou(f=60, V=480)
     "Voltage source"
     annotation (Placement(transformation(extent={{-10,40},{10,60}})));
   Modelica.Blocks.Sources.RealExpression tau_m(y=0.002*simMot.omega_r*simMot.omega_r)

--- a/Buildings/Electrical/AC/ThreePhasesBalanced/Loads/MotorDrive/InductionMotors/Examples/SquirrelCageDrive.mo
+++ b/Buildings/Electrical/AC/ThreePhasesBalanced/Loads/MotorDrive/InductionMotors/Examples/SquirrelCageDrive.mo
@@ -8,7 +8,7 @@ model SquirrelCageDrive "This example shows how to use the squirrel cage inducti
   parameter Modelica.Units.SI.Reactance X_r=0.464 "Complex component of the impedance of rotor";
   parameter Modelica.Units.SI.Reactance X_m=26.3 "Complex component of the magnetizing reactance";
 
-  Buildings.Electrical.AC.OnePhase.Sources.Grid sou(f=60, V=120)
+  Buildings.Electrical.AC.ThreePhasesBalanced.Sources.Grid sou(f=60, V=480)
     "Voltage source"
     annotation (Placement(transformation(extent={{-10,40},{10,60}})));
   Modelica.Blocks.Sources.RealExpression tau_m(y=0.002*simMot.omega_r*simMot.omega_r)

--- a/Buildings/Electrical/AC/ThreePhasesBalanced/Loads/MotorDrive/InductionMotors/SquirrelCage.mo
+++ b/Buildings/Electrical/AC/ThreePhasesBalanced/Loads/MotorDrive/InductionMotors/SquirrelCage.mo
@@ -5,7 +5,6 @@ model SquirrelCage "Squirrel cage type induction motor with electrical interface
     redeclare replaceable Interfaces.Terminal_n terminal);
 
   parameter Integer pole=4 "Number of pole pairs";
-  parameter Integer n=3 "Number of phases";
   parameter Modelica.Units.SI.Inertia J(min=0)=2
     "Moment of inertia";
   parameter Modelica.Units.SI.Resistance R_s=0.641
@@ -51,7 +50,6 @@ model SquirrelCage "Squirrel cage type induction motor with electrical interface
   Modelica.Mechanics.Rotational.Interfaces.Flange_b shaft "Mechanical connector"
     annotation (Placement(transformation(extent={{90,-10},{110,10}})));
   Buildings.Electrical.AC.ThreePhasesBalanced.Loads.MotorDrive.InductionMotors.BaseClasses.MotorMachineInterface torSpe(
-    final n=n,
     final pole=pole,
     final R_s=R_s,
     final R_r=R_r,
@@ -100,8 +98,8 @@ equation
   Req = R_s + R_r*s*X_m^2/(R_r^2+(s^2)*(X_r+X_m)^2);
   Xeq = X_s + X_m*(R_r^2+(s*X_r)^2+(s^2)*X_r*X_m)/(R_r^2+(s^2)*(X_r+X_m)^2);
 
-  P = if noEvent(torSpe.omega_s>0) then n*v_rms^2*Req/(Req^2+Xeq^2) else 0;
-  Q = if noEvent(torSpe.omega_s>0) then n*v_rms^2*Xeq/(Req^2+Xeq^2) else 0;
+  P = if noEvent(torSpe.omega_s>0) then 3*v_rms^2*Req/(Req^2+Xeq^2) else 0;
+  Q = if noEvent(torSpe.omega_s>0) then 3*v_rms^2*Xeq/(Req^2+Xeq^2) else 0;
 
   // Equations to calculate current
   i[1] = (v[2]*Q + v[1]*P)/(v[1]^2 + v[2]^2);

--- a/Buildings/Electrical/AC/ThreePhasesBalanced/Loads/MotorDrive/InductionMotors/SquirrelCageDrive.mo
+++ b/Buildings/Electrical/AC/ThreePhasesBalanced/Loads/MotorDrive/InductionMotors/SquirrelCageDrive.mo
@@ -110,13 +110,13 @@ model SquirrelCageDrive "Squirrel cage type induction motor with electrical inte
   final Modelica.Blocks.Sources.RealExpression Vrms(y=v_rms) "RMS voltage"
     annotation (Placement(transformation(extent={{-80,40},{-60,60}})));
   Buildings.Controls.Continuous.LimPID VFD(
-    controllerType=controllerType,
-    Td=Td,
-    yMax=yMax,
-    yMin=yMin,
-    k=k,
-    Ti=Ti,
-    reverseActing=true) if have_controller
+    final controllerType=controllerType,
+    final Td=Td,
+    final yMax=yMax,
+    final yMin=yMin,
+    final k=k,
+    final Ti=Ti,
+    final reverseActing=true) if have_controller
     "PI controller as variable frequency drive"
     annotation (Placement(transformation(extent={{-80,-10},{-60,10}})));
   final Modelica.Blocks.Sources.RealExpression fre(y=omega/(2*Modelica.Constants.pi))

--- a/Buildings/Electrical/AC/ThreePhasesBalanced/Loads/MotorDrive/InductionMotors/SquirrelCageDrive.mo
+++ b/Buildings/Electrical/AC/ThreePhasesBalanced/Loads/MotorDrive/InductionMotors/SquirrelCageDrive.mo
@@ -19,54 +19,72 @@ model SquirrelCageDrive "Squirrel cage type induction motor with electrical inte
     "Complex component of the magnetizing reactance";
   parameter Boolean have_controller = true
     "Set to true for enableing PID control";
-
-  parameter Modelica.Blocks.Types.SimpleController controllerType=
-         Modelica.Blocks.Types.SimpleController.PI
+  parameter Modelica.Blocks.Types.SimpleController 
+  controllerType=Modelica.Blocks.Types.SimpleController.PI
      "Type of controller"
-      annotation (Dialog(tab="Advanced", group="Controller", enable=have_controller));
+      annotation (Dialog(tab="Advanced", 
+                         group="Controller",
+                         enable=have_controller));
   parameter Real k(min=0) = 1
      "Gain of controller"
-      annotation (Dialog(tab="Advanced", group="Controller", enable=have_controller));
-
+      annotation (Dialog(tab="Advanced",
+                         group="Controller", 
+                         enable=have_controller));
   parameter Modelica.Units.SI.Time Ti(min=Modelica.Constants.small)=0.5
      "Time constant of Integrator block"
-      annotation (Dialog(tab="Advanced", group="Controller",enable=have_controller and controllerType == Modelica.Blocks.Types.SimpleController.PI or 
-    controllerType == Modelica.Blocks.Types.SimpleController.PID));
+      annotation (Dialog(tab="Advanced",
+                         group="Controller",
+                         enable=have_controller and 
+  controllerType == Modelica.Blocks.Types.SimpleController.PI or 
+  controllerType == Modelica.Blocks.Types.SimpleController.PID));
   parameter Modelica.Units.SI.Time Td(min=0) = 0.1
      "Time constant of Derivative block"
-      annotation (Dialog(tab="Advanced", group="Controller",enable=have_controller and 
-    controllerType == Modelica.Blocks.Types.SimpleController.PD or 
-    controllerType == Modelica.Blocks.Types.SimpleController.PID));
+      annotation (Dialog(tab="Advanced",
+                         group="Controller",
+                         enable=have_controller and 
+  controllerType == Modelica.Blocks.Types.SimpleController.PD or 
+  controllerType == Modelica.Blocks.Types.SimpleController.PID));
   parameter Real yMax(start=1)=1
     "Upper limit of output"
-    annotation (Dialog(tab="Advanced", group="Controller", enable=have_controller));
+     annotation (Dialog(tab="Advanced", 
+                       group="Controller", 
+                       enable=have_controller));
   parameter Real yMin=0
     "Lower limit of output"
-    annotation (Dialog(tab="Advanced", group="Controller", enable=have_controller));
+     annotation (Dialog(tab="Advanced", 
+                       group="Controller",
+                       enable=have_controller));
   parameter Real wp(min=0) = 1
     "Set-point weight for Proportional block (0..1)"
-    annotation (Dialog(tab="Advanced", group="Controller", enable=have_controller));
+     annotation (Dialog(tab="Advanced",
+                        group="Controller", 
+                        enable=have_controller));
   parameter Real wd(min=0) = 0
     "Set-point weight for Derivative block (0..1)"
-       annotation(Dialog(tab="Advanced", group="Controller", enable=have_controller and 
-       controllerType==.Modelica.Blocks.Types.SimpleController.PD or 
-                                controllerType==.Modelica.Blocks.Types.SimpleController.PID));
+     annotation(Dialog(tab="Advanced", 
+                        group="Controller", 
+                        enable=have_controller and 
+  controllerType==.Modelica.Blocks.Types.SimpleController.PD or 
+  controllerType==.Modelica.Blocks.Types.SimpleController.PID));
   parameter Real Ni(min=100*Modelica.Constants.eps) = 0.9
     "Ni*Ti is time constant of anti-windup compensation"
-     annotation(Dialog(tab="Advanced", group="Controller", enable=have_controller and 
-     controllerType==.Modelica.Blocks.Types.SimpleController.PI or 
-                              controllerType==.Modelica.Blocks.Types.SimpleController.PID));
+     annotation(Dialog(tab="Advanced", 
+                       group="Controller", 
+                       enable=have_controller and 
+   controllerType==.Modelica.Blocks.Types.SimpleController.PI or 
+   controllerType==.Modelica.Blocks.Types.SimpleController.PID));
   parameter Real Nd(min=100*Modelica.Constants.eps) = 10
     "The higher Nd, the more ideal the derivative block"
-       annotation(Dialog(tab="Advanced", group="Controller", enable=have_controller and 
-       controllerType==.Modelica.Blocks.Types.SimpleController.PD or 
-                                controllerType==.Modelica.Blocks.Types.SimpleController.PID));
-
+      annotation(Dialog(tab="Advanced", 
+                        group="Controller", 
+                        enable=have_controller and 
+    controllerType==.Modelica.Blocks.Types.SimpleController.PD or 
+    controllerType==.Modelica.Blocks.Types.SimpleController.PID));
   parameter Boolean reverseActing = true
     "Set to true for reverse acting, or false for direct acting control action"
-    annotation (Dialog(tab="Advanced", group="Controller", enable=have_controller));
-
-
+    annotation (Dialog(tab="Advanced", 
+                       group="Controller",
+                       enable=have_controller));
   Real s(min=0,max=1) "Motor slip";
   Real v_rms "RMS voltage";
   Modelica.Units.SI.Torque tau_e
@@ -277,4 +295,3 @@ First implementation.
 </ul>
 </html>"));
 end SquirrelCageDrive;
-

--- a/Buildings/Electrical/AC/ThreePhasesBalanced/Loads/MotorDrive/InductionMotors/SquirrelCageDrive.mo
+++ b/Buildings/Electrical/AC/ThreePhasesBalanced/Loads/MotorDrive/InductionMotors/SquirrelCageDrive.mo
@@ -5,7 +5,6 @@ model SquirrelCageDrive "Squirrel cage type induction motor with electrical inte
     redeclare replaceable Interfaces.Terminal_n terminal);
 
   parameter Integer pole=4 "Number of pole pairs";
-  parameter Integer n=3 "Number of phases";
   parameter Modelica.Units.SI.Inertia J(min=0)=2
     "Moment of inertia";
   parameter Modelica.Units.SI.Resistance R_s=0.641
@@ -80,7 +79,6 @@ model SquirrelCageDrive "Squirrel cage type induction motor with electrical inte
   Modelica.Mechanics.Rotational.Interfaces.Flange_b shaft "Mechanical connector"
     annotation (Placement(transformation(extent={{90,-10},{110,10}})));
   Buildings.Electrical.AC.ThreePhasesBalanced.Loads.MotorDrive.InductionMotors.BaseClasses.MotorMachineInterface torSpe(
-    final n=n,
     final pole=pole,
     final R_s=R_s,
     final R_r=R_r,
@@ -88,6 +86,7 @@ model SquirrelCageDrive "Squirrel cage type induction motor with electrical inte
     final X_r=X_r,
     final X_m=X_m) "Motor machine interface"
     annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
+
   Modelica.Blocks.Math.Product VFDvol "Controlled voltage"
     annotation (Placement(transformation(extent={{-40,40},{-20,60}})));
 
@@ -129,10 +128,10 @@ model SquirrelCageDrive "Squirrel cage type induction motor with electrical inte
         iconTransformation(extent={{100,20},{140,60}})));
 
 
-initial equation
+initial equation 
   omega_r=0;
 
-equation
+equation 
   // Assign values for motor model calculation from electrical interface
   theta_s = PhaseSystem.thetaRef(terminal.theta);
   omega = der(theta_s);
@@ -148,8 +147,8 @@ equation
   Req = R_s + R_r*s*X_m^2/(R_r^2+(s^2)*(X_r+X_m)^2);
   Xeq = X_s + X_m*(R_r^2+(s*X_r)^2+(s^2)*X_r*X_m)/(R_r^2+(s^2)*(X_r+X_m)^2);
 
-  P = if noEvent(torSpe.omega_s>0) then n*v_rms^2*Req/(Req^2+Xeq^2) else 0;
-  Q = if noEvent(torSpe.omega_s>0) then n*v_rms^2*Xeq/(Req^2+Xeq^2) else 0;
+  P = if noEvent(torSpe.omega_s>0) then 3*v_rms^2*Req/(Req^2+Xeq^2) else 0;
+  Q = if noEvent(torSpe.omega_s>0) then 3*v_rms^2*Xeq/(Req^2+Xeq^2) else 0;
 
   // Equations to calculate current
   i[1] = (v[2]*Q + v[1]*P)/(v[1]^2 + v[2]^2);

--- a/Buildings/Electrical/AC/ThreePhasesBalanced/Loads/MotorDrive/InductionMotors/SquirrelCageDrive.mo
+++ b/Buildings/Electrical/AC/ThreePhasesBalanced/Loads/MotorDrive/InductionMotors/SquirrelCageDrive.mo
@@ -20,17 +20,52 @@ model SquirrelCageDrive "Squirrel cage type induction motor with electrical inte
   parameter Boolean have_controller = true
     "Set to true for enableing PID control";
 
-  parameter Modelica.Blocks.Types.SimpleController controllerType=Modelica.Blocks.Types.SimpleController.PID
-    "Type of controller"
-    annotation (Dialog(tab="Advanced", enable=have_controller));
-  parameter Real k=0.1 "Gain of controller"
-    annotation (Dialog(tab="Advanced", enable=have_controller));
-  parameter Modelica.Units.SI.Time Ti=60 "Time constant of Integrator block"
-    annotation (Dialog(tab="Advanced",
-                       enable=have_controller and controllerType==Modelica.Blocks.Types.SimpleController.PID or Modelica.Blocks.Types.SimpleController.PI));
-  parameter Modelica.Units.SI.Time Td=0.1 "Time constant of Derivative block";
-  parameter Real yMax=1 "Upper limit of output";
-  parameter Real yMin=0.2 "Lower limit of output";
+  parameter Modelica.Blocks.Types.SimpleController controllerType=
+         Modelica.Blocks.Types.SimpleController.PI
+     "Type of controller"
+      annotation (Dialog(tab="Advanced", group="Controller", enable=have_controller));
+  parameter Real k(min=0) = 1
+     "Gain of controller"
+      annotation (Dialog(tab="Advanced", group="Controller", enable=have_controller));
+
+  parameter Modelica.Units.SI.Time Ti(min=Modelica.Constants.small)=0.5
+     "Time constant of Integrator block"
+      annotation (Dialog(tab="Advanced", group="Controller",enable=have_controller and controllerType == Modelica.Blocks.Types.SimpleController.PI or 
+    controllerType == Modelica.Blocks.Types.SimpleController.PID));
+  parameter Modelica.Units.SI.Time Td(min=0) = 0.1
+     "Time constant of Derivative block"
+      annotation (Dialog(tab="Advanced", group="Controller",enable=have_controller and 
+    controllerType == Modelica.Blocks.Types.SimpleController.PD or 
+    controllerType == Modelica.Blocks.Types.SimpleController.PID));
+  parameter Real yMax(start=1)=1
+    "Upper limit of output"
+    annotation (Dialog(tab="Advanced", group="Controller", enable=have_controller));
+  parameter Real yMin=0
+    "Lower limit of output"
+    annotation (Dialog(tab="Advanced", group="Controller", enable=have_controller));
+  parameter Real wp(min=0) = 1
+    "Set-point weight for Proportional block (0..1)"
+    annotation (Dialog(tab="Advanced", group="Controller", enable=have_controller));
+  parameter Real wd(min=0) = 0
+    "Set-point weight for Derivative block (0..1)"
+       annotation(Dialog(tab="Advanced", group="Controller", enable=have_controller and 
+       controllerType==.Modelica.Blocks.Types.SimpleController.PD or 
+                                controllerType==.Modelica.Blocks.Types.SimpleController.PID));
+  parameter Real Ni(min=100*Modelica.Constants.eps) = 0.9
+    "Ni*Ti is time constant of anti-windup compensation"
+     annotation(Dialog(tab="Advanced", group="Controller", enable=have_controller and 
+     controllerType==.Modelica.Blocks.Types.SimpleController.PI or 
+                              controllerType==.Modelica.Blocks.Types.SimpleController.PID));
+  parameter Real Nd(min=100*Modelica.Constants.eps) = 10
+    "The higher Nd, the more ideal the derivative block"
+       annotation(Dialog(tab="Advanced", group="Controller", enable=have_controller and 
+       controllerType==.Modelica.Blocks.Types.SimpleController.PD or 
+                                controllerType==.Modelica.Blocks.Types.SimpleController.PID));
+
+  parameter Boolean reverseActing = true
+    "Set to true for reverse acting, or false for direct acting control action"
+    annotation (Dialog(tab="Advanced", group="Controller", enable=have_controller));
+
 
   Real s(min=0,max=1) "Motor slip";
   Real v_rms "RMS voltage";
@@ -126,7 +161,6 @@ model SquirrelCageDrive "Squirrel cage type induction motor with electrical inte
     "Reactive power"
     annotation (Placement(transformation(extent={{100,20},{140,60}}),
         iconTransformation(extent={{100,20},{140,60}})));
-
 
 initial equation 
   omega_r=0;
@@ -243,3 +277,4 @@ First implementation.
 </ul>
 </html>"));
 end SquirrelCageDrive;
+


### PR DESCRIPTION
1. Remove the parameter n (number of phases) and replace the n with the value "3" in the equations used for calculating torque, active power, and reactive power. Theses updates should be applied to the following components:  coupled chiller, coupled heat pump, coupled pump, squirrel cage, squirrel cage drive, and motor machine interface.
2. Remove the assertion in coupled chiller and coupled heat pump since the base models of chiller and heat pump in ThermoFulid folder already have these assertions.
3.  Replace the OnePhase grid with ThreePhasesBalanced grid and update the nominal RMS voltage to 480 V in the examples located in the Coupled and InductionMotors folders
4. Delete "noEvent" of the hysteresis in the base model located in MotorMachineInterface since the if statement triggers an event based on the Boolean variable y_internal value. 
5. Expose the built-in controller parameters in the SquirrelCageDrive.mo and group them under an "Advanced" tab with the group name "Controller"