### PR TITLE
Corrected typo (maint_10.0.x)

### DIFF
--- a/Buildings/Controls/OBC/ASHRAE/G36/TerminalUnits/CoolingOnly/Subsequences/Alarms.mo
+++ b/Buildings/Controls/OBC/ASHRAE/G36/TerminalUnits/CoolingOnly/Subsequences/Alarms.mo
@@ -479,7 +479,7 @@ This is for
 </li>
 <li>
 August 23, 2023, by Jianjun Hu:<br/>
-Added delay <code>staTim</code> to allow the system becoming stablized.
+Added delay <code>staTim</code> to allow the system becoming stabilized.
 This is for <a href=\"https://github.com/lbl-srg/modelica-buildings/issues/3257\">issue 3257</a>.
 </li>
 <li>

--- a/Buildings/Controls/OBC/ASHRAE/G36/TerminalUnits/DualDuctColdDuctMin/Subsequences/Alarms.mo
+++ b/Buildings/Controls/OBC/ASHRAE/G36/TerminalUnits/DualDuctColdDuctMin/Subsequences/Alarms.mo
@@ -657,7 +657,7 @@ This is for
 </li>
 <li>
 August 23, 2023, by Jianjun Hu:<br/>
-Added delay <code>staTim</code> to allow the system becoming stablized.
+Added delay <code>staTim</code> to allow the system becoming stabilized.
 This is for <a href=\"https://github.com/lbl-srg/modelica-buildings/issues/3257\">issue 3257</a>.
 </li>
 <li>

--- a/Buildings/Controls/OBC/ASHRAE/G36/TerminalUnits/DualDuctMixConDischargeSensor/Subsequences/Alarms.mo
+++ b/Buildings/Controls/OBC/ASHRAE/G36/TerminalUnits/DualDuctMixConDischargeSensor/Subsequences/Alarms.mo
@@ -519,7 +519,7 @@ This is for
 </li>
 <li>
 August 23, 2023, by Jianjun Hu:<br/>
-Added delay <code>staTim</code> to allow the system becoming stablized.
+Added delay <code>staTim</code> to allow the system becoming stabilized.
 This is for <a href=\"https://github.com/lbl-srg/modelica-buildings/issues/3257\">issue 3257</a>.
 </li>
 <li>

--- a/Buildings/Controls/OBC/ASHRAE/G36/TerminalUnits/DualDuctMixConInletSensor/Subsequences/Alarms.mo
+++ b/Buildings/Controls/OBC/ASHRAE/G36/TerminalUnits/DualDuctMixConInletSensor/Subsequences/Alarms.mo
@@ -657,7 +657,7 @@ This is for
 </li>
 <li>
 August 23, 2023, by Jianjun Hu:<br/>
-Added delay <code>staTim</code> to allow the system becoming stablized.
+Added delay <code>staTim</code> to allow the system becoming stabilized.
 This is for <a href=\"https://github.com/lbl-srg/modelica-buildings/issues/3257\">issue 3257</a>.
 </li>
 <li>

--- a/Buildings/Controls/OBC/ASHRAE/G36/TerminalUnits/DualDuctSnapActing/Subsequences/Alarms.mo
+++ b/Buildings/Controls/OBC/ASHRAE/G36/TerminalUnits/DualDuctSnapActing/Subsequences/Alarms.mo
@@ -859,7 +859,7 @@ This is for
 </li>
 <li>
 August 23, 2023, by Jianjun Hu:<br/>
-Added delay <code>staTim</code> to allow the system becoming stablized.
+Added delay <code>staTim</code> to allow the system becoming stabilized.
 This is for <a href=\"https://github.com/lbl-srg/modelica-buildings/issues/3257\">issue 3257</a>.
 </li>
 <li>

--- a/Buildings/Controls/OBC/ASHRAE/G36/TerminalUnits/ParallelFanCVF/Subsequences/Alarms.mo
+++ b/Buildings/Controls/OBC/ASHRAE/G36/TerminalUnits/ParallelFanCVF/Subsequences/Alarms.mo
@@ -950,7 +950,7 @@ This is for
 </li>
 <li>
 August 23, 2023, by Jianjun Hu:<br/>
