### PR TITLE
issue 3865 change OptimalStart test tolerance 

### DIFF
--- a/Buildings/Controls/OBC/Utilities/Validation/OptimalStartCoolingNegativeStartTime.mo
+++ b/Buildings/Controls/OBC/Utilities/Validation/OptimalStartCoolingNegativeStartTime.mo
@@ -100,7 +100,7 @@ equation
     experiment(
       StartTime=-660000,
       StopTime=0,
-      Tolerance=1e-06),
+      Tolerance=1e-07),
     __Dymola_Commands(
       file="modelica://Buildings/Resources/Scripts/Dymola/Controls/OBC/Utilities/Validation/OptimalStartCoolingNegativeStartTime.mos" "Simulate and plot"),
     Documentation(

--- a/Buildings/Controls/OBC/Utilities/Validation/OptimalStartCoolingPositiveStartTime.mo
+++ b/Buildings/Controls/OBC/Utilities/Validation/OptimalStartCoolingPositiveStartTime.mo
@@ -99,7 +99,7 @@ equation
     experiment(
       StartTime=34000,
       StopTime=864000,
-      Tolerance=1e-06),
+      Tolerance=1e-07),
     __Dymola_Commands(
       file="modelica://Buildings/Resources/Scripts/Dymola/Controls/OBC/Utilities/Validation/OptimalStartCoolingPositiveStartTime.mos" "Simulate and plot"),
     Documentation(

--- a/Buildings/Controls/OBC/Utilities/Validation/OptimalStartHeating.mo
+++ b/Buildings/Controls/OBC/Utilities/Validation/OptimalStartHeating.mo
@@ -98,7 +98,7 @@ equation
     experiment(
       StartTime=-172800,
       StopTime=604800,
-      Tolerance=1e-06),
+      Tolerance=1e-07),
     __Dymola_Commands(
       file="modelica://Buildings/Resources/Scripts/Dymola/Controls/OBC/Utilities/Validation/OptimalStartHeating.mos" "Simulate and plot"),
     Documentation(

--- a/Buildings/Resources/Scripts/Dymola/Controls/OBC/Utilities/Validation/OptimalStartCoolingNegativeStartTime.mos
+++ b/Buildings/Resources/Scripts/Dymola/Controls/OBC/Utilities/Validation/OptimalStartCoolingNegativeStartTime.mos
@@ -1,4 +1,4 @@
-simulateModel("Buildings.Controls.OBC.Utilities.Validation.OptimalStartCoolingNegativeStartTime", method="Cvode", startTime=-660000,stopTime=0, tolerance=1e-06, resultFile="OptimalStartCoolingNegativeStartTime");
+simulateModel("Buildings.Controls.OBC.Utilities.Validation.OptimalStartCoolingNegativeStartTime", method="Cvode", startTime=-660000,stopTime=0, tolerance=1e-07, resultFile="OptimalStartCoolingNegativeStartTime");
 createPlot(id=1, position={10, 9, 1161, 1054}, subPlot=1, y={"optStaCoo.tOpt"}, range={-691200.0, 0.0, 0, 20000.0}, grid=true, colors={{28,108,200}});
 createPlot(id=1, position={10, 9, 1161, 346}, subPlot=2, y={"TSetCoo.y", "optStaCoo.TZon"}, range={-691200.0, 0.0, 16, 24}, grid=true, colors={{238,46,47}, {0,140,72}});
 createPlot(id=1, position={10, 9, 1161, 346}, subPlot=3, y={"optStaCoo.optOn"}, range={-691200.0, 0.0, 0, 20000.0}, grid=true, colors={{28,108,200}});

--- a/Buildings/Resources/Scripts/Dymola/Controls/OBC/Utilities/Validation/OptimalStartCoolingPositiveStartTime.mos
+++ b/Buildings/Resources/Scripts/Dymola/Controls/OBC/Utilities/Validation/OptimalStartCoolingPositiveStartTime.mos
@@ -1,4 +1,4 @@
-simulateModel("Buildings.Controls.OBC.Utilities.Validation.OptimalStartCoolingPositiveStartTime", method="Cvode", startTime=34000,stopTime=864000, tolerance=1e-06, resultFile="OptimalStartCoolingPositiveStartTime");
+simulateModel("Buildings.Controls.OBC.Utilities.Validation.OptimalStartCoolingPositiveStartTime", method="Cvode", startTime=34000,stopTime=864000, tolerance=1e-07, resultFile="OptimalStartCoolingPositiveStartTime");
 createPlot(id=1, position={10, 9, 1161, 1054}, subPlot=1, y={"optStaCoo.tOpt"}, range={34000.0, 604800.0, 0, 20000.0}, grid=true, colors={{28,108,200}});
 createPlot(id=1, position={10, 9, 1161, 346}, subPlot=2, y={"TSetCoo.y", "optStaCoo.TZon"}, range={34000.0, 604800.0, 16, 24}, grid=true, colors={{238,46,47}, {0,140,72}});
 createPlot(id=1, position={10, 9, 1161, 346}, subPlot=3, y={"optStaCoo.optOn"}, range={34000.0, 604800.0, 0, 20000.0}, grid=true, colors={{28,108,200}});

--- a/Buildings/Resources/Scripts/Dymola/Controls/OBC/Utilities/Validation/OptimalStartHeating.mos
+++ b/Buildings/Resources/Scripts/Dymola/Controls/OBC/Utilities/Validation/OptimalStartHeating.mos
@@ -1,4 +1,4 @@
-simulateModel("Buildings.Controls.OBC.Utilities.Validation.OptimalStartHeating", method="Cvode", startTime=-172800, stopTime=604800, tolerance=1e-06, resultFile="OptimalStartHeating");
+simulateModel("Buildings.Controls.OBC.Utilities.Validation.OptimalStartHeating", method="Cvode", startTime=-172800, stopTime=604800, tolerance=1e-07, resultFile="OptimalStartHeating");
 createPlot(id=1, position={10, 9, 1161, 1054}, subPlot=1, y={"optStaHea.tOpt"}, range={-172800.0, 604800.0, 0, 20000.0}, grid=true, colors={{28,108,200}});
 createPlot(id=1, position={10, 9, 1161, 346}, subPlot=2, y={"TSetHea.y", "optStaHea.TZon"}, range={-172800.0, 604800.0, 16, 24}, grid=true, colors={{238,46,47}, {0,140,72}});
 createPlot(id=1, position={10, 9, 1161, 346}, subPlot=3, y={"optStaHea.optOn"}, range={-172800.0, 604800.0, 0, 20000.0}, grid=true, colors={{28,108,200}});


### PR DESCRIPTION
This is for #3865, pending external tests.

This PR reduces the tolerance of `Buildings.Controls.OBC.Utilities.Validation{OptimalStartCoolingNegativeStartTime,OptimalStartCoolingPositiveStartTime,OptimalStartHeating}` by a factor of 10 in both the `.mo` file annotations and the `.mos` files.
This did _not_ cause the unit test results to change.