### PR TITLE
Flag for checking if the Co-Simulation has started or not

### DIFF
--- a/Buildings/Resources/C-Sources/cfdSendStopCommand.c
+++ b/Buildings/Resources/C-Sources/cfdSendStopCommand.c
@@ -29,7 +29,7 @@ void cfdSendStopCommand(void *thread) {
   cosim->para->flag = 0;
 
   /* Wait for the feedback from FFD*/
- while(cosim->para->flag==0 && i<imax) {
+ while(cosim->started==1 && cosim->para->flag==0 && i<imax) {
     if(cosim->para->ffdError==1) {
       ModelicaError(cosim->ffd->msg);
     }
@@ -43,7 +43,7 @@ void cfdSendStopCommand(void *thread) {
     if(cosim->para->ffdError==1) {
       ModelicaError(cosim->ffd->msg);
     }
-    else {
+    else if (cosim->started==1) {
       ModelicaMessage("Successfully stopped the FFD simulation.\n");
     }
   }

--- a/Buildings/Resources/C-Sources/cfdStartCosimulation.c
+++ b/Buildings/Resources/C-Sources/cfdStartCosimulation.c
@@ -230,6 +230,7 @@ int cfdStartCosimulation(const char *cfdFilNam, const char **name, const double 
   | Implicitly launch DLL module.
   ****************************************************************************/
   ffd_dll(cosim);
+  cosim->started = 1;
 
   return 0;
 } /* End of cfdStartCosimulation()*/

--- a/Buildings/Resources/C-Sources/cfdcosim.c
+++ b/Buildings/Resources/C-Sources/cfdcosim.c
@@ -98,6 +98,7 @@ void *cfdcosim() {
   cosim->modelica->shaConSig = NULL;
   cosim->modelica->shaAbsRad = NULL;
   cosim->ffd->TSha = NULL;
+  cosim->started = 0;
 
   return (void*) cosim;
 } /* End of cfdcosim()*/

--- a/Buildings/Resources/src/FastFluidDynamics/modelica_ffd_common.h
+++ b/Buildings/Resources/src/FastFluidDynamics/modelica_ffd_common.h
@@ -72,6 +72,7 @@ typedef struct {
 }ffdSharedData;
 
 typedef struct{
+  int started; /* Flag to indicate if the Co-simulation has started or not. */
   ParameterSharedData *para;
   ffdSharedData *ffd;
   ModelicaSharedData *modelica;


### PR DESCRIPTION
In the constructor of the external object `Buildings.ThermalZones.Detailed.BaseClasses.CFDThread`, there is a call to the underlying C method "`cfdcosim`". Furthermore, in the destructor of the same, there is a call to the underlying C method "`cfdSendStopCommand`". There is an issue in the latter as it currently assumes that the Co-Simulation has started when the destructor is called, i.e. that `Buildings.ThermalZones.Detailed.BaseClasses.cfdStartCosimulation` has been invoked.

This is not necessarily the case as in some unusal situations it might be so that the destructor is called without there having been a call to the `cfdStartCosimulation`. If this happens, the destructor will get stuck and eventually throw an error.

To handle these situations more gracefully I'd propose to simply add a flag in the underlying C-struct that indicates if the co-simulation has been started or not and that this is taken into account in the destructor.