-Added delay <code>staTim</code> to allow the system becoming stablized.
+Added delay <code>staTim</code> to allow the system becoming stabilized.
 This is for <a href=\"https://github.com/lbl-srg/modelica-buildings/issues/3257\">issue 3257</a>.
 </li>
 <li>

--- a/Buildings/Controls/OBC/ASHRAE/G36/TerminalUnits/ParallelFanVVF/Subsequences/Alarms.mo
+++ b/Buildings/Controls/OBC/ASHRAE/G36/TerminalUnits/ParallelFanVVF/Subsequences/Alarms.mo
@@ -948,7 +948,7 @@ This is for
 </li>
 <li>
 August 23, 2023, by Jianjun Hu:<br/>
-Added delay <code>staTim</code> to allow the system becoming stablized.
+Added delay <code>staTim</code> to allow the system becoming stabilized.
 This is for <a href=\"https://github.com/lbl-srg/modelica-buildings/issues/3257\">issue 3257</a>.
 </li>
 <li>

--- a/Buildings/Controls/OBC/ASHRAE/G36/TerminalUnits/Reheat/Subsequences/Alarms.mo
+++ b/Buildings/Controls/OBC/ASHRAE/G36/TerminalUnits/Reheat/Subsequences/Alarms.mo
@@ -818,7 +818,7 @@ This is for
 </li>
 <li>
 August 23, 2023, by Jianjun Hu:<br/>
-Added delay <code>staTim</code> to allow the system becoming stablized.
+Added delay <code>staTim</code> to allow the system becoming stabilized.
 This is for <a href=\"https://github.com/lbl-srg/modelica-buildings/issues/3257\">issue 3257</a>.
 </li>
 <li>

--- a/Buildings/Controls/OBC/ASHRAE/G36/TerminalUnits/SeriesFanCVF/Subsequences/Alarms.mo
+++ b/Buildings/Controls/OBC/ASHRAE/G36/TerminalUnits/SeriesFanCVF/Subsequences/Alarms.mo
@@ -949,7 +949,7 @@ This is for
 </li>
 <li>
 August 23, 2023, by Jianjun Hu:<br/>
-Added delay <code>staTim</code> to allow the system becoming stablized.
+Added delay <code>staTim</code> to allow the system becoming stabilized.
 This is for <a href=\"https://github.com/lbl-srg/modelica-buildings/issues/3257\">issue 3257</a>.
 </li>
 <li>

--- a/Buildings/Controls/OBC/ASHRAE/G36/TerminalUnits/SeriesFanVVF/Subsequences/Alarms.mo
+++ b/Buildings/Controls/OBC/ASHRAE/G36/TerminalUnits/SeriesFanVVF/Subsequences/Alarms.mo
@@ -948,7 +948,7 @@ This is for
 </li>
 <li>
 August 23, 2023, by Jianjun Hu:<br/>
-Added delay <code>staTim</code> to allow the system becoming stablized.
+Added delay <code>staTim</code> to allow the system becoming stabilized.
 This is for <a href=\"https://github.com/lbl-srg/modelica-buildings/issues/3257\">issue 3257</a>.
 </li>
 <li>

--- a/Buildings/package.mo
+++ b/Buildings/package.mo
@@ -658,7 +658,7 @@ have been <b style=\"color:blue\">improved</b> in a
                        Buildings.Controls.OBC.ASHRAE.G36.TerminalUnits.SeriesFanCVF.Subsequences.Alarms<br/>
                        Buildings.Controls.OBC.ASHRAE.G36.TerminalUnits.SeriesFanVVF.Subsequences.Alarms
     </td>
-    <td valign=\"top\">Added delay triggering alarms after enabling AHU supply fan, to allow the system becoming stablized.<br/>
+    <td valign=\"top\">Added delay triggering alarms after enabling AHU supply fan, to allow the system becoming stabilized.<br/>
                        This is for <a href=\"https://github.com/lbl-srg/modelica-buildings/issues/3257\">issue 3257</a>.
     </td>
 </tr>


### PR DESCRIPTION
This corrects a typo in the documentation.