### PR TITLE
Interval time reduced in order to speed-up the simulation during the initial phase

### DIFF
--- a/Buildings/Fluid/FixedResistances/Validation/PlugFlowPipes/PlugFlowAIT.mo
+++ b/Buildings/Fluid/FixedResistances/Validation/PlugFlowPipes/PlugFlowAIT.mo
@@ -375,7 +375,7 @@ equation
   annotation (
     experiment(
       StopTime=603900,
-      Interval=900,
+      Interval=120,
       Tolerance=1e-006),
     __Dymola_Commands(file="modelica://Buildings/Resources/Scripts/Dymola/Fluid/FixedResistances/Validation/PlugFlowPipes/PlugFlowAIT.mos"
         "Simulate and plot"),


### PR DESCRIPTION
This PR reduces the interval time in the model `Buildings.Fluid.FixedResistances.Validation.PlugFlowPipes.PlugFlowAIT` in order to reduce the simulation warnings and to speed-up the simulation during the initial phases. This should prevent the CI to fail.

More details are available in https://github.com/OpenModelica/OpenModelica/issues/11000