### PR TITLE
Update documentation about Spawn's warmup procedure

### DIFF
--- a/Buildings/ThermalZones/EnergyPlus_9_6_0/UsersGuide.mo
+++ b/Buildings/ThermalZones/EnergyPlus_9_6_0/UsersGuide.mo
@@ -480,7 +480,7 @@ The first day of the simulation is repeated, but Spawn uses a different criteria
 the iteration compared to a conventional EnergyPlus simulation. In EnergyPlus, the first day is repeated
 until the zone air temperature reaches a periodic steady state as indicated by the minimum and maximum temperatures
 for the warmup day stablizing. In Spawn, the exit criteria is similarly based on reaching a periodic steady state,
-however Spawn exits warmup when the wall temperatures stablize instead of the air temperature.
+however Spawn exits warmup when the surface temperatures stabilize instead of the air temperature.
 </p>
 </li>
 </ol>

--- a/Buildings/ThermalZones/EnergyPlus_9_6_0/UsersGuide.mo
+++ b/Buildings/ThermalZones/EnergyPlus_9_6_0/UsersGuide.mo
@@ -476,21 +476,14 @@ in the same way as a conventional EnergyPlus simulation.
 </li>
 <li>
 <p>
-The first day of the simulation is repeated until the minimum and maximum air temperatures
-during the warmup day remain nearly the same between two successive iterations.
+The first day of the simulation is repeated, but Spawn uses a different criteria for stopping
+the iteration compared to a conventional EnergyPlus simulation. In EnergyPlus, the first day is repeated
+until the zone air temperature reaches a periodic steady state as indicated by the minimum and maximum temperatures
+for the warmup day stablizing. In Spawn, the exit criteria is similarly based on reaching a periodic steady state,
+however Spawn exits warmup when the wall temperatures stablize instead of the air temperature.
 </p>
 </li>
 </ol>
-<p>
-The Spawn warmup procedure is still invoked even if there are no unconnected zones defined in the model.
-However, in this case the warmup convergence criteria will be met after only two iterations of the warmup day
-because all zone temperature and humidity values are fixed to the initial values defined in Modelica.
-It is possible for startup transients to still exist after Spawn warmup due thermal mass
-in the wall materials not being fully exposed to the surface boundary conditions
-defined by the outdoor environment and the initial zone air conditions.
-A future enhancement may define a new warmup convergence criteria that takes into account
-the internal wall temperatures.
-</p>
 </html>"));
   end EnergyPlusWarmUp;
 


### PR DESCRIPTION
The documentation was not been updated to reflect an enhancement to Spawn's warmup procedure. Specifically, a change was made to use wall temperatures instead of air temperature to exit warmup iteration.

https://github.com/NREL/Spawn/commit/ef91931157c988478c0ce212a8a0e708ce7e8035

close #3176