### PR TITLE
Corrected annotation in HeatTransfer data (maint 9.1.x)

### DIFF
--- a/Buildings/HeatTransfer/Data/BaseClasses.mo
+++ b/Buildings/HeatTransfer/Data/BaseClasses.mo
@@ -6,7 +6,7 @@ package BaseClasses "Base classes for package Data"
     parameter Modelica.Units.SI.Length x "Material thickness";
     parameter Modelica.Units.SI.ThermalConductivity k "Thermal conductivity";
     parameter Modelica.Units.SI.SpecificHeatCapacity c "Specific heat capacity";
-    parameter Modelica.Units.SI.Density d "Mass density";
+    parameter Modelica.Units.SI.Density d(displayUnit="kg/m3") "Mass density";
     parameter Real R(unit="m2.K/W")
       "Thermal resistance of a unit area of material";
     parameter Integer nStaRef(min=0) = 3
@@ -48,8 +48,9 @@ package BaseClasses "Base classes for package Data"
     defaultComponentPrefixes="parameter",
     defaultComponentName="datMat",
     Documentation(info="<html>
+<p>
 Base record for materials that declares the thermal properties.
-<br/>
+</p>
 <p>
 The specific heat capacity can be zero, in which case the material
 will be modeled as a thermal resistor that does not store energy.
@@ -100,19 +101,19 @@ First implementation.
 </ul>
 </html>"),   Icon(graphics={
           Text(
-            extent={{-94,44},{-16,12}},
+            extent={{-98,44},{-2,12}},
             textColor={0,0,0},
             textString="x=%x"),
           Text(
-            extent={{8,40},{86,8}},
+            extent={{2,40},{96,8}},
             textColor={0,0,0},
             textString="k=%k"),
           Text(
-            extent={{-90,-58},{-12,-90}},
+            extent={{-98,-58},{-4,-90}},
             textColor={0,0,0},
             textString="R=%R"),
           Text(
-            extent={{-92,-10},{-14,-42}},
+            extent={{-98,-10},{-4,-42}},
             textColor={0,0,0},
             textString="U=%U"),
           Rectangle(
@@ -123,13 +124,13 @@ First implementation.
             fillPattern=FillPattern.Solid),
           Line(points={{-100,-50},{100,-50}}, color={0,0,0}),
           Text(
-            visible=not (c > 0),
-            extent={{8,-8},{86,-40}},
+            visible=not (c > 1E-10),
+            extent={{4,-8},{98,-40}},
             lineColor={0,0,0},
             textString="d=%d"),
           Text(
-            visible=not (c > 0),
-            extent={{10,-56},{88,-88}},
+            visible=not (c > 1E-10),
+            extent={{4,-56},{98,-88}},
             lineColor={0,0,0},
             textString="c=%c")}));
   end Material;
@@ -138,7 +139,7 @@ First implementation.
     extends Modelica.Icons.Record;
     parameter Modelica.Units.SI.ThermalConductivity k "Thermal conductivity";
     parameter Modelica.Units.SI.SpecificHeatCapacity c "Specific heat capacity";
-    parameter Modelica.Units.SI.Density d "Mass density";
+    parameter Modelica.Units.SI.Density d(displayUnit="kg/m3") "Mass density";
     parameter Boolean steadyState= (c < Modelica.Constants.eps or d < Modelica.Constants.eps)
       "Flag, if true, then material is computed using steady-state heat conduction"
       annotation(Evaluate=true);
@@ -146,8 +147,9 @@ First implementation.
    defaultComponentPrefixes="parameter",
    defaultComponentName="datThePro",
     Documentation(info="<html>
+<p>
 Base record for materials, used in circular geometry or other configurations, that only declares the thermal properties.
-<br/>
+</p>
 <p>
 The specific heat capacity can be zero, in which case the material
 will be modeled as a thermal resistor that does not store energy.
@@ -156,13 +158,15 @@ will be modeled as a thermal resistor that does not store energy.
   revisions="<html>
 <ul>
 <li>
+June 25, 2023, by Michael Wetter:<br/>
+Removed test for equality in annotation. This is needed for OMEdit
+as equality on <code>Real</code> variables are only allowed in functions.
+</li>
+<li>
 March 1, 2016, by Michael Wetter:<br/>
 Removed test for equality of <code>Real</code> variables.
 This is for
 <a href=\"https://github.com/lbl-srg/modelica-buildings/issues/493\">issue 493</a>.
-</li>
-<li>
-April 2011, by Pierre Vigouroux:<br/>
 </li>
 <li>
 April 12 2011, by Pierre Vigouroux:<br/>
@@ -172,17 +176,17 @@ First implementation.
 </html>"),   Icon(graphics={
           Line(points={{-100,-50},{100,-50}}, color={0,0,0}),
           Text(
-            visible=not (c == 0),
-            extent={{-80,36},{-10,12}},
+            visible=d > 1E-10,
+            extent={{-98,-62},{-2,-86}},
             lineColor={0,0,0},
             textString="d=%d"),
           Text(
-            visible=not (c == 0),
-            extent={{-80,-58},{-6,-88}},
+            visible=c > 1E-10,
+            extent={{-98,-8},{-2,-38}},
             lineColor={0,0,0},
             textString="c=%c"),
           Text(
-            extent={{-74,-12},{-14,-36}},
+            extent={{-98,38},{-2,14}},
             textColor={0,0,0},
             textString="k=%k"),
           Line(points={{-100,0},{100,0}},     color={0,0,0})}));

--- a/Buildings/HeatTransfer/Data/BaseClasses.mo
+++ b/Buildings/HeatTransfer/Data/BaseClasses.mo
@@ -126,12 +126,12 @@ First implementation.
           Text(
             visible=not (c > 1E-10),
             extent={{4,-8},{98,-40}},
-            lineColor={0,0,0},
+            textColor={0,0,0},
             textString="d=%d"),
           Text(
             visible=not (c > 1E-10),
             extent={{4,-56},{98,-88}},
-            lineColor={0,0,0},
+            textColor={0,0,0},
             textString="c=%c")}));
   end Material;
 
@@ -178,12 +178,12 @@ First implementation.
           Text(
             visible=d > 1E-10,
             extent={{-98,-62},{-2,-86}},
-            lineColor={0,0,0},
+            textColor={0,0,0},
             textString="d=%d"),
           Text(
             visible=c > 1E-10,
             extent={{-98,-8},{-2,-38}},
-            lineColor={0,0,0},
+            textColor={0,0,0},
             textString="c=%c"),
           Text(
             extent={{-98,38},{-2,14}},


### PR DESCRIPTION
This avoids a test for equality in the icon, which is not compliant with the Modelica Language Standard. It also improves the icon layout and sets the displayUnit for density.

This fix avoids a warning in OMEdit.