### PR TITLE
Issue3425 documentation chiller EIR factors

### DIFF
--- a/Buildings/Fluid/Chillers/BaseClasses/PartialElectric.mo
+++ b/Buildings/Fluid/Chillers/BaseClasses/PartialElectric.mo
@@ -378,21 +378,43 @@ for an example with a chiller operating in heating mode.
 </p>
 <h4>Implementation</h4>
 <p>
-Models that extend from this base class need to provide
-three functions to predict capacity and power consumption:
+This implementation computes the chiller capacity and power consumption
+the same way as documented in
+<a href=\"https://energyplus.net/assets/nrel_custom/pdfs/pdfs_v22.1.0/EngineeringReference.pdf\">
+EnergyPlus v22.1.0 Engineering Reference</a>
+section 14.3.9.2.
+The chiller capacity is computed as
+</p>
+<pre>  QEva_flow_ava = QEva_flow_nominal*capFunT;</pre>
+<p>
+and the power consumption is computed as
+</p>
+<pre>  P = -QEva_flow_ava/COP_nominal*EIRFunT*EIRFunPLR*CR;</pre>
+<p>
+(See equations 14.234 and 14.240 in the referenced document.)
+</p>
+<p>
+Models that extend from this base class need to provide the following
+three functions:
 </p>
 <ul>
 <li>
-A function to predict cooling capacity. The function value needs
-to be assigned to <code>capFunT</code>.
+<code>capFunT</code> to predict cooling capacity,
 </li>
 <li>
-A function to predict the power input as a function of temperature.
-The function value needs to be assigned to <code>EIRFunT</code>.
+<code>EIRFunT</code> to predict the power input as a function of temperature,
+and
 </li>
 <li>
-A function to predict the power input as a function of the part load ratio.
-The function value needs to be assigned to <code>EIRFunPLR</code>.
+<code>EIRFunPLR</code> to predict the power input as a function of the
+part load ratio.
+</li>
+</ul>
+<h4>References</h4>
+<ul>
+<li>
+<a href=\"https://energyplus.net/assets/nrel_custom/pdfs/pdfs_v22.1.0/EngineeringReference.pdf\">
+EnergyPlus v22.1.0 Engineering Reference</a>
 </li>
 </ul>
 </html>",

--- a/Buildings/Fluid/Chillers/BaseClasses/PartialElectric.mo
+++ b/Buildings/Fluid/Chillers/BaseClasses/PartialElectric.mo
@@ -410,6 +410,12 @@ and
 part load ratio.
 </li>
 </ul>
+<p>
+See the documentation of
+<a href=\"Modelica://Buildings.Fluid.Chillers.Data.ElectricEIR.Generic\">
+Buildings.Fluid.Chillers.Data.ElectricEIR.Generic</a>
+to see how they are formulated in extended models.
+</p>
 <h4>References</h4>
 <ul>
 <li>

--- a/Buildings/Fluid/Chillers/BaseClasses/PartialElectric.mo
+++ b/Buildings/Fluid/Chillers/BaseClasses/PartialElectric.mo
@@ -333,14 +333,14 @@ The model has three tests on the part load ratio and the cycling ratio:
 <li>
 The test
 <pre>
-  PLR1 =min(QEva_flow_set/QEva_flow_ava, PLRMax);
+  PLR1 =min(QEva_flow_set/QEva_flow_ava, PLRMax)
 </pre>
 ensures that the chiller capacity does not exceed the chiller capacity specified
 by the parameter <code>PLRMax</code>.
 </li>
 <li>
 The test <pre>
-  CR = min(PLR1/per.PRLMin, 1.0);
+  CR = min(PLR1/per.PRLMin, 1.0)
 </pre>
 computes a cycling ratio. This ratio expresses the fraction of time
 that a chiller would run if it were to cycle because its load is smaller than
@@ -351,7 +351,7 @@ average temperature between the modes where the compressor is off and on.
 </li>
 <li>
 The test <pre>
-  PLR2 = max(PLRMinUnl, PLR1);
+  PLR2 = max(PLRMinUnl, PLR1)
 </pre>
 computes the part load ratio of the compressor.
 The assumption is that for a part load ratio below <code>PLRMinUnl</code>,
