### PR TITLE
Issue3416 correct broken links

### DIFF
--- a/Buildings/Fluid/Geothermal/Borefields/BaseClasses/HeatTransfer/ThermalResponseFactors/finiteLineSource_Equivalent.mo
+++ b/Buildings/Fluid/Geothermal/Borefields/BaseClasses/HeatTransfer/ThermalResponseFactors/finiteLineSource_Equivalent.mo
@@ -124,7 +124,7 @@ where <i>&alpha;<sub>s</sub></i> is the ground thermal diffusivity and
 <i>erfint</i> is the integral of the error function, defined in
 <a href=\"modelica://Buildings.Fluid.Geothermal.Borefields.BaseClasses.HeatTransfer.ThermalResponseFactors.finiteLineSource_Erfint\">Buildings.Fluid.Geothermal.Borefields.BaseClasses.HeatTransfer.ThermalResponseFactors.finiteLineSource_erfint</a>.
 The integral is solved numerically, with the integrand defined in
-<a href=\"modelica://Buildings.Fluid.Geothermal.Borefields.BaseClasses.HeatTransfer.ThermalResponseFactors.finiteLineSource_Integrand_EquivalentBoreholes\">Buildings.Fluid.Geothermal.Borefields.BaseClasses.HeatTransfer.ThermalResponseFactors.finiteLineSource_Integrand_EquivalentBoreholes</a>.
+<a href=\"modelica://Buildings.Fluid.Geothermal.Borefields.BaseClasses.HeatTransfer.ThermalResponseFactors.finiteLineSource_Integrand_Equivalent\">Buildings.Fluid.Geothermal.Borefields.BaseClasses.HeatTransfer.ThermalResponseFactors.finiteLineSource_Integrand_Equivalent</a>.
 </p>
 </html>", revisions="<html>
 <ul>

--- a/Buildings/Fluid/Geothermal/Borefields/BaseClasses/HeatTransfer/ThermalResponseFactors/finiteLineSource_Integrand_Equivalent.mo
+++ b/Buildings/Fluid/Geothermal/Borefields/BaseClasses/HeatTransfer/ThermalResponseFactors/finiteLineSource_Integrand_Equivalent.mo
@@ -51,8 +51,8 @@ annotation (
 Documentation(info="<html>
 <p>
 Integrand of the finite line source solution for use in
-<a href=\"modelica://Buildings.Fluid.Geothermal.Borefields.BaseClasses.HeatTransfer.ThermalResponseFactors.finiteLineSource_EquivalentBoreholes\">
-Buildings.Fluid.Geothermal.Borefields.BaseClasses.HeatTransfer.ThermalResponseFactors.finiteLineSource_EquivalentBoreholes</a>.
+<a href=\"modelica://Buildings.Fluid.Geothermal.Borefields.BaseClasses.HeatTransfer.ThermalResponseFactors.finiteLineSource_Equivalent\">
+Buildings.Fluid.Geothermal.Borefields.BaseClasses.HeatTransfer.ThermalResponseFactors.finiteLineSource_Equivalent</a>.
 </p>
 </html>", revisions="<html>
 <ul>

--- a/Buildings/Fluid/HydronicConfigurations/ActiveNetworks/Examples/BaseClasses/LoadThreeWayValveControl.mo
+++ b/Buildings/Fluid/HydronicConfigurations/ActiveNetworks/Examples/BaseClasses/LoadThreeWayValveControl.mo
@@ -33,8 +33,8 @@ model LoadThreeWayValveControl
 <p>
 This is a model of a thermal load on a hydronic circuit that
 is composed of
-<a href=\"modelica://Buildings.Fluid.HydronicConfigurations.Examples.BaseClasses.Load\">
-Buildings.Fluid.HydronicConfigurations.Examples.BaseClasses.Load</a>
+<a href=\"modelica://Buildings.Fluid.HydronicConfigurations.ActiveNetworks.Examples.BaseClasses.Load\">
+Buildings.Fluid.HydronicConfigurations.ActiveNetworks.Examples.BaseClasses.Load</a>
 and a diversion circuit with a three-way valve 
 that is used to modulate the flow rate through the load component.
 </p>

--- a/Buildings/Fluid/HydronicConfigurations/ActiveNetworks/Examples/BaseClasses/LoadTwoWayValveControl.mo
+++ b/Buildings/Fluid/HydronicConfigurations/ActiveNetworks/Examples/BaseClasses/LoadTwoWayValveControl.mo
@@ -12,8 +12,8 @@ model LoadTwoWayValveControl
 <p>
 This is a model of a thermal load on a hydronic circuit that
 is composed of
-<a href=\"modelica://Buildings.Fluid.HydronicConfigurations.Examples.BaseClasses.Load\">
-Buildings.Fluid.HydronicConfigurations.Examples.BaseClasses.Load</a>
+<a href=\"modelica://Buildings.Fluid.HydronicConfigurations.ActiveNetworks.Examples.BaseClasses.Load\">
+Buildings.Fluid.HydronicConfigurations.ActiveNetworks.Examples.BaseClasses.Load</a>
 and a throttle circuit with a two-way valve 
 that is used to modulate the flow rate through the load component.
 </p>

--- a/Buildings/Fluid/HydronicConfigurations/ActiveNetworks/Examples/BaseClasses/PartialLoadValveControl.mo
+++ b/Buildings/Fluid/HydronicConfigurations/ActiveNetworks/Examples/BaseClasses/PartialLoadValveControl.mo
@@ -245,8 +245,8 @@ equation
 <p>
 This is a partial model of a thermal load on a hydronic circuit that
 is composed of
-<a href=\"modelica://Buildings.Fluid.HydronicConfigurations.Examples.BaseClasses.Load\">
-Buildings.Fluid.HydronicConfigurations.Examples.BaseClasses.Load</a>
+<a href=\"modelica://Buildings.Fluid.HydronicConfigurations.ActiveNetworks.Examples.BaseClasses.Load\">
+Buildings.Fluid.HydronicConfigurations.ActiveNetworks.Examples.BaseClasses.Load</a>
 and a replaceable configuration component derived from 
 <a href=\"modelica://Buildings.Fluid.HydronicConfigurations.Interfaces.PartialHydronicConfiguration\">
 Buildings.Fluid.HydronicConfigurations.Interfaces.PartialHydronicConfiguration</a>

--- a/Buildings/Fluid/HydronicConfigurations/ActiveNetworks/Examples/DecouplingMixing.mo
+++ b/Buildings/Fluid/HydronicConfigurations/ActiveNetworks/Examples/DecouplingMixing.mo
@@ -172,8 +172,8 @@ followed by a large overshoot, and the control loop is hard to tune.
 The fact that the load seems unmet at partial load (see plot #4) is due to the
 load model that does not guarantee a linear variation of the load
 with the input signal in cooling mode, see
-<a href=\"modelica://Buildings.Fluid.HydronicConfigurations.Examples.BaseClasses.Load\">
-Buildings.Fluid.HydronicConfigurations.Examples.BaseClasses.Load</a>.
+<a href=\"modelica://Buildings.Fluid.HydronicConfigurations.ActiveNetworks.Examples.BaseClasses.Load\">
+Buildings.Fluid.HydronicConfigurations.ActiveNetworks.Examples.BaseClasses.Load</a>.
 </p>
 </html>", revisions="<html>
 <ul>

--- a/Buildings/Fluid/HydronicConfigurations/ActiveNetworks/Examples/InjectionTwoWayConstantReturn.mo
+++ b/Buildings/Fluid/HydronicConfigurations/ActiveNetworks/Examples/InjectionTwoWayConstantReturn.mo
@@ -45,8 +45,8 @@ the load diversity as required when controlling for the return temperature
 Buildings.Fluid.HydronicConfigurations.ActiveNetworks.Examples.InjectionTwoWayConstant</a>).
 In addition, the load model does not guarantee a linear variation of the load
 with the input signal in cooling mode, see
-<a href=\"modelica://Buildings.Fluid.HydronicConfigurations.Examples.BaseClasses.Load\">
-Buildings.Fluid.HydronicConfigurations.Examples.BaseClasses.Load</a>.
+<a href=\"modelica://Buildings.Fluid.HydronicConfigurations.ActiveNetworks.Examples.BaseClasses.Load\">
+Buildings.Fluid.HydronicConfigurations.ActiveNetworks.Examples.BaseClasses.Load</a>.
 This amplifies the effect of the unmet load at partial load.
 </p>
 </html>", revisions="<html>

--- a/Buildings/Fluid/HydronicConfigurations/ActiveNetworks/Examples/InjectionTwoWayVariable.mo
+++ b/Buildings/Fluid/HydronicConfigurations/ActiveNetworks/Examples/InjectionTwoWayVariable.mo
@@ -103,8 +103,8 @@ on the primary return line.
 The fact that the load seems unmet at partial load (see plot #4) is due to the
 load model that does not guarantee a linear variation of the load
 with the input signal in cooling mode, see
-<a href=\"modelica://Buildings.Fluid.HydronicConfigurations.Examples.BaseClasses.Load\">
-Buildings.Fluid.HydronicConfigurations.Examples.BaseClasses.Load</a>.
+<a href=\"modelica://Buildings.Fluid.HydronicConfigurations.ActiveNetworks.Examples.BaseClasses.Load\">
+Buildings.Fluid.HydronicConfigurations.ActiveNetworks.Examples.BaseClasses.Load</a>.
 </p>
 </html>", revisions="<html>
 <ul>

--- a/Buildings/Fluid/HydronicConfigurations/Controls/PIDWithOperatingMode.mo
+++ b/Buildings/Fluid/HydronicConfigurations/Controls/PIDWithOperatingMode.mo
@@ -213,9 +213,7 @@ applies the minimum control effect, i.e., valves/dampers closed,
 VFDs at minimum speed, etc.
 </li>
 <li>
-When operated under the mode
-<a href=\"modelica://Buildings.Fluid.HydronicConfigurations.Controls.OperatingModes.enabled\">
-Buildings.Fluid.HydronicConfigurations.Controls.OperatingModes.enabled</a>
+When operated under the mode <code>enabled</code>
 the controller behaves exactly as
 <a href=\"modelica://Buildings.Controls.OBC.CDL.Continuous.PIDWithReset\">
 Buildings.Controls.OBC.CDL.Continuous.PIDWithReset</a>.
@@ -223,9 +221,7 @@ Furthermore, the controller output is reset to <code>y_reset</code> at enable
 time.
 </li>
 <li>
-When operated under the mode
-<a href=\"modelica://Buildings.Fluid.HydronicConfigurations.Controls.OperatingModes.heating\">
-Buildings.Fluid.HydronicConfigurations.Controls.OperatingModes.heating</a>
+When operated under the mode <code>heating</code>
 the controller behaves as
 <a href=\"modelica://Buildings.Controls.OBC.CDL.Continuous.PIDWithReset\">
 Buildings.Controls.OBC.CDL.Continuous.PIDWithReset</a>

--- a/Buildings/Obsolete/Fluid/Movers/Data/Pumps/Wilo/Stratos25slash1to4.mo
+++ b/Buildings/Obsolete/Fluid/Movers/Data/Pumps/Wilo/Stratos25slash1to4.mo
@@ -26,8 +26,8 @@ Documentation(info="<html>
   </a>
   </p>
   <p>See
-  <a href=\"modelica://Buildings.Obsolete.Fluid.Movers.Data.Pumps.Wilo.Stratos25slash1to6\">
-  Buildings.Obsolete.Fluid.Movers.Data.Pumps.Wilo.Stratos25slash1to6
+  <a href=\"modelica://Buildings.Fluid.Movers.Data.Pumps.Wilo.Stratos25slash1to6\">
+  Buildings.Fluid.Movers.Data.Pumps.Wilo.Stratos25slash1to6
   </a>
   for more information about how the data is derived.
   </p>

--- a/Buildings/Obsolete/Fluid/Movers/Data/Pumps/Wilo/Stratos32slash1to12.mo
+++ b/Buildings/Obsolete/Fluid/Movers/Data/Pumps/Wilo/Stratos32slash1to12.mo
@@ -26,8 +26,8 @@ Documentation(info="<html>
   </a>
   </p>
   <p>See
-  <a href=\"modelica://Buildings.Obsolete.Fluid.Movers.Data.Pumps.Wilo.Stratos25slash1to6\">
-  Buildings.Obsolete.Fluid.Movers.Data.Pumps.Wilo.Stratos25slash1to6
+  <a href=\"modelica://Buildings.Fluid.Movers.Data.Pumps.Wilo.Stratos25slash1to6\">
+  Buildings.Fluid.Movers.Data.Pumps.Wilo.Stratos25slash1to6
   </a>
   for more information about how the data is derived.
   </p>


### PR DESCRIPTION
This closes #3416.

@mwetter -
It looks like most of them are just links not properly updated after the classes were moved around.
The two exceptions are `Buildings.Fluid.HydronicConfigurations.Controls.OperatingModes.enabled` and `Buildings.Fluid.HydronicConfigurations.Controls.OperatingModes.heating` in `HydronicConfigurations.Controls.PIDWithOperatingMode`. They point to constants instead of classes and therefore cannot be clicked to open in Dymola. Because the package `OperatingModes` which contains these constants is already linked uptext in the documentation, I simply replaced these two links with just plain texts.
I will go ahead and merge relevant changes to IBPSA.