### PR TITLE
Merged IBPSA, issues 1842, 1847, 1850

### DIFF
--- a/Buildings/Airflow/Multizone/MediumColumn.mo
+++ b/Buildings/Airflow/Multizone/MediumColumn.mo
@@ -143,7 +143,7 @@ equation
           lineColor={0,0,0}),
         Rectangle(
           visible=densitySelection == Buildings.Airflow.Multizone.Types.densitySelection.fromBottom,
-          extent={{-16,0},{16,-82}},
+          extent={{-16,0},{16,-80}},
           fillColor={85,170,255},
           fillPattern=FillPattern.Solid,
           pattern=LinePattern.None,

--- a/Buildings/Airflow/Multizone/MediumColumn.mo
+++ b/Buildings/Airflow/Multizone/MediumColumn.mo
@@ -103,11 +103,13 @@ equation
         Text(
           extent={{24,-78},{106,-100}},
           textColor={0,0,127},
-          textString="Bottom"),
+          textString="Bottom",
+          fontSize=36),
         Text(
           extent={{32,104},{98,70}},
           textColor={0,0,127},
-          textString="Top"),
+          textString="Top",
+          fontSize=36),
         Text(
           extent={{36,26},{88,-10}},
           textColor={0,0,127},
@@ -129,7 +131,7 @@ equation
         Text(
           extent={{-50.5,20.5},{50.5,-20.5}},
           textColor={0,0,127},
-          origin={-72.5,-12.5},
+          origin={-72.5,-0.5},
           rotation=90,
           textString="%name"),
         Rectangle(

--- a/Buildings/Airflow/Multizone/MediumColumnDynamic.mo
+++ b/Buildings/Airflow/Multizone/MediumColumnDynamic.mo
@@ -98,11 +98,13 @@ equation
         Text(
           extent={{24,-78},{106,-100}},
           textColor={0,0,127},
-          textString="Bottom"),
+          textString="Bottom",
+          fontSize=36),
         Text(
           extent={{32,104},{98,70}},
           textColor={0,0,127},
-          textString="Top"),
+          textString="Top",
+          fontSize=36),
         Text(
           extent={{42,26},{94,-10}},
           textColor={0,0,127},
@@ -112,12 +114,12 @@ equation
         Text(
           extent={{-50.5,20.5},{50.5,-20.5}},
           textColor={0,0,127},
-          origin={-72.5,-12.5},
+          origin={-72.5,-0.5},
           rotation=90,
           textString="%name"),
         Rectangle(
           extent={{-16,80},{16,-80}},
-          fillColor={0,66,132},
+          fillColor={85,170,255},
           fillPattern=FillPattern.Solid,
           pattern=LinePattern.None,
           lineColor={0,0,0}),

--- a/Buildings/BoundaryConditions/SolarIrradiation/BaseClasses/SkyClearness.mo
+++ b/Buildings/BoundaryConditions/SolarIrradiation/BaseClasses/SkyClearness.mo
@@ -5,7 +5,7 @@ block SkyClearness "Sky clearness"
   Modelica.Blocks.Interfaces.RealInput zen(
     quantity="Angle",
     unit="rad",
-    displayUnit="degreeC") "Zenith angle of the sun beam"
+    displayUnit="deg") "Zenith angle of the sun beam"
     annotation (Placement(transformation(extent={{-140,-80},{-100,-40}})));
   Modelica.Blocks.Interfaces.RealInput HDifHor(quantity=
         "RadiantEnergyFluenceRate", unit="W/m2")
@@ -65,6 +65,12 @@ is such that the regularization is usually not triggered.
 </p>
 </html>", revisions="<html>
 <ul>
+<li>
+March 4, 2024, by Michael Wetter:<br/>
+Corrected <code>displayUnit</code>.<br/>
+This is for
+<a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1848\">IBPSA, #1848</a>.
+</li>
 <li>
 September 6, 2021, by Ettore Zanetti:<br/>
 Changed <code>lat</code> from being a parameter to an input from weather bus.<br/>

--- a/Buildings/Controls/OBC/CDL/Types/ZeroTime.mo
+++ b/Buildings/Controls/OBC/CDL/Types/ZeroTime.mo
@@ -1,34 +1,50 @@
 within Buildings.Controls.OBC.CDL.Types;
 type ZeroTime = enumeration(
-    UnixTimeStamp
-  "Thu, 01 Jan 1970 00:00:00 local time",
-    UnixTimeStampGMT
-  "Thu, 01 Jan 1970 00:00:00 GMT",
-    Custom
-  "User specified local time",
-    NY2010
-  "New year 2010, 00:00:00 local time",
-    NY2011
-  "New year 2011, 00:00:00 local time",
-    NY2012
-  "New year 2012, 00:00:00 local time",
-    NY2013
-  "New year 2013, 00:00:00 local time",
-    NY2014
-  "New year 2014, 00:00:00 local time",
-    NY2015
-  "New year 2015, 00:00:00 local time",
-    NY2016
-  "New year 2016, 00:00:00 local time",
-    NY2017
-  "New year 2017, 00:00:00 local time",
-    NY2018
-  "New year 2018, 00:00:00 local time",
-    NY2019
-  "New year 2019, 00:00:00 local time",
-    NY2020
-  "New year 2020, 00:00:00 local time")
-  "Enumeration to set the date corresponding to time = 0"
+    UnixTimeStamp "Thu, 01 Jan 1970 00:00:00 local time",
+    UnixTimeStampGMT "Thu, 01 Jan 1970 00:00:00 GMT",
+    Custom "User specified local time",
+    NY2010 "New year 2010, 00:00:00 local time",
+    NY2011 "New year 2011, 00:00:00 local time",
+    NY2012 "New year 2012, 00:00:00 local time",
+    NY2013 "New year 2013, 00:00:00 local time",
+    NY2014 "New year 2014, 00:00:00 local time",
+    NY2015 "New year 2015, 00:00:00 local time",
+    NY2016 "New year 2016, 00:00:00 local time",
+    NY2017 "New year 2017, 00:00:00 local time",
+    NY2018 "New year 2018, 00:00:00 local time",
+    NY2019 "New year 2019, 00:00:00 local time",
+    NY2020 "New year 2020, 00:00:00 local time",
+    NY2021 "New year 2021, 00:00:00 local time",
+    NY2022 "New year 2022, 00:00:00 local time",
+    NY2023 "New year 2023, 00:00:00 local time",
+    NY2024 "New year 2024, 00:00:00 local time",
+    NY2025 "New year 2025, 00:00:00 local time",
+    NY2026 "New year 2026, 00:00:00 local time",
+    NY2027 "New year 2027, 00:00:00 local time",
+    NY2028 "New year 2028, 00:00:00 local time",
+    NY2029 "New year 2029, 00:00:00 local time",
+    NY2030 "New year 2030, 00:00:00 local time",
+    NY2031 "New year 2031, 00:00:00 local time",
+    NY2032 "New year 2032, 00:00:00 local time",
+    NY2033 "New year 2033, 00:00:00 local time",
+    NY2034 "New year 2034, 00:00:00 local time",
+    NY2035 "New year 2035, 00:00:00 local time",
+    NY2036 "New year 2036, 00:00:00 local time",
+    NY2037 "New year 2037, 00:00:00 local time",
+    NY2038 "New year 2038, 00:00:00 local time",
+    NY2039 "New year 2039, 00:00:00 local time",
+    NY2040 "New year 2040, 00:00:00 local time",
+    NY2041 "New year 2041, 00:00:00 local time",
+    NY2042 "New year 2042, 00:00:00 local time",
+    NY2043 "New year 2043, 00:00:00 local time",
+    NY2044 "New year 2044, 00:00:00 local time",
+    NY2045 "New year 2045, 00:00:00 local time",
+    NY2046 "New year 2046, 00:00:00 local time",
+    NY2047 "New year 2047, 00:00:00 local time",
+    NY2048 "New year 2048, 00:00:00 local time",
+    NY2049 "New year 2049, 00:00:00 local time",
+    NY2050 "New year 2050, 00:00:00 local time")
+  "Use this to set the date corresponding to time = 0"
   annotation (Documentation(info="<html>
 <p>
 Type for choosing how to set the reference time in
@@ -43,12 +59,10 @@ January 1, 2016, 0:00:00 local time.
 </html>",revisions="<html>
 <ul>
 <li>
-March 14, 2017, by Michael Wetter:<br/>
-Revised documentation.
-</li>
-<li>
-February 23, 2017, by Milica Grahovac:<br/>
-Initial CDL implementation.
+March 8, 2024, by Jelger Jansen:<br/>
+Extend functionality to year 2050.<br/>
+This is for
+<a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1847\">#1847</a>.
 </li>
 <li>
 September 10, 2016, by Michael Wetter:<br/>

--- a/Buildings/Controls/OBC/CDL/Types/ZeroTime.mo
+++ b/Buildings/Controls/OBC/CDL/Types/ZeroTime.mo
@@ -65,6 +65,14 @@ This is for
 <a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1847\">#1847</a>.
 </li>
 <li>
+March 14, 2017, by Michael Wetter:<br/>
+Revised documentation.
+</li>
+<li>
+February 23, 2017, by Milica Grahovac:<br/>
+Initial CDL implementation.
+</li>
+<li>
 September 10, 2016, by Michael Wetter:<br/>
 Revised implementation and moved to new package
 <a href=\"modelica://Buildings.Utilities.Time.CalendarTime.Types\">

--- a/Buildings/Controls/SetPoints/SupplyReturnTemperatureReset.mo
+++ b/Buildings/Controls/SetPoints/SupplyReturnTemperatureReset.mo
@@ -15,7 +15,7 @@ block SupplyReturnTemperatureReset
 
   parameter Boolean use_TRoo_in = false
     "Get the room temperature set point from the input connector"
-    annotation(Evaluate=true, HideResult=true);
+    annotation(Evaluate=true);
   parameter Modelica.Units.SI.Temperature TRoo=293.15
     "Fixed value of room temperature set point"
     annotation (Dialog(enable=not use_TRoo_in));
@@ -86,8 +86,14 @@ shift the heating curve.
 </html>", revisions="<html>
 <ul>
 <li>
+March 11, 2024, by Michael Wetter:<br/>
+Corrected use of <code>HideResult</code>.<br/>
+This is for
+<a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1850\">#1850</a>.
+</li>
+<li>
 January 03, 2020, by Jianjun Hu:<br/>
-Changed name from <code>HotWaterTemperatureReset</code> to 
+Changed name from <code>HotWaterTemperatureReset</code> to
 <code>SupplyReturnTemperatureReset</code>.<br/>
 This is for
 <a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1273\">#1273</a>.

--- a/Buildings/Fluid/Sources/BaseClasses/Outside.mo
+++ b/Buildings/Fluid/Sources/BaseClasses/Outside.mo
@@ -5,7 +5,7 @@ partial model Outside
 
   parameter Boolean use_C_in = false
     "Get the trace substances from the input connector"
-    annotation(Evaluate=true, HideResult=true);
+    annotation(Evaluate=true);
   parameter Medium.ExtraProperty C[Medium.nC](
     final quantity=Medium.extraPropertiesNames)=fill(0, Medium.nC)
     "Fixed values of trace substances"
@@ -128,6 +128,12 @@ with exception of boundary pressure, do not have an effect.
 </html>",
 revisions="<html>
 <ul>
+<li>
+March 11, 2024, by Michael Wetter:<br/>
+Corrected use of <code>HideResult</code>.<br/>
+This is for
+<a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1850\">#1850</a>.
+</li>
 <li>
 January 09, 2023, by Jianjun Hu:<br/>
 Changed base class to constrain medium to moist air.<br/>

--- a/Buildings/Fluid/Sources/BaseClasses/PartialSource_Xi_C.mo
+++ b/Buildings/Fluid/Sources/BaseClasses/PartialSource_Xi_C.mo
@@ -5,13 +5,13 @@ partial model PartialSource_Xi_C
 
   parameter Boolean use_X_in = false
     "Get the composition (all fractions) from the input connector"
-    annotation(Evaluate=true, HideResult=true, Dialog(tab="Advanced"));
+    annotation(Evaluate=true, Dialog(tab="Advanced"));
   parameter Boolean use_Xi_in = false
     "Get the composition (independent fractions) from the input connector"
-    annotation(Evaluate=true, HideResult=true, Dialog(group="Conditional inputs"));
+    annotation(Evaluate=true, Dialog(group="Conditional inputs"));
   parameter Boolean use_C_in = false
     "Get the trace substances from the input connector"
-    annotation(Evaluate=true, HideResult=true, Dialog(group="Conditional inputs"));
+    annotation(Evaluate=true, Dialog(group="Conditional inputs"));
   parameter Medium.MassFraction X[Medium.nX](
     final quantity=Medium.substanceNames) = Medium.X_default
     "Fixed value of composition"
@@ -119,6 +119,12 @@ Otherwise the parameter value is used.
 </p>
 </html>", revisions="<html>
 <ul>
+<li>
+March 11, 2024, by Michael Wetter:<br/>
+Corrected use of <code>HideResult</code>.<br/>
+This is for
+<a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1850\">#1850</a>.
+</li>
 <li>
 September 19, 2019, by Michael Wetter:<br/>
 Refactored handling of mass fractions which was needed to handle media such as

--- a/Buildings/Fluid/Sources/Boundary_pT.mo
+++ b/Buildings/Fluid/Sources/Boundary_pT.mo
@@ -5,14 +5,14 @@ model Boundary_pT
 
   parameter Boolean use_p_in = false
     "Get the pressure from the input connector"
-    annotation(Evaluate=true, HideResult=true, Dialog(group="Conditional inputs"));
+    annotation(Evaluate=true, Dialog(group="Conditional inputs"));
   parameter Medium.AbsolutePressure p = Medium.p_default
     "Fixed value of pressure"
     annotation (Dialog(enable = not use_p_in, group="Fixed inputs"));
 
   parameter Boolean use_T_in= false
     "Get the temperature from the input connector"
-    annotation(Evaluate=true, HideResult=true,Dialog(group="Conditional inputs"));
+    annotation(Evaluate=true, Dialog(group="Conditional inputs"));
   parameter Medium.Temperature T = Medium.T_default
     "Fixed value of temperature"
     annotation (Dialog(enable = not use_T_in,group="Fixed inputs"));
@@ -129,6 +129,12 @@ with exception of boundary pressure, do not have an effect.
 </html>",
 revisions="<html>
 <ul>
+<li>
+March 11, 2024, by Michael Wetter:<br/>
+Corrected use of <code>HideResult</code>.<br/>
+This is for
+<a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1850\">#1850</a>.
+</li>
 <li>
 February 25, 2020, by Michael Wetter:<br/>
 Changed icon to display its operating state.<br/>

--- a/Buildings/Fluid/Sources/Boundary_ph.mo
+++ b/Buildings/Fluid/Sources/Boundary_ph.mo
@@ -5,14 +5,14 @@ model Boundary_ph
 
   parameter Boolean use_p_in = false
     "Get the pressure from the input connector"
-    annotation(Evaluate=true, HideResult=true, Dialog(group="Conditional inputs"));
+    annotation(Evaluate=true, Dialog(group="Conditional inputs"));
   parameter Medium.AbsolutePressure p = Medium.p_default
     "Fixed value of pressure"
     annotation (Dialog(enable = not use_p_in, group="Fixed inputs"));
 
   parameter Boolean use_h_in= false
     "Get the specific enthalpy from the input connector"
-    annotation(Evaluate=true, HideResult=true, Dialog(group="Conditional inputs"));
+    annotation(Evaluate=true, Dialog(group="Conditional inputs"));
   parameter Medium.SpecificEnthalpy h = Medium.h_default
     "Fixed value of specific enthalpy"
     annotation (Dialog(enable = not use_h_in, group="Fixed inputs"));
@@ -124,6 +124,12 @@ with exception of boundary pressure, do not have an effect.
 </html>",
 revisions="<html>
 <ul>
+<li>
+March 11, 2024, by Michael Wetter:<br/>
+Corrected use of <code>HideResult</code>.<br/>
+This is for
+<a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1850\">#1850</a>.
+</li>
 <li>
 Juni 7, 2019, by Michael Wetter:<br/>
 Added constant boolean expressions to avoid a potential string comparison in an equation section.<br/>

--- a/Buildings/Fluid/Sources/MassFlowSource_T.mo
+++ b/Buildings/Fluid/Sources/MassFlowSource_T.mo
@@ -5,13 +5,13 @@ model MassFlowSource_T
 
   parameter Boolean use_m_flow_in = false
     "Get the mass flow rate from the input connector"
-    annotation(Evaluate=true, HideResult=true, Dialog(group="Conditional inputs"));
+    annotation(Evaluate=true, Dialog(group="Conditional inputs"));
   parameter Modelica.Units.SI.MassFlowRate m_flow=0
     "Fixed mass flow rate going out of the fluid port"
     annotation (Dialog(enable=not use_m_flow_in, group="Fixed inputs"));
   parameter Boolean use_T_in= false
     "Get the temperature from the input connector"
-    annotation(Evaluate=true, HideResult=true,Dialog(group="Conditional inputs"));
+    annotation(Evaluate=true, Dialog(group="Conditional inputs"));
   parameter Medium.Temperature T = Medium.T_default
     "Fixed value of temperature"
     annotation (Dialog(enable = not use_T_in,group="Fixed inputs"));
@@ -104,6 +104,12 @@ with exception of boundary flow rate, do not have an effect.
 </html>",
 revisions="<html>
 <ul>
+<li>
+March 11, 2024, by Michael Wetter:<br/>
+Corrected use of <code>HideResult</code>.<br/>
+This is for
+<a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1850\">#1850</a>.
+</li>
 <li>
 January 25, 2019, by Michael Wetter:<br/>
 Refactored use of base classes.<br/>

--- a/Buildings/Fluid/Sources/MassFlowSource_WeatherData.mo
+++ b/Buildings/Fluid/Sources/MassFlowSource_WeatherData.mo
@@ -5,10 +5,10 @@ model MassFlowSource_WeatherData
   extends Buildings.Fluid.Sources.BaseClasses.PartialAirSource(final verifyInputs=true);
   parameter Boolean use_m_flow_in = false
     "Get the mass flow rate from the input connector"
-    annotation(Evaluate=true, HideResult=true);
+    annotation(Evaluate=true);
   parameter Boolean use_C_in = false
     "Get the trace substances from the input connector"
-    annotation(Evaluate=true, HideResult=true);
+    annotation(Evaluate=true);
   parameter Modelica.Units.SI.MassFlowRate m_flow=0
     "Fixed mass flow rate going out of the fluid port"
     annotation (Dialog(enable=not use_m_flow_in));
@@ -186,6 +186,12 @@ with exception of boundary flow rate, do not have an effect.
 </html>",
 revisions="<html>
 <ul>
+<li>
+March 11, 2024, by Michael Wetter:<br/>
+Corrected use of <code>HideResult</code>.<br/>
+This is for
+<a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1850\">#1850</a>.
+</li>
 <li>
 January 09, 2023, by Jianjun Hu:<br/>
 Changed base class to constrain medium to moist air.<br/>

--- a/Buildings/Fluid/Sources/MassFlowSource_h.mo
+++ b/Buildings/Fluid/Sources/MassFlowSource_h.mo
@@ -5,14 +5,14 @@ model MassFlowSource_h
 
   parameter Boolean use_m_flow_in = false
     "Get the mass flow rate from the input connector"
-    annotation(Evaluate=true, HideResult=true, Dialog(group="Conditional inputs"));
+    annotation(Evaluate=true, Dialog(group="Conditional inputs"));
   parameter Modelica.Units.SI.MassFlowRate m_flow=0
     "Fixed mass flow rate going out of the fluid port"
     annotation (Dialog(enable=not use_m_flow_in, group="Fixed inputs"));
 
   parameter Boolean use_h_in= false
     "Get the specific enthalpy from the input connector"
-    annotation(Evaluate=true, HideResult=true, Dialog(group="Conditional inputs"));
+    annotation(Evaluate=true, Dialog(group="Conditional inputs"));
   parameter Medium.SpecificEnthalpy h = Medium.h_default
     "Fixed value of specific enthalpy"
     annotation (Dialog(enable = not use_h_in, group="Fixed inputs"));
@@ -100,6 +100,12 @@ with exception of boundary flow rate, do not have an effect.
 </html>",
 revisions="<html>
 <ul>
+<li>
+March 11, 2024, by Michael Wetter:<br/>
+Corrected use of <code>HideResult</code>.<br/>
+This is for
+<a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1850\">#1850</a>.
+</li>
 <li>
 February 2nd, 2018 by Filip Jorissen<br/>
 Made <code>medium</code> conditional and refactored inputs.

--- a/Buildings/Fluid/Sources/TraceSubstancesFlowSource.mo
+++ b/Buildings/Fluid/Sources/TraceSubstancesFlowSource.mo
@@ -13,7 +13,7 @@ model TraceSubstancesFlowSource
   parameter String substanceName = "CO2" "Name of trace substance";
   parameter Boolean use_m_flow_in = false
     "Get the trace substance mass flow rate from the input connector"
-    annotation(Evaluate=true, HideResult=true);
+    annotation(Evaluate=true);
 
   parameter Modelica.Units.SI.MassFlowRate m_flow=0
     "Fixed mass flow rate going out of the fluid port"
@@ -104,6 +104,12 @@ which is more efficient than using this model.
 </p>
 </html>", revisions="<html>
 <ul>
+<li>
+March 11, 2024, by Michael Wetter:<br/>
+Corrected use of <code>HideResult</code>.<br/>
+This is for
+<a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1850\">#1850</a>.
+</li>
 <li>
 November 14, 2019, by Michael Wetter:<br/>
 Rewrote assignment of <code>C_in_internal</code> to avoid an initial algorithm section.<br/>

--- a/Buildings/Utilities/Psychrometrics/BaseClasses/HumidityRatioVaporPressure.mo
+++ b/Buildings/Utilities/Psychrometrics/BaseClasses/HumidityRatioVaporPressure.mo
@@ -3,7 +3,7 @@ partial block HumidityRatioVaporPressure
   "Humidity ratio for given water vapor pressure"
   extends Modelica.Blocks.Icons.Block;
   parameter Boolean use_p_in = true "Get the pressure from the input connector"
-    annotation(Evaluate=true, HideResult=true);
+    annotation(Evaluate=true);
 
   parameter Modelica.Units.SI.Pressure p=101325 "Fixed value of pressure"
     annotation (Dialog(enable=not use_p_in));
@@ -35,6 +35,12 @@ and the value provided by the input connector is used instead.
 </p>
 </html>", revisions="<html>
 <ul>
+<li>
+March 11, 2024, by Michael Wetter:<br/>
+Corrected use of <code>HideResult</code>.<br/>
+This is for
+<a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1850\">#1850</a>.
+</li>
 <li>
 May 29, 2014, by Michael Wetter:<br/>
 Removed undesirable annotation <code>Evaluate=true</code>.

--- a/Buildings/Utilities/Time/CalendarTime.mo
+++ b/Buildings/Utilities/Time/CalendarTime.mo
@@ -50,20 +50,29 @@ protected
   final constant Integer firstYear = 2010
     "First year that is supported, i.e. the first year in timeStampsNewYear[:]";
   final constant Integer lastYear = firstYear + size(timeStampsNewYear,1) - 1;
-  constant Modelica.Units.SI.Time timeStampsNewYear[22]={1262304000.0,
-      1293840000.0,1325376000.0,1356998400.0,1388534400.0,1420070400.0,
-      1451606400.0,1483228800.0,1514764800.0,1546300800.0,1577836800.0,
-      1609459200.0,1640995200.0,1672531200.0,1704067200.0,1735689600.0,
-      1767225600.0,1798761600.0,1830297600.0,1861920000.0,1893456000.0,
-      1924992000.0} "Epoch time stamps for new years day 2010 to 2031";
-  constant Boolean isLeapYear[21] = {
+  constant Modelica.Units.SI.Time timeStampsNewYear[42]={1262304000.0,
+    1293840000.0,1325376000.0,1356998400.0,1388534400.0,1420070400.0,
+    1451606400.0,1483228800.0,1514764800.0,1546300800.0,1577836800.0,
+    1609459200.0,1640995200.0,1672531200.0,1704067200.0,1735689600.0,
+    1767225600.0,1798761600.0,1830297600.0,1861920000.0,1893456000.0,
+    1924992000.0,1956528000.0,1988150400.0,2019686400.0,2051222400.0,
+    2082758400.0,2114380800.0,2145916800.0,2177452800.0,2208988800.0,
+    2240611200.0,2272147200.0,2303683200.0,2335219200.0,2366841600.0,
+    2398377600.0,2429913600.0,2461449600.0,2493072000.0,2524608000.0,
+    2556144000.0} "Epoch time stamps for new years day 2010 to 2051";
+  constant Boolean isLeapYear[41] = {
+    false, false, true, false,
+    false, false, true, false,
+    false, false, true, false,
+    false, false, true, false,
+    false, false, true, false,
     false, false, true, false,
     false, false, true, false,
     false, false, true, false,
     false, false, true, false,
     false, false, true, false,
     false}
-    "List of leap years starting from firstYear (2010), up to and including 2030";
+    "List of leap years starting from firstYear (2010), up to and including 2050";
   final constant Integer dayInMonth[12] = {31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31}
     "Number of days in each month";
   parameter Modelica.Units.SI.Time timOff(fixed=false) "Time offset";
@@ -150,6 +159,96 @@ initial algorithm
   elseif zerTim == Buildings.Utilities.Time.Types.ZeroTime.NY2020 or
     zerTim == Buildings.Utilities.Time.Types.ZeroTime.Custom and yearRef == 2020 then
       timOff :=timeStampsNewYear[11];
+  elseif zerTim == Buildings.Utilities.Time.Types.ZeroTime.NY2021 or
+    zerTim == Buildings.Utilities.Time.Types.ZeroTime.Custom and yearRef == 2021 then
+      timOff :=timeStampsNewYear[12];
+  elseif zerTim == Buildings.Utilities.Time.Types.ZeroTime.NY2022 or
+    zerTim == Buildings.Utilities.Time.Types.ZeroTime.Custom and yearRef == 2022 then
+      timOff :=timeStampsNewYear[13];
+  elseif zerTim == Buildings.Utilities.Time.Types.ZeroTime.NY2023 or
+    zerTim == Buildings.Utilities.Time.Types.ZeroTime.Custom and yearRef == 2023 then
+      timOff :=timeStampsNewYear[14];
+  elseif zerTim == Buildings.Utilities.Time.Types.ZeroTime.NY2024 or
+    zerTim == Buildings.Utilities.Time.Types.ZeroTime.Custom and yearRef == 2024 then
+      timOff := timeStampsNewYear[14];
+  elseif zerTim == Buildings.Utilities.Time.Types.ZeroTime.NY2025 or
+    zerTim == Buildings.Utilities.Time.Types.ZeroTime.Custom and yearRef == 2025 then
+      timOff := timeStampsNewYear[15];
+  elseif zerTim == Buildings.Utilities.Time.Types.ZeroTime.NY2026 or
+    zerTim == Buildings.Utilities.Time.Types.ZeroTime.Custom and yearRef == 2026 then
+      timOff := timeStampsNewYear[16];
+  elseif zerTim == Buildings.Utilities.Time.Types.ZeroTime.NY2027 or
+    zerTim == Buildings.Utilities.Time.Types.ZeroTime.Custom and yearRef == 2027 then
+      timOff := timeStampsNewYear[17];
+  elseif zerTim == Buildings.Utilities.Time.Types.ZeroTime.NY2028 or
+    zerTim == Buildings.Utilities.Time.Types.ZeroTime.Custom and yearRef == 2028 then
+      timOff := timeStampsNewYear[18];
+  elseif zerTim == Buildings.Utilities.Time.Types.ZeroTime.NY2029 or
+    zerTim == Buildings.Utilities.Time.Types.ZeroTime.Custom and yearRef == 2029 then
+      timOff := timeStampsNewYear[19];
+  elseif zerTim == Buildings.Utilities.Time.Types.ZeroTime.NY2030 or
+    zerTim == Buildings.Utilities.Time.Types.ZeroTime.Custom and yearRef == 2030 then
+      timOff := timeStampsNewYear[20];
+  elseif zerTim == Buildings.Utilities.Time.Types.ZeroTime.NY2031 or
+    zerTim == Buildings.Utilities.Time.Types.ZeroTime.Custom and yearRef == 2031 then
+      timOff := timeStampsNewYear[21];
+  elseif zerTim == Buildings.Utilities.Time.Types.ZeroTime.NY2032 or
+    zerTim == Buildings.Utilities.Time.Types.ZeroTime.Custom and yearRef == 2032 then
+      timOff := timeStampsNewYear[22];
+  elseif zerTim == Buildings.Utilities.Time.Types.ZeroTime.NY2033 or
+    zerTim == Buildings.Utilities.Time.Types.ZeroTime.Custom and yearRef == 2033 then
+      timOff := timeStampsNewYear[23];
+  elseif zerTim == Buildings.Utilities.Time.Types.ZeroTime.NY2034 or
+    zerTim == Buildings.Utilities.Time.Types.ZeroTime.Custom and yearRef == 2034 then
+      timOff := timeStampsNewYear[24];
+  elseif zerTim == Buildings.Utilities.Time.Types.ZeroTime.NY2035 or
+    zerTim == Buildings.Utilities.Time.Types.ZeroTime.Custom and yearRef == 2035 then
+      timOff := timeStampsNewYear[25];
+  elseif zerTim == Buildings.Utilities.Time.Types.ZeroTime.NY2036 or
+    zerTim == Buildings.Utilities.Time.Types.ZeroTime.Custom and yearRef == 2036 then
+      timOff := timeStampsNewYear[26];
+  elseif zerTim == Buildings.Utilities.Time.Types.ZeroTime.NY2037 or
+    zerTim == Buildings.Utilities.Time.Types.ZeroTime.Custom and yearRef == 2037 then
+      timOff := timeStampsNewYear[27];
+  elseif zerTim == Buildings.Utilities.Time.Types.ZeroTime.NY2038 or
+    zerTim == Buildings.Utilities.Time.Types.ZeroTime.Custom and yearRef == 2038 then
+      timOff := timeStampsNewYear[28];
+  elseif zerTim == Buildings.Utilities.Time.Types.ZeroTime.NY2039 or
+    zerTim == Buildings.Utilities.Time.Types.ZeroTime.Custom and yearRef == 2039 then
+      timOff := timeStampsNewYear[29];
+  elseif zerTim == Buildings.Utilities.Time.Types.ZeroTime.NY2040 or
+    zerTim == Buildings.Utilities.Time.Types.ZeroTime.Custom and yearRef == 2040 then
+      timOff := timeStampsNewYear[30];
+  elseif zerTim == Buildings.Utilities.Time.Types.ZeroTime.NY2041 or
+    zerTim == Buildings.Utilities.Time.Types.ZeroTime.Custom and yearRef == 2041 then
+      timOff := timeStampsNewYear[31];
+  elseif zerTim == Buildings.Utilities.Time.Types.ZeroTime.NY2042 or
+    zerTim == Buildings.Utilities.Time.Types.ZeroTime.Custom and yearRef == 2042 then
+      timOff := timeStampsNewYear[32];
+  elseif zerTim == Buildings.Utilities.Time.Types.ZeroTime.NY2043 or
+    zerTim == Buildings.Utilities.Time.Types.ZeroTime.Custom and yearRef == 2043 then
+      timOff := timeStampsNewYear[33];
+  elseif zerTim == Buildings.Utilities.Time.Types.ZeroTime.NY2044 or
+    zerTim == Buildings.Utilities.Time.Types.ZeroTime.Custom and yearRef == 2044 then
+      timOff := timeStampsNewYear[34];
+  elseif zerTim == Buildings.Utilities.Time.Types.ZeroTime.NY2045 or
+    zerTim == Buildings.Utilities.Time.Types.ZeroTime.Custom and yearRef == 2045 then
+      timOff := timeStampsNewYear[35];
+  elseif zerTim == Buildings.Utilities.Time.Types.ZeroTime.NY2046 or
+    zerTim == Buildings.Utilities.Time.Types.ZeroTime.Custom and yearRef == 2046 then
+      timOff := timeStampsNewYear[36];
+  elseif zerTim == Buildings.Utilities.Time.Types.ZeroTime.NY2047 or
+    zerTim == Buildings.Utilities.Time.Types.ZeroTime.Custom and yearRef == 2047 then
+      timOff := timeStampsNewYear[37];
+  elseif zerTim == Buildings.Utilities.Time.Types.ZeroTime.NY2048 or
+    zerTim == Buildings.Utilities.Time.Types.ZeroTime.Custom and yearRef == 2048 then
+      timOff := timeStampsNewYear[38];
+  elseif zerTim == Buildings.Utilities.Time.Types.ZeroTime.NY2049 or
+    zerTim == Buildings.Utilities.Time.Types.ZeroTime.Custom and yearRef == 2049 then
+      timOff := timeStampsNewYear[39];
+  elseif zerTim == Buildings.Utilities.Time.Types.ZeroTime.NY2050 or
+    zerTim == Buildings.Utilities.Time.Types.ZeroTime.Custom and yearRef == 2050 then
+      timOff := timeStampsNewYear[40];
   else
     timOff :=0;
     // this code should not be reachable
@@ -257,7 +356,7 @@ equation
         + String(firstYear+size(timeStampsNewYear,1)));
 
     // update the month when passing the last day of the current month
-    if unixTimeStampLocal - ( pre(epochLastMonth) + (if pre(month)==2 and isLeapYear[yearIndex] then 1 + dayInMonth[pre(month)] else dayInMonth[pre(month)])*3600*24 ) > -eps_time then
+    if unixTimeStampLocal - ( pre(epochLastMonth) + (if pre(month)==2 and isLeapYear[yearIndex] then 1 + dayInMonth[pre(month)] else dayInMonth[pre(month)])*3600*24)  > -eps_time then
       month = if pre(month) == 12 then 1 else pre(month) + 1;
       // Use floor(0.1 + ...) to avoid floating point errors when accumulating epochLastMonth.
       epochLastMonth = floor(0.1 + pre(epochLastMonth) +
@@ -280,6 +379,12 @@ equation
     defaultComponentName="calTim",
   Documentation(revisions="<html>
 <ul>
+<li>
+March 8, 2024, by Jelger Jansen:<br/>
+Allow reference years later than 2020 and extend functionality to year 2050.<br/>
+This is for 
+<a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1847\">#1847</a>.
+</li>  
 <li>
 December 19, 2022, by Michael Wetter:<br/>
 Refactored implementation to avoid wrong day number due to rounding errors that caused simultaneous events
@@ -351,14 +456,14 @@ Buildings.BoundaryConditions.WeatherData.ReaderTMY3</a>
 must also be defined with GMT as the time stamp.
 
 The user can choose from new year, midnight for a number of years:
-2010 to 2030 and also 1970.
+2010 to 2050 and also 1970.
 The latter corresponds to a unix stamp of <i>0</i>.
 (Note that when choosing the reference time equal to 0 at 1970,
-the actual simulation time must be within the 2010-2030 range.
+the actual simulation time must be within the 2010-2051 range.
 For instance <code>startTime = 1262304000</code> corresponds
 to the simulation starting on the 1st of January 2010
 when setting <code>zerTim = ZeroTime.UnixTimeStamp</code>.
-This is within the 2010-2020 range and is therefore allowed.)
+This is within the 2010-2050 range and is therefore allowed.)
 The unix time stamp is formally defined as the number of
 seconds since midnight of new year in 1970 GMT.
 To output the correct unix time stamp, set <code>outputUnixTimeStamp=true</code>

--- a/Buildings/Utilities/Time/Types/ZeroTime.mo
+++ b/Buildings/Utilities/Time/Types/ZeroTime.mo
@@ -13,7 +13,37 @@ type ZeroTime = enumeration(
     NY2017 "New year 2017, 00:00:00 local time",
     NY2018 "New year 2018, 00:00:00 local time",
     NY2019 "New year 2019, 00:00:00 local time",
-    NY2020 "New year 2020, 00:00:00 local time")
+    NY2020 "New year 2020, 00:00:00 local time",
+    NY2021 "New year 2021, 00:00:00 local time",
+    NY2022 "New year 2022, 00:00:00 local time",
+    NY2023 "New year 2023, 00:00:00 local time",
+    NY2024 "New year 2024, 00:00:00 local time",
+    NY2025 "New year 2025, 00:00:00 local time",
+    NY2026 "New year 2026, 00:00:00 local time",
+    NY2027 "New year 2027, 00:00:00 local time",
+    NY2028 "New year 2028, 00:00:00 local time",
+    NY2029 "New year 2029, 00:00:00 local time",
+    NY2030 "New year 2030, 00:00:00 local time",
+    NY2031 "New year 2031, 00:00:00 local time",
+    NY2032 "New year 2032, 00:00:00 local time",
+    NY2033 "New year 2033, 00:00:00 local time",
+    NY2034 "New year 2034, 00:00:00 local time",
+    NY2035 "New year 2035, 00:00:00 local time",
+    NY2036 "New year 2036, 00:00:00 local time",
+    NY2037 "New year 2037, 00:00:00 local time",
+    NY2038 "New year 2038, 00:00:00 local time",
+    NY2039 "New year 2039, 00:00:00 local time",
+    NY2040 "New year 2040, 00:00:00 local time",
+    NY2041 "New year 2041, 00:00:00 local time",
+    NY2042 "New year 2042, 00:00:00 local time",
+    NY2043 "New year 2043, 00:00:00 local time",
+    NY2044 "New year 2044, 00:00:00 local time",
+    NY2045 "New year 2045, 00:00:00 local time",
+    NY2046 "New year 2046, 00:00:00 local time",
+    NY2047 "New year 2047, 00:00:00 local time",
+    NY2048 "New year 2048, 00:00:00 local time",
+    NY2049 "New year 2049, 00:00:00 local time",
+    NY2050 "New year 2050, 00:00:00 local time")
   "Use this to set the date corresponding to time = 0"
   annotation (Documentation(info="<html>
 <p>
@@ -36,6 +66,12 @@ that <code>time</code> is expressed in local time.
 </p>
 </html>", revisions="<html>
 <ul>
+<li>
+March 8, 2024, by Jelger Jansen:<br/>
+Extend functionality to year 2050.<br/>
+This is for 
+<a href=\"https://github.com/ibpsa/modelica-ibpsa/issues/1847\">#1847</a>.
+</li> 
 <li>
 September 10, 2016, by Michael Wetter:<br/>
 Revised implementation and moved to new package


### PR DESCRIPTION
This merges updates from IBPSA that corrects `HideResult` annotation, `displayUnit` annotation, and extends the time covered by `CalendarTime`.