@@ -385,13 +385,13 @@ EnergyPlus v22.1.0 Engineering Reference</a>
 section 14.3.9.2.
 The chiller capacity is computed as
 </p>
-<pre>  QEva_flow_ava = QEva_flow_nominal*capFunT;</pre>
+<pre>  QEva_flow_ava = QEva_flow_nominal*capFunT</pre>
 <p>
 and the power consumption is computed as
 </p>
-<pre>  P = -QEva_flow_ava/COP_nominal*EIRFunT*EIRFunPLR*CR;</pre>
+<pre>  P = -QEva_flow_ava/COP_nominal*EIRFunT*EIRFunPLR*CR.</pre>
 <p>
-(See equations 14.234 and 14.240 in the referenced document.)
+See equations 14.234 and 14.240 in the referenced document.
 </p>
 <p>
 Models that extend from this base class need to provide the following

--- a/Buildings/Fluid/Chillers/BaseClasses/PartialElectric.mo
+++ b/Buildings/Fluid/Chillers/BaseClasses/PartialElectric.mo
@@ -381,40 +381,62 @@ for an example with a chiller operating in heating mode.
 This implementation computes the chiller capacity and power consumption
 the same way as documented in
 <a href=\"https://energyplus.net/assets/nrel_custom/pdfs/pdfs_v22.1.0/EngineeringReference.pdf\">
-EnergyPlus v22.1.0 Engineering Reference</a>
-section 14.3.9.2.
-The chiller capacity is computed as
+EnergyPlus v22.1.0 Engineering Reference</a> section 14.3.9.2.
+Especially see equations 14.234 and 14.240 in the referenced document.
+</p>
+<p>
+The available chiller capacity <code>QEva_flow_ava</code> is adjusted from
+its nominal capacity <code>QEva_flow_nominal</code>
+by factor <code>capFunT</code> as
 </p>
 <pre>  QEva_flow_ava = QEva_flow_nominal*capFunT</pre>
 <p>
-and the power consumption is computed as
+and the compressor power consumption is computed as
 </p>
-<pre>  P = -QEva_flow_ava/COP_nominal*EIRFunT*EIRFunPLR*CR.</pre>
+<pre>  P = -QEva_flow_ava*(1/COP_nominal)*EIRFunT*EIRFunPLR*CR.</pre>
 <p>
-See equations 14.234 and 14.240 in the referenced document.
+The models that extend from this base class implement the functions used above
+in ways that are shown in the table below.
 </p>
+<table summary=\"summary\" border=\"1\" cellspacing=\"0\" cellpadding=\"2\" style=\"border-collapse:collapse;\">
+<thead>
+  <tr>
+    <th rowspan=\"2\">Function</th>
+    <th rowspan=\"2\">Description</th>
+    <th colspan=\"2\">Formulation</th>
+  </tr>
+  <tr>
+    <th><code><a href=\"Modelica://Buildings.Fluid.Chillers.ElectricEIR\">ElectricEIR</a></code></th>
+    <th><code><a href=\"Modelica://Buildings.Fluid.Chillers.ElectricReformulatedEIR\">ElectricReformulatedEIR</a></code></th>
+  </tr>
+</thead>
+<tbody>
+  <tr>
+    <td><code>capFunT</code></td>
+    <td>Adjusts cooling capacity for current fluid temperatures</td>
+    <td>Biquadratic on <code>TConEnt</code> and <code>TEvaLvg</code></td>
+    <td>Biquadratic on <code>TConLvg</code> and <code>TEvaLvg</code></td>
+  </tr>
+  <tr>
+    <td><code>EIRFunPLR</code></td>
+    <td>Adjusts EIR for the current PLR</td>
+    <td>Quadratic on PLR</td>
+    <td>Bicubic on <code>TConLvg</code> and PLR</td>
+  </tr>
+  <tr>
+    <td><code>EIRFunT</code></td>
+    <td>Adjusts EIR for current fluid temperatures</td>
+    <td>Biquadratic on <code>TConEnt</code> and <code>TEvaLvg</code></td>
+    <td>Biquadratic on <code>TConLvg</code> and <code>TEvaLvg</code></td>
+  </tr>
+</tbody>
+</table>
 <p>
