### PR TITLE
Add Buildings.Templates to OpenModelica tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -98,6 +98,7 @@ env:
     - TEST_ARG="make test-openmodelica PACKAGE=\"Buildings.Utilities\""
     - TEST_ARG="make test-optimica  PACKAGE=\"Buildings.Utilities\""
     - TEST_ARG="make test-dymola    PACKAGE=\"Buildings.Templates\""
+    - TEST_ARG="make test-openmodelica  PACKAGE=\"Buildings.Templates\""
     - TEST_ARG="make test-optimica  PACKAGE=\"Buildings.Templates\""
 
 before_install:

--- a/Buildings/Resources/Scripts/BuildingsPy/conf.yml
+++ b/Buildings/Resources/Scripts/BuildingsPy/conf.yml
@@ -138,7 +138,7 @@
     simulate: false
 - model_name: Buildings.Experimental.DHC.Plants.Steam.Examples.SingleBoiler
   optimica:
-    comment: 'Fails initialization, works if Buildings.Experimental.DHC.Plants.Steam.SingleBoiler.allowFlowReversal=true, but then OpenModelica fails'
+    comment: Fails initialization, works if Buildings.Experimental.DHC.Plants.Steam.SingleBoiler.allowFlowReversal=true, but then OpenModelica fails
     simulate: false
 - model_name: Buildings.Fluid.Examples.FlowSystem.Basic
   openmodelica:
@@ -270,17 +270,63 @@
   optimica:
     comment: See https://github.com/lbl-srg/modelica-buildings/issues/2235
     translate: false
+- model_name: Buildings.Templates.AirHandlersFans.Validation.VAVMZBase
+  openmodelica:
+    comment: Translation failed.
+    translate: false
+- model_name: Buildings.Templates.AirHandlersFans.Validation.VAVMZCoilElectricHeating
+  openmodelica:
+    comment: Translation failed.
+    translate: false
+- model_name: Buildings.Templates.AirHandlersFans.Validation.VAVMZCoilEvaporatorMultiStage
+  openmodelica:
+    comment: Translation failed.
+    translate: false
+- model_name: Buildings.Templates.AirHandlersFans.Validation.VAVMZCoilWaterHeating3WVReheat
+  openmodelica:
+    comment: Time out after 300 s.
+    translate: false
 - model_name: Buildings.Templates.AirHandlersFans.Validation.VAVMZControlG36Airflow
   optimica:
-    comment: >
-      Array size mismatch in modification of the attribute quantity for the variable TZon.
-      This is a bug in OCT tracked under Modelon#2023022839000276.
+    comment: 'Array size mismatch in modification of the attribute quantity for the variable TZon. This is a bug in OCT tracked under Modelon#2023022839000276.'
+    translate: false
+  openmodelica:
+    comment: Translation failed.
     translate: false
 - model_name: Buildings.Templates.AirHandlersFans.Validation.VAVMZControlG36Pressure
   optimica:
-    comment: >
-      Array size mismatch in modification of the attribute quantity for the variable TZon.
-      This is a bug in OCT tracked under Modelon#2023022839000276.
+    comment: 'Array size mismatch in modification of the attribute quantity for the variable TZon. This is a bug in OCT tracked under Modelon#2023022839000276.'
+    translate: false
+  openmodelica:
+    comment: Translation failed.
+    translate: false
+- model_name: Buildings.Templates.AirHandlersFans.Validation.VAVMZDedicatedDampersPressure
+  openmodelica:
+    comment: Time out after 300 s.
+    translate: false
+- model_name: Buildings.Templates.AirHandlersFans.Validation.VAVMZFanRelief
+  openmodelica:
+    comment: Time out after 300 s.
+    translate: false
+- model_name: Buildings.Templates.AirHandlersFans.Validation.VAVMZFanSupplyBlowThrough
+  openmodelica:
+    comment: Translation failed.
+    translate: false
+- model_name: Buildings.Templates.Components.Validation.Fans
+  openmodelica:
+    comment: Translation failed.
+    translate: false
+- model_name: Buildings.Templates.ZoneEquipment.Validation.VAVBoxCoolingOnly
+  openmodelica:
+    comment: Time out after 300 s.
+    translate: false
+- model_name: Buildings.Templates.ZoneEquipment.Validation.VAVBoxCoolingOnlyControlG36
+  openmodelica:
+    comment: Translation failed.
+    translate: false
+- model_name: Buildings.Templates.ZoneEquipment.Validation.VAVBoxReheatControlG36
+  openmodelica:
+    comment: Time out after 300 s.
     translate: false
 - model_name: Buildings.ThermalZones.Detailed.Examples.FFD.ForcedConvection
   optimica:

--- a/Buildings/Resources/Scripts/BuildingsPy/conf.yml
+++ b/Buildings/Resources/Scripts/BuildingsPy/conf.yml
@@ -282,6 +282,10 @@
   openmodelica:
     comment: Translation failed.
     translate: false
+- model_name: Buildings.Templates.AirHandlersFans.Validation.VAVMZCoilEvaporatorVariable
+  openmodelica:
+    comment: Translation failed.
+    translate: false
 - model_name: Buildings.Templates.AirHandlersFans.Validation.VAVMZCoilWaterHeating3WVReheat
   openmodelica:
     comment: Time out after 300 s.


### PR DESCRIPTION
This adds the directory to the tests, and excludes models that don't translate with OpenModelica