### PR TITLE
Removed argument initialCall in Spawn

### DIFF
--- a/Buildings/Resources/C-Sources/EnergyPlus_9_6_0_Wrapper.c
+++ b/Buildings/Resources/C-Sources/EnergyPlus_9_6_0_Wrapper.c
@@ -126,7 +126,7 @@ void exchange_Modelica_EnergyPlus_9_6_0(
 
     exchange_Spawn_EnergyPlus_9_6_0(
       object,
-      false, /* Argument initialCall is hard-coded to false, and can be removed when binaries need to be recompiled. */
+      0, /* Argument initialCall is hard-coded to false, and can be removed when binaries need to be recompiled. */
       u,
       y);
   }

--- a/Buildings/Resources/C-Sources/EnergyPlus_9_6_0_Wrapper.c
+++ b/Buildings/Resources/C-Sources/EnergyPlus_9_6_0_Wrapper.c
@@ -120,14 +120,13 @@ void getParameters_Modelica_EnergyPlus_9_6_0(
 
 void exchange_Modelica_EnergyPlus_9_6_0(
   void* object,
-  int initialCall,
   const double* u,
   double dummy,
   double* y){
 
     exchange_Spawn_EnergyPlus_9_6_0(
       object,
-      initialCall,
+      false, /* Argument initialCall is hard-coded to false, and can be removed when binaries need to be recompiled. */
       u,
       y);
   }

--- a/Buildings/ThermalZones/EnergyPlus_9_6_0/Actuator.mo
+++ b/Buildings/ThermalZones/EnergyPlus_9_6_0/Actuator.mo
@@ -85,7 +85,6 @@ initial equation
 equation
   yEP=Buildings.ThermalZones.EnergyPlus_9_6_0.BaseClasses.exchange(
     adapter=adapter,
-    initialCall=false,
     nY=nY,
     u={u,round(time,1E-3)},
     dummy=nObj);

--- a/Buildings/ThermalZones/EnergyPlus_9_6_0/BaseClasses/ThermalZoneAdapter.mo
+++ b/Buildings/ThermalZones/EnergyPlus_9_6_0/BaseClasses/ThermalZoneAdapter.mo
@@ -231,7 +231,6 @@ equation
     // Below, the term X_w/(1.-X_w) is for conversion from kg/kg_total_air (Modelica) to kg/kg_dry_air (EnergyPlus)
     yEP=Buildings.ThermalZones.EnergyPlus_9_6_0.BaseClasses.exchange(
       adapter=adapter,
-      initialCall=false,
       nY=nY,
       u={T,X_w/(1.-X_w),pre(mInlet_flow),TAveInlet,pre(QGaiRad_flow),round(time,1E-3)},
       dummy=AFlo);

--- a/Buildings/ThermalZones/EnergyPlus_9_6_0/BaseClasses/exchange.mo
+++ b/Buildings/ThermalZones/EnergyPlus_9_6_0/BaseClasses/exchange.mo
@@ -4,8 +4,6 @@ pure function exchange
   extends Modelica.Icons.Function;
   input Buildings.ThermalZones.EnergyPlus_9_6_0.BaseClasses.SpawnExternalObject adapter
     "External object";
-  input Boolean initialCall
-    "Set to true if initial() is true, false otherwise";
   input Integer nY
     "Size of output y";
   input Real u[:]
@@ -14,8 +12,7 @@ pure function exchange
     "Dummy value (used to force Modelica tools to call initialize())";
   output Real y[nY]
     "Output values. First all outputs, then all derivatives, then next event time";
-external "C" exchange_Modelica_EnergyPlus_9_6_0(
-  adapter,initialCall,u,dummy,y)
+external "C" exchange_Modelica_EnergyPlus_9_6_0(adapter, u, dummy, y)
   annotation (
       Include="#include <EnergyPlus_9_6_0_Wrapper.c>",
       IncludeDirectory="modelica://Buildings/Resources/C-Sources",
@@ -29,6 +26,10 @@ External function that exchanges data with EnergyPlus.
 </html>",
       revisions="<html>
 <ul>
+<li>
+March 27, 2024, by Michael Wetter:<br/>
+Removed non-needed argument <code>initialCall</code>.
+</li>
 <li>
 December 11, 2021, by Michael Wetter:<br/>
 Declared function as <code>pure</code> for MSL 4.0.0.

--- a/Buildings/ThermalZones/EnergyPlus_9_6_0/OpaqueConstruction.mo
+++ b/Buildings/ThermalZones/EnergyPlus_9_6_0/OpaqueConstruction.mo
@@ -126,7 +126,6 @@ equation
     dtLast=time-pre(tLast);
     yEP=Buildings.ThermalZones.EnergyPlus_9_6_0.BaseClasses.exchange(
       adapter=adapter,
-      initialCall=false,
       nY=nY,
       u={heaPorFro.T,heaPorBac.T,round(time,1E-3)},
       dummy=A);

--- a/Buildings/ThermalZones/EnergyPlus_9_6_0/OutputVariable.mo
+++ b/Buildings/ThermalZones/EnergyPlus_9_6_0/OutputVariable.mo
@@ -91,7 +91,6 @@ equation
   when {initial(),time >= pre(tNext)} then
     yEP=Buildings.ThermalZones.EnergyPlus_9_6_0.BaseClasses.exchange(
       adapter=adapter,
-      initialCall=false,
       nY=nY,
       u={round(time,1E-3),directDependency_in_internal},
       dummy=nObj);

--- a/Buildings/ThermalZones/EnergyPlus_9_6_0/Schedule.mo
+++ b/Buildings/ThermalZones/EnergyPlus_9_6_0/Schedule.mo
@@ -80,7 +80,6 @@ initial equation
 equation
   yEP=Buildings.ThermalZones.EnergyPlus_9_6_0.BaseClasses.exchange(
     adapter=adapter,
-    initialCall=false,
     nY=nY,
     u={u,round(time,1E-3)},
     dummy=nObj);

--- a/Buildings/ThermalZones/EnergyPlus_9_6_0/ZoneSurface.mo
+++ b/Buildings/ThermalZones/EnergyPlus_9_6_0/ZoneSurface.mo
@@ -116,7 +116,6 @@ equation
     dtLast=time-pre(tLast);
     yEP=Buildings.ThermalZones.EnergyPlus_9_6_0.BaseClasses.exchange(
       adapter=adapter,
-      initialCall=false,
       nY=nY,
       u={T,round(time,1E-3)},
       dummy=A);


### PR DESCRIPTION
This is no longer needed. In the compiled C library, the argument is still present, but can be removed next time when the libraries need to be recompiled.