-Models that extend from this base class need to provide the following
-three functions:
-</p>
-<ul>
-<li>
-<code>capFunT</code> to predict cooling capacity,
-</li>
-<li>
-<code>EIRFunT</code> to predict the power input as a function of temperature,
-and
-</li>
-<li>
-<code>EIRFunPLR</code> to predict the power input as a function of the
-part load ratio.
-</li>
-</ul>
-<p>
-See the documentation of
-<a href=\"Modelica://Buildings.Fluid.Chillers.Data.ElectricEIR.Generic\">
-Buildings.Fluid.Chillers.Data.ElectricEIR.Generic</a>
-to see how they are formulated in extended models.
+where
+<code>TConEnt</code> is the condenser entering temperature,
+<code>TEvaLvg</code> is the evaporator leaving temperature,
+<code>TConLvg</code> is the condenser leaving temperatore, and
+PLR is the part load ratio.
 </p>
 <h4>References</h4>
 <ul>

--- a/Buildings/Fluid/Chillers/Data/ElectricEIR.mo
+++ b/Buildings/Fluid/Chillers/Data/ElectricEIR.mo
@@ -27,6 +27,46 @@ package ElectricEIR "Performance data for chiller ElectricEIR"
 for the chiller model
 <a href=\"modelica://Buildings.Fluid.Chillers.ElectricEIR\">
 Buildings.Fluid.Chillers.ElectricEIR</a>.
+It provides coefficients for the following functions:</p>
+<table summary=\"summary\" border=\"1\" cellspacing=\"0\" cellpadding=\"2\" style=\"border-collapse:collapse;\">
+<thead>
+  <tr>
+    <th rowspan=\"2\">Function</th>
+    <th rowspan=\"2\">Description</th>
+    <th colspan=\"2\">Formulation</th>
+  </tr>
+  <tr>
+    <th><code><a href=\"Modelica://Buildings.Fluid.Chillers.ElectricEIR\">ElectricEIR</a></code></th>
+    <th><code><a href=\"Modelica://Buildings.Fluid.Chillers.ElectricReformulatedEIR\">ElectricReformulatedEIR</a></code></th>
+  </tr>
+</thead>
+<tbody>
+  <tr>
+    <td><code>capFunT</code></td>
+    <td>Modifies cooling capacity</td>
+    <td>Biquadratic on <code>TConEnt</code> and <code>TEvaLvg</code></td>
+    <td>Biquadratic on <code>TConLvg</code> and <code>TEvaLvg</code></td>
+  </tr>
+  <tr>
+    <td><code>EIRFunPLR</code></td>
+    <td>Modifies EIR</td>
+    <td>Quadratic on PLR</td>
+    <td>Bicubic on <code>TConLvg</code> and PLR</td>
+  </tr>
+  <tr>
+    <td><code>EIRFunT</code></td>
+    <td>Modifies EIR</td>
+    <td>Biquadratic on <code>TConEnt</code> and <code>TEvaLvg</code></td>
+    <td>BIquadratic on <code>TConLvg</code> and <code>TEvaLvg</code></td>
+  </tr>
+</tbody>
+</table>
+<p>
+where
+<code>TConEnt</code> is the condenser entering temperature,
+<code>TEvaLvg</code> is the evaporator leaving temperature,
+<code>TConLvg</code> is the condenser leaving temperatore, and
+PLR is the part load ratio.
 </p>
 </html>", revisions="<html>
 <ul>

--- a/Buildings/Fluid/Chillers/Data/ElectricEIR.mo
+++ b/Buildings/Fluid/Chillers/Data/ElectricEIR.mo
@@ -27,46 +27,11 @@ package ElectricEIR "Performance data for chiller ElectricEIR"
 for the chiller model
 <a href=\"modelica://Buildings.Fluid.Chillers.ElectricEIR\">
 Buildings.Fluid.Chillers.ElectricEIR</a>.
-It provides coefficients for the following functions:</p>
-<table summary=\"summary\" border=\"1\" cellspacing=\"0\" cellpadding=\"2\" style=\"border-collapse:collapse;\">
-<thead>
-  <tr>
-    <th rowspan=\"2\">Function</th>
-    <th rowspan=\"2\">Description</th>
-    <th colspan=\"2\">Formulation</th>
-  </tr>
-  <tr>
-    <th><code><a href=\"Modelica://Buildings.Fluid.Chillers.ElectricEIR\">ElectricEIR</a></code></th>
-    <th><code><a href=\"Modelica://Buildings.Fluid.Chillers.ElectricReformulatedEIR\">ElectricReformulatedEIR</a></code></th>
-  </tr>
-</thead>
-<tbody>
-  <tr>
-    <td><code>capFunT</code></td>
-    <td>Modifies cooling capacity</td>
-    <td>Biquadratic on <code>TConEnt</code> and <code>TEvaLvg</code></td>
-    <td>Biquadratic on <code>TConLvg</code> and <code>TEvaLvg</code></td>
-  </tr>
-  <tr>
-    <td><code>EIRFunPLR</code></td>
-    <td>Modifies EIR</td>
-    <td>Quadratic on PLR</td>
-    <td>Bicubic on <code>TConLvg</code> and PLR</td>
-  </tr>
-  <tr>
-    <td><code>EIRFunT</code></td>
-    <td>Modifies EIR</td>
-    <td>Biquadratic on <code>TConEnt</code> and <code>TEvaLvg</code></td>
-    <td>BIquadratic on <code>TConLvg</code> and <code>TEvaLvg</code></td>
-  </tr>
-</tbody>
-</table>
-<p>
-where
-<code>TConEnt</code> is the condenser entering temperature,
-<code>TEvaLvg</code> is the evaporator leaving temperature,
-<code>TConLvg</code> is the condenser leaving temperatore, and
-PLR is the part load ratio.
+To provide performance data for
+<a href=\"modelica://Buildings.Fluid.Chillers.ElectricReformulatedEIR\">
+Buildings.Fluid.Chillers.ElectricReformulatedEIR</a>, use
+<a href=\"modelica://Buildings.Fluid.Chillers.Data.ElectricReformulatedEIR.Generic\">
+Buildings.Fluid.Chillers.Data.ElectricReformulatedEIR.Generic</a> instead.
 </p>
 </html>", revisions="<html>
 <ul>

--- a/Buildings/Fluid/Chillers/Data/ElectricReformulatedEIR.mo
+++ b/Buildings/Fluid/Chillers/Data/ElectricReformulatedEIR.mo
@@ -25,6 +25,11 @@ This record is used as a template for performance data
 for the chiller model
 <a href=\"modelica://Buildings.Fluid.Chillers.ElectricReformulatedEIR\">
 Buildings.Fluid.Chillers.ElectricReformulatedEIR</a>.
+To provide performance data for
+<a href=\"modelica://Buildings.Fluid.Chillers.ElectricEIR\">
+Buildings.Fluid.Chillers.ElectricEIR</a>, use
+<a href=\"modelica://Buildings.Fluid.Chillers.Data.ElectricEIR.Generic\">
+Buildings.Fluid.Chillers.Data.ElectricEIR.Generic</a> instead.
 </html>", revisions="<html>
 <ul>
 <li>

--- a/Buildings/Fluid/Chillers/ElectricEIR.mo
+++ b/Buildings/Fluid/Chillers/ElectricEIR.mo
@@ -140,22 +140,39 @@ the EnergyPlus chiller model <code>Chiller:Electric:EIR</code>.
 </p>
 <p> This model uses three functions to predict capacity and power consumption:
 </p>
-<ul>
-<li>
-A biquadratic function <code>capFunT</code> is used to predict
-cooling capacity as a function of condenser entering temperature
-<code>TConEnt</code> and evaporator leaving temperature <code>TEvaLvg</code>.
-</li>
-<li>
-A quadratic function <code>EIRFunPLR</code> is used to predict
-power input to cooling capacity ratio with respect to the part load ratio.
-</li>
-<li>
-A biquadratic function <code>EIRFunT</code> is used to predict power input to
-cooling capacity ratio as a function of condenser entering temperature
-<code>TConEnt</code> and evaporator leaving temperature <code>TEvaLvg</code>.
-</li>
-</ul>
+<table summary=\"summary\" border=\"1\" cellspacing=\"0\" cellpadding=\"2\" style=\"border-collapse:collapse;\">
+<thead>
+  <tr>
+    <th rowspan=\"2\">Function</th>
+    <th rowspan=\"2\">Description</th>
+    <th colspan=\"2\">Formulation</th>
+  </tr>
+  <tr>
+  <th><code><a href=\"Modelica://Buildings.Fluid.Chillers.ElectricEIR\">ElectricEIR</a></code> (this model)</th>
+    <th><code><a href=\"Modelica://Buildings.Fluid.Chillers.ElectricReformulatedEIR\">ElectricReformulatedEIR</a></code></th>
+  </tr>
+</thead>
+<tbody>
+  <tr>
+    <td><code>capFunT</code></td>
+    <td>Adjusts cooling capacity for current fluid temperatures</td>
+    <td>Biquadratic on <code>TConEnt</code> and <code>TEvaLvg</code></td>
+    <td>Biquadratic on <code>TConLvg</code> and <code>TEvaLvg</code></td>
+  </tr>
+  <tr>
+    <td><code>EIRFunPLR</code></td>
+    <td>Adjusts EIR for the current PLR</td>
+    <td>Quadratic on PLR</td>
+    <td>Bicubic on <code>TConLvg</code> and PLR</td>
+  </tr>
+  <tr>
+    <td><code>EIRFunT</code></td>
+    <td>Adjusts EIR for current fluid temperatures</td>
+    <td>Biquadratic on <code>TConEnt</code> and <code>TEvaLvg</code></td>
+    <td>Biquadratic on <code>TConLvg</code> and <code>TEvaLvg</code></td>
+  </tr>
+</tbody>
+</table>
 <p>
 These functions take the same form as documented in
 <a href=\"https://energyplus.net/assets/nrel_custom/pdfs/pdfs_v22.1.0/EngineeringReference.pdf\">
@@ -164,6 +181,10 @@ section 14.3.9.2 (equations 14.231 through 14.233).
 These curves are stored in the data record <code>per</code> and are available from
 <a href=\"modelica://Buildings.Fluid.Chillers.Data.ElectricEIR\">
 Buildings.Fluid.Chillers.Data.ElectricEIR</a>.
+How they are used to compute the adjusted capacity and compressor power
+can be found in the documentation of
+<a href=\"modelica://Buildings.Fluid.Chillers.BaseClasses.PartialElectric\">
+Buildings.Fluid.Chillers.BaseClasses.PartialElectric</a>.
 Additional performance curves can be developed using
 two available techniques (Hydeman and Gillespie, 2002). The first technique is called the
 Least-squares Linear Regression method and is used when sufficient performance data exist

--- a/Buildings/Fluid/Chillers/ElectricEIR.mo
+++ b/Buildings/Fluid/Chillers/ElectricEIR.mo
@@ -143,17 +143,17 @@ the EnergyPlus chiller model <code>Chiller:Electric:EIR</code>.
 <ul>
 <li>
 A biquadratic function <code>capFunT</code> is used to predict
-cooling capacity as a function of condenser entering and evaporator leaving
-fluid temperature.
+cooling capacity as a function of condenser entering temperature
+<code>TConEnt</code> and evaporator leaving temperature <code>TEvaLvg</code>.
 </li>
 <li>
 A quadratic function <code>EIRFunPLR</code> is used to predict
 power input to cooling capacity ratio with respect to the part load ratio.
 </li>
 <li>
-A biquadratic function <code>EIRFunT</code> is used to predict
-power input to cooling capacity ratio as a function of
-condenser entering and evaporator leaving fluid temperature.
+A biquadratic function <code>EIRFunT</code> is used to predict power input to
+cooling capacity ratio as a function of condenser entering temperature
+<code>TConEnt</code> and evaporator leaving temperature <code>TEvaLvg</code>.
 </li>
 </ul>
 <p>

--- a/Buildings/Fluid/Chillers/ElectricEIR.mo
+++ b/Buildings/Fluid/Chillers/ElectricEIR.mo
@@ -142,18 +142,25 @@ the EnergyPlus chiller model <code>Chiller:Electric:EIR</code>.
 </p>
 <ul>
 <li>
-A biquadratic function is used to predict cooling capacity as a function of
-condenser entering and evaporator leaving fluid temperature.
+A biquadratic function <code>capFunT</code> is used to predict
+cooling capacity as a function of condenser entering and evaporator leaving
+fluid temperature.
 </li>
 <li>
-A quadratic function is used to predict power input to cooling capacity ratio with respect to the part load ratio.
+A quadratic function <code>EIRFunPLR</code> is used to predict
+power input to cooling capacity ratio with respect to the part load ratio.
 </li>
 <li>
-A biquadratic function is used to predict power input to cooling capacity ratio as a function of
+A biquadratic function <code>EIRFunT</code> is used to predict
+power input to cooling capacity ratio as a function of
 condenser entering and evaporator leaving fluid temperature.
 </li>
 </ul>
 <p>
+These functions take the same form as documented in
+<a href=\"https://energyplus.net/assets/nrel_custom/pdfs/pdfs_v22.1.0/EngineeringReference.pdf\">
+EnergyPlus v22.1.0 Engineering Reference</a>
+section 14.3.9.2 (equations 14.231 through 14.233).
 These curves are stored in the data record <code>per</code> and are available from
 <a href=\"modelica://Buildings.Fluid.Chillers.Data.ElectricEIR\">
 Buildings.Fluid.Chillers.Data.ElectricEIR</a>.
@@ -229,6 +236,10 @@ for an example with a chiller operating in heating mode.
 <li>
 Hydeman, M. and K.L. Gillespie. 2002. Tools and Techniques to Calibrate Electric Chiller
 Component Models. <i>ASHRAE Transactions</i>, AC-02-9-1.
+</li>
+<li>
+<a href=\"https://energyplus.net/assets/nrel_custom/pdfs/pdfs_v22.1.0/EngineeringReference.pdf\">
+EnergyPlus v22.1.0 Engineering Reference</a>
 </li>
 </ul>
 </html>",

--- a/Buildings/Fluid/Chillers/ElectricReformulatedEIR.mo
+++ b/Buildings/Fluid/Chillers/ElectricReformulatedEIR.mo
@@ -129,28 +129,48 @@ and it uses a bicubic polynomial to compute the part load performance.
 
 <p>
 This model uses three functions to predict capacity and power consumption:</p>
-<ul>
-<li>
-A biquadratic function <code>capFunT</code> is used to predict
-cooling capacity as a function of condenser leaving temperature
-<code>TConLvg</code> and evaporator leaving temperature <code>TEvaLvg</code>.
-</li>
-<li>
-A bicubic function <code>EIRFunPLR</code> is used to predict
-power input to cooling capacity ratio as a function of
-condenser leaving temperature <code>TConLvg</code> and part load ratio.
-</li>
-<li>
-A biquadratic function <code>EIRFunT</code> is used to predict power input to
-cooling capacity ratio as a function of condenser leaving temperature
-<code>TConLvg</code> and evaporator leaving temperature <code>TEvaLvg</code>.
-</li>
-</ul>
+<table summary=\"summary\" border=\"1\" cellspacing=\"0\" cellpadding=\"2\" style=\"border-collapse:collapse;\">
+<thead>
+  <tr>
+    <th rowspan=\"2\">Function</th>
+    <th rowspan=\"2\">Description</th>
+    <th colspan=\"2\">Formulation</th>
+  </tr>
+  <tr>
+  <th><code><a href=\"Modelica://Buildings.Fluid.Chillers.ElectricEIR\">ElectricEIR</a></code> (this model)</th>
+  <th><code><a href=\"Modelica://Buildings.Fluid.Chillers.ElectricReformulatedEIR\">ElectricReformulatedEIR</a></code> (this model)</th>
+  </tr>
+</thead>
+<tbody>
+  <tr>
+    <td><code>capFunT</code></td>
+    <td>Adjusts cooling capacity for current fluid temperatures</td>
+    <td>Biquadratic on <code>TConEnt</code> and <code>TEvaLvg</code></td>
+    <td>Biquadratic on <code>TConLvg</code> and <code>TEvaLvg</code></td>
+  </tr>
+  <tr>
+    <td><code>EIRFunPLR</code></td>
+    <td>Adjusts EIR for the current PLR</td>
+    <td>Quadratic on PLR</td>
+    <td>Bicubic on <code>TConLvg</code> and PLR</td>
+  </tr>
+  <tr>
+    <td><code>EIRFunT</code></td>
+    <td>Adjusts EIR for current fluid temperatures</td>
+    <td>Biquadratic on <code>TConEnt</code> and <code>TEvaLvg</code></td>
+    <td>Biquadratic on <code>TConLvg</code> and <code>TEvaLvg</code></td>
+  </tr>
+</tbody>
+</table>
 
 <p>
 These curves are stored in the data record <code>per</code> and are available from
 <a href=\"modelica://Buildings.Fluid.Chillers.Data.ElectricReformulatedEIR\">
 Buildings.Fluid.Chillers.Data.ElectricReformulatedEIR</a>.
+How they are used to compute the adjusted capacity and compressor power
+can be found in the documentation of
+<a href=\"modelica://Buildings.Fluid.Chillers.BaseClasses.PartialElectric\">
+Buildings.Fluid.Chillers.BaseClasses.PartialElectric</a>.
 Additional performance curves can be developed using
 two available techniques (Hydeman and Gillespie, 2002). The first technique is called the
 Least-squares Linear Regression method and is used when sufficient performance data exist

--- a/Buildings/Fluid/Chillers/ElectricReformulatedEIR.mo
+++ b/Buildings/Fluid/Chillers/ElectricReformulatedEIR.mo
@@ -132,18 +132,18 @@ This model uses three functions to predict capacity and power consumption:</p>
 <ul>
 <li>
 A biquadratic function <code>capFunT</code> is used to predict
-cooling capacity as a function of condenser leaving and evaporator leaving
-fluid temperature.
+cooling capacity as a function of condenser leaving temperature
+<code>TConLvg</code> and evaporator leaving temperature <code>TEvaLvg</code>.
 </li>
 <li>
 A bicubic function <code>EIRFunPLR</code> is used to predict
 power input to cooling capacity ratio as a function of
-condenser leaving temperature and part load ratio.
+condenser leaving temperature <code>TConLvg</code> and part load ratio.
 </li>
 <li>
-A biquadratic function <code>EIRFunT</code> is used to predict
-power input to cooling capacity ratio as a function of
-condenser leaving and evaporator leaving fluid temperature.
+A biquadratic function <code>EIRFunT</code> is used to predict power input to
+cooling capacity ratio as a function of condenser leaving temperature
+<code>TConLvg</code> and evaporator leaving temperature <code>TEvaLvg</code>.
 </li>
 </ul>
 

--- a/Buildings/Fluid/Chillers/ElectricReformulatedEIR.mo
+++ b/Buildings/Fluid/Chillers/ElectricReformulatedEIR.mo
@@ -131,15 +131,18 @@ and it uses a bicubic polynomial to compute the part load performance.
 This model uses three functions to predict capacity and power consumption:</p>
 <ul>
 <li>
-A biquadratic function is used to predict cooling capacity as a function of
-condenser leaving and evaporator leaving fluid temperature.
+A biquadratic function <code>capFunT</code> is used to predict
+cooling capacity as a function of condenser leaving and evaporator leaving
+fluid temperature.
 </li>
 <li>
-A bicubic function is used to predict power input to cooling capacity ratio
-as a function of condenser leaving temperature and part load ratio.
+A bicubic function <code>EIRFunPLR</code> is used to predict
+power input to cooling capacity ratio as a function of
+condenser leaving temperature and part load ratio.
 </li>
 <li>
-A biquadratic function is used to predict power input to cooling capacity ratio as a function of
+A biquadratic function <code>EIRFunT</code> is used to predict
+power input to cooling capacity ratio as a function of
 condenser leaving and evaporator leaving fluid temperature.
 </li>
 </ul>


### PR DESCRIPTION
This PR provides sources (i.e. [EnergyPlus Engineering Reference](https://energyplus.net/assets/nrel_custom/pdfs/pdfs_v22.1.0/EngineeringReference.pdf)) and details in the documentation for electric chillers.
This closes #3425.