### PR TITLE
Fixed issue when multiple sims are performed for models including FFD

### DIFF
--- a/Buildings/Resources/C-Sources/cfdSendStopCommand.c
+++ b/Buildings/Resources/C-Sources/cfdSendStopCommand.c
@@ -149,6 +149,9 @@ void cfdSendStopCommand(void *thread) {
   }
   if (cosim != NULL){
     free(cosim);
+    /* If it is not explicitly set to NULL - then the check in cfdcosim() 
+       will fail if a second simulation is performed. */
+    cosim = NULL;
   }
 
 } /* End of cfdSendStopCommand*/


### PR DESCRIPTION
If multiple simulations are performed for a model that includes FFD without fully releasing the library, then the second simulation would fail due to that the global structure "cosim" has not been set to NULL in the destructor. The use case can be for instance when the model is compiled into an FMU and the following is performed:

1. Load the FMU 
2. Simulate
3. Use the FMI reset method
4. Simulate again (will fail)

An example model is Buildings.ThermalZones.Detailed.Examples.FFD.ForcedConvection)

Setting the structure "cosim" to NULL will resolve the issue.