### PR TITLE
Corrected wrong use of getInstanceName

### DIFF
--- a/Buildings/Fluid/Geothermal/Borefields/BaseClasses/Boreholes/BaseClasses/Functions/Validation/InternalResistancesOneUTube.mo
+++ b/Buildings/Fluid/Geothermal/Borefields/BaseClasses/Boreholes/BaseClasses/Functions/Validation/InternalResistancesOneUTube.mo
@@ -57,7 +57,8 @@ initial equation
       kMed=kMed,
       muMed=muMed,
       cpMed=cpMed,
-      m_flow_nominal=m_flow_nominal);
+      m_flow_nominal=m_flow_nominal,
+      instanceName=getInstanceName());
 
   annotation (
     __Dymola_Commands(file=
@@ -74,6 +75,13 @@ borehole.
 </p>
 </html>", revisions="<html>
 <ul>
+<li>
+November 22, 2023, by Michael Wetter:<br/>
+Corrected use of <code>getInstanceName()</code> which was called inside a function which
+is not allowed.<br/>
+This is for
+<a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1814\">IBPSA, #1814</a>.
+</li>
 <li>
 June 21, 2018, by Massimo Cimmino:<br/>
 First implementation.

--- a/Buildings/Fluid/Geothermal/Borefields/BaseClasses/Boreholes/BaseClasses/Functions/Validation/InternalResistancesOneUTubeNegative.mo
+++ b/Buildings/Fluid/Geothermal/Borefields/BaseClasses/Boreholes/BaseClasses/Functions/Validation/InternalResistancesOneUTubeNegative.mo
@@ -56,7 +56,8 @@ initial equation
       kMed=kMed,
       muMed=muMed,
       cpMed=cpMed,
-      m_flow_nominal=m_flow_nominal);
+      m_flow_nominal=m_flow_nominal,
+      instanceName=getInstanceName());
 
   annotation (
     __Dymola_Commands(file=
@@ -78,6 +79,13 @@ capacity location <code>x</code> is then automatically set to zero.
 </p>
 </html>", revisions="<html>
 <ul>
+<li>
+November 22, 2023, by Michael Wetter:<br/>
+Corrected use of <code>getInstanceName()</code> which was called inside a function which
+is not allowed.<br/>
+This is for
+<a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1814\">IBPSA, #1814</a>.
+</li>
 <li>
 June 21, 2018, by Massimo Cimmino:<br/>
 First implementation.

--- a/Buildings/Fluid/Geothermal/Borefields/BaseClasses/Boreholes/BaseClasses/Functions/Validation/InternalResistancesTwoUTube.mo
+++ b/Buildings/Fluid/Geothermal/Borefields/BaseClasses/Boreholes/BaseClasses/Functions/Validation/InternalResistancesTwoUTube.mo
@@ -58,7 +58,8 @@ initial equation
       kMed=kMed,
       muMed=muMed,
       cpMed=cpMed,
-      m_flow_nominal=m_flow_nominal);
+      m_flow_nominal=m_flow_nominal,
+      instanceName=getInstanceName());
 
   annotation (
     __Dymola_Commands(file=
@@ -75,6 +76,13 @@ borehole.
 </p>
 </html>", revisions="<html>
 <ul>
+<li>
+November 22, 2023, by Michael Wetter:<br/>
+Corrected use of <code>getInstanceName()</code> which was called inside a function which
+is not allowed.<br/>
+This is for
+<a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1814\">IBPSA, #1814</a>.
+</li>
 <li>
 June 21, 2018, by Massimo Cimmino:<br/>
 First implementation.

--- a/Buildings/Fluid/Geothermal/Borefields/BaseClasses/Boreholes/BaseClasses/Functions/Validation/InternalResistancesTwoUTubeNegative.mo
+++ b/Buildings/Fluid/Geothermal/Borefields/BaseClasses/Boreholes/BaseClasses/Functions/Validation/InternalResistancesTwoUTubeNegative.mo
@@ -58,7 +58,8 @@ initial equation
       kMed=kMed,
       muMed=muMed,
       cpMed=cpMed,
-      m_flow_nominal=m_flow_nominal);
+      m_flow_nominal=m_flow_nominal,
+      instanceName=getInstanceName());
 
   annotation (
     __Dymola_Commands(file=
@@ -80,6 +81,13 @@ capacity location <code>x</code> is then automatically set to zero.
 </p>
 </html>", revisions="<html>
 <ul>
+<li>
+November 22, 2023, by Michael Wetter:<br/>
+Corrected use of <code>getInstanceName()</code> which was called inside a function which
+is not allowed.<br/>
+This is for
+<a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1814\">IBPSA, #1814</a>.
+</li>
 <li>
 June 21, 2018, by Massimo Cimmino:<br/>
 First implementation.

--- a/Buildings/Fluid/Geothermal/Borefields/BaseClasses/Boreholes/BaseClasses/Functions/internalResistancesOneUTube.mo
+++ b/Buildings/Fluid/Geothermal/Borefields/BaseClasses/Boreholes/BaseClasses/Functions/internalResistancesOneUTube.mo
@@ -81,7 +81,7 @@ algorithm
       i := i + 1;
     end while;
   end if;
-  assert(test, "In " + getInstanceName() + ":\n" +
+  assert(test, "In " + instanceName + ":\n" +
   "Maximum number of iterations exceeded. Check the borehole geometry.
   The tubes may be too close to the borehole wall.
   Input to the function
@@ -120,6 +120,13 @@ HVAC&amp;R Research,
 International Journal of Energy Research, 35:312&ndash;320, 2011.</p>
 </html>", revisions="<html>
 <ul>
+<li>
+November 22, 2023, by Michael Wetter:<br/>
+Corrected use of <code>getInstanceName()</code> which was called inside a function which
+is not allowed.<br/>
+This is for
+<a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1814\">IBPSA, #1814</a>.
+</li>
 <li>
 February 7, 2022, by Michael Wetter:<br/>
 Changed function to be <code>pure</code>.<br/>

--- a/Buildings/Fluid/Geothermal/Borefields/BaseClasses/Boreholes/BaseClasses/Functions/internalResistancesTwoUTube.mo
+++ b/Buildings/Fluid/Geothermal/Borefields/BaseClasses/Boreholes/BaseClasses/Functions/internalResistancesTwoUTube.mo
@@ -88,7 +88,7 @@ algorithm
       i := i + 1;
     end while;
   end if;
-  assert(test, "In " + getInstanceName() + ":\n" +
+  assert(test, "In " + instanceName + ":\n" +
   "Maximum number of iterations exceeded. Check the borehole geometry.
   The tubes may be too close to the borehole wall.
   Input to the function
@@ -128,6 +128,13 @@ HVAC&amp;R Research,
 International Journal of Energy Research, 35:312&ndash;320, 2011.</p>
 </html>", revisions="<html>
 <ul>
+<li>
+November 22, 2023, by Michael Wetter:<br/>
+Corrected use of <code>getInstanceName()</code> which was called inside a function which
+is not allowed.<br/>
+This is for
+<a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1814\">IBPSA, #1814</a>.
+</li>
 <li>
 February 7, 2022, by Michael Wetter:<br/>
 Changed function to be <code>pure</code>.<br/>

--- a/Buildings/Fluid/Geothermal/Borefields/BaseClasses/Boreholes/BaseClasses/Functions/partialInternalResistances.mo
+++ b/Buildings/Fluid/Geothermal/Borefields/BaseClasses/Boreholes/BaseClasses/Functions/partialInternalResistances.mo
@@ -29,6 +29,8 @@ partial function partialInternalResistances
   input Modelica.Units.SI.SpecificHeatCapacity cpMed
     "Specific heat capacity of the fluid";
   input Modelica.Units.SI.MassFlowRate m_flow_nominal "Nominal mass flow rate";
+  input String instanceName "undeclared caller"
+    "Instance name of the model or block that calls this function";
 
   // Outputs
   output Real x "Capacity location";
@@ -70,6 +72,13 @@ the borehole internal resistances.
 </p>
 </html>", revisions="<html>
 <ul>
+<li>
+November 22, 2023, by Michael Wetter:<br/>
+Corrected use of <code>getInstanceName()</code> which was called inside a function which
+is not allowed.<br/>
+This is for
+<a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1814\">IBPSA, #1814</a>.
+</li>
 <li>
 June 4, 2023, by Michael Wetter:<br/>
 Corrected variability.<br/>

--- a/Buildings/Fluid/Geothermal/Borefields/BaseClasses/Boreholes/BaseClasses/Functions/partialInternalResistances.mo
+++ b/Buildings/Fluid/Geothermal/Borefields/BaseClasses/Boreholes/BaseClasses/Functions/partialInternalResistances.mo
@@ -29,7 +29,7 @@ partial function partialInternalResistances
   input Modelica.Units.SI.SpecificHeatCapacity cpMed
     "Specific heat capacity of the fluid";
   input Modelica.Units.SI.MassFlowRate m_flow_nominal "Nominal mass flow rate";
-  input String instanceName "undeclared caller"
+  input String instanceName="undeclared caller"
     "Instance name of the model or block that calls this function";
 
   // Outputs

--- a/Buildings/Fluid/Geothermal/Borefields/BaseClasses/Boreholes/BaseClasses/InternalHEXOneUTube.mo
+++ b/Buildings/Fluid/Geothermal/Borefields/BaseClasses/Boreholes/BaseClasses/InternalHEXOneUTube.mo
@@ -92,7 +92,8 @@ initial equation
       kMed=kMed,
       muMed=muMed,
       cpMed=cpMed,
-      m_flow_nominal=m1_flow_nominal);
+      m_flow_nominal=m1_flow_nominal,
+      instanceName=getInstanceName());
 
 equation
     assert(borFieDat.conDat.borCon == Buildings.Fluid.Geothermal.Borefields.Types.BoreholeConfiguration.SingleUTube,
@@ -158,6 +159,13 @@ International Journal Of Energy Research, 35:312-320, 2011.
 </p>
 </html>", revisions="<html>
 <ul>
+<li>
+November 22, 2023, by Michael Wetter:<br/>
+Corrected use of <code>getInstanceName()</code> which was called inside a function which
+is not allowed.<br/>
+This is for
+<a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1814\">IBPSA, #1814</a>.
+</li>
 <li>
 March 7, 2022, by Michael Wetter:<br/>
 Removed <code>massDynamics</code>.<br/>

--- a/Buildings/Fluid/Geothermal/Borefields/BaseClasses/Boreholes/BaseClasses/InternalHEXTwoUTube.mo
+++ b/Buildings/Fluid/Geothermal/Borefields/BaseClasses/Boreholes/BaseClasses/InternalHEXTwoUTube.mo
@@ -153,7 +153,8 @@ initial equation
       kMed=kMed,
       muMed=muMed,
       cpMed=cpMed,
-      m_flow_nominal=m1_flow_nominal);
+      m_flow_nominal=m1_flow_nominal,
+      instanceName=getInstanceName());
 
 equation
   assert(borFieDat.conDat.borCon == Buildings.Fluid.Geothermal.Borefields.Types.BoreholeConfiguration.DoubleUTubeParallel
@@ -252,6 +253,13 @@ International Journal Of Energy Research, 35:312-320, 2011.
 </p>
 </html>", revisions="<html>
 <ul>
+<li>
+November 22, 2023, by Michael Wetter:<br/>
+Corrected use of <code>getInstanceName()</code> which was called inside a function which
+is not allowed.<br/>
+This is for
+<a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1814\">IBPSA, #1814</a>.
+</li>
 <li>
 March 7, 2022, by Michael Wetter:<br/>
 Removed <code>massDynamics</code>.<br/>


### PR DESCRIPTION
This integrates IBPSA, issue 1814. The use of this function is not allowed inside other functions, and causes OpenModelica to fail during translation