### PR TITLE
Corrected wrong parameter assignment in ChillerDXHeatingEconomizer (maint 10.0.x)

### DIFF
--- a/Buildings/Air/Systems/SingleZone/VAV/ChillerDXHeatingEconomizer.mo
+++ b/Buildings/Air/Systems/SingleZone/VAV/ChillerDXHeatingEconomizer.mo
@@ -144,7 +144,7 @@ model ChillerDXHeatingEconomizer
     "Heating efficiency"
     annotation (Placement(transformation(extent={{120,100},{140,120}})));
   Buildings.Fluid.Sources.Outside out(
-    final C=fill(0.0004, 1),
+    final C=fill(0.0004, MediumA.nC),
     final nPorts=3,
     redeclare package Medium = MediumA)
     "Boundary conditions for outside air"
@@ -634,6 +634,10 @@ feedback control of damper positions. The cooling coil is a dry coil model.
 </p>
 </html>", revisions="<html>
 <ul>
+<li>
+March 27, 2024, by Michael Wetter:<br/>
+Corrected wrong assignment of <code>out.C</code>.
+</li>
 <li>
 November 1, 2021, by Hongxiang Fu:<br/>
 Refactored the model by replacing <code>not use_powerCharacteristic</code>


### PR DESCRIPTION
This corrects the wrong dimension, which OMEdit detects and triggers a warning