### PR TITLE
Corrected variability

### DIFF
--- a/Buildings/Fluid/Geothermal/Borefields/BaseClasses/Boreholes/BaseClasses/Functions/convectionResistanceCircularPipe.mo
+++ b/Buildings/Fluid/Geothermal/Borefields/BaseClasses/Boreholes/BaseClasses/Functions/convectionResistanceCircularPipe.mo
@@ -22,7 +22,7 @@ function convectionResistanceCircularPipe
     "Convection resistance (or conduction in fluid if no mass flow)";
 
 protected
-  parameter Modelica.Units.SI.Radius rTub_in=rTub - eTub "Pipe inner radius";
+  Modelica.Units.SI.Radius rTub_in=rTub - eTub "Pipe inner radius";
   Modelica.Units.SI.CoefficientOfHeatTransfer h
     "Convective heat transfer coefficient of the fluid";
 
@@ -64,9 +64,9 @@ algorithm
 
   RFluPip := 1/(2*Modelica.Constants.pi*rTub_in*hSeg*h);
 
-  annotation (Diagram(graphics), Documentation(info="<html>
+  annotation (Documentation(info="<html>
 <p>
-This model computes the convection resistance in the pipes of a borehole segment 
+This model computes the convection resistance in the pipes of a borehole segment
 with heigth <i>h<sub>Seg</sub></i> using correlations suggested by Bergman et al. (2011).
 </p>
 <p>
@@ -78,9 +78,9 @@ the correlation of Dittus-Boelter is used to find the convection heat transfer c
   Nu = 0.023 &nbsp; Re<sup>0.8</sup> &nbsp; Pr<sup>n</sup>,
 </p>
 <p>
-where <i>Nu</i> is the Nusselt number and 
+where <i>Nu</i> is the Nusselt number and
 <i>Pr</i> is the Prandlt number.
-A value of <i>n=0.35</i> is used, as the reference uses <i>n=0.4</i> for heating and 
+A value of <i>n=0.35</i> is used, as the reference uses <i>n=0.4</i> for heating and
 <i>n=0.3</i> for cooling. To ensure that the function is continuously differentiable,
 a smooth transition between the laminar and turbulent values is created for the
 range <i>2300 &lt; Re &lt; 2400</i>.
@@ -93,6 +93,11 @@ transfer</i> (7th ed.). New York: John Wiley &amp; Sons.
 </html>", revisions="<html>
 <ul>
 <li>
+June 4, 2023, by Michael Wetter:<br/>
+Corrected variability.<br/>
+This is for <a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1762\">IBPSA, #1762</a>.
+</li>
+<li>
 July 10, 2018, by Alex Laferri&egrave;re:<br/>
 Added laminar flow and smooth laminar-turbulent transition.
 Revised documentation.
@@ -104,7 +109,7 @@ Revised documentation.
 </li>
 <li>
 January 24, 2014, by Michael Wetter:<br/>
-Revised implementation. 
+Revised implementation.
 Changed <code>cpFluid</code> to <code>cpMed</code> to use consistent notation.
 Added regularization for computation of convective heat transfer coefficient to
 avoid an event and a non-differentiability.

--- a/Buildings/Fluid/Geothermal/Borefields/BaseClasses/Boreholes/BaseClasses/Functions/partialInternalResistances.mo
+++ b/Buildings/Fluid/Geothermal/Borefields/BaseClasses/Boreholes/BaseClasses/Functions/partialInternalResistances.mo
@@ -36,7 +36,7 @@ partial function partialInternalResistances
 protected
   parameter Real pi = 3.141592653589793 "pi";
 
-  parameter Real rTub_in = rTub-eTub "Inner radius of tube";
+  Real rTub_in = rTub-eTub "Inner radius of tube";
 
   Real RConv(unit="(m.K)/W")=
     Buildings.Fluid.Geothermal.Borefields.BaseClasses.Boreholes.BaseClasses.Functions.convectionResistanceCircularPipe(
@@ -70,6 +70,11 @@ the borehole internal resistances.
 </p>
 </html>", revisions="<html>
 <ul>
+<li>
+June 4, 2023, by Michael Wetter:<br/>
+Corrected variability.<br/>
+This is for <a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1762\">IBPSA, #1762</a>.
+</li>
 <li>
 February 28, 2022, by Massimo Cimmino:<br/>
 Changed function to be <code>pure</code>.<br/>


### PR DESCRIPTION
This integrates IBPSA 1762.
This corrects the variability as assigning an input to a parameter is not allowed