### PR TITLE
Improve comment strings and reformat implementation of CDL Elementary Blocks

### DIFF
--- a/Buildings/Controls/OBC/CDL/Constants.mo
+++ b/Buildings/Controls/OBC/CDL/Constants.mo
@@ -6,8 +6,7 @@ package Constants
     "Biggest number such that 1.0 + eps = 1.0";
   final constant Real small=1E-37
     "Smallest number such that small and -small are representable on the machine";
-  final constant Real pi=2*Modelica.Math.asin(
-    1.0)
+  final constant Real pi=2*Modelica.Math.asin(1.0)
     "Constant number pi, 3.14159265358979";
   annotation (
     Documentation(

--- a/Buildings/Controls/OBC/CDL/Conversions/BooleanToInteger.mo
+++ b/Buildings/Controls/OBC/CDL/Conversions/BooleanToInteger.mo
@@ -6,10 +6,10 @@ block BooleanToInteger
   parameter Integer integerFalse=0
     "Output signal for false Boolean input";
   Buildings.Controls.OBC.CDL.Interfaces.BooleanInput u
-    "Connector of Boolean input signal"
+    "Boolean signal to be converted to an Integer signal"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.IntegerOutput y
-    "Connector of Integer output signal"
+    "Converted input signal as an Integer"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 equation

--- a/Buildings/Controls/OBC/CDL/Conversions/BooleanToReal.mo
+++ b/Buildings/Controls/OBC/CDL/Conversions/BooleanToReal.mo
@@ -6,10 +6,10 @@ block BooleanToReal
   parameter Real realFalse=0.0
     "Output signal for false Boolean input";
   Buildings.Controls.OBC.CDL.Interfaces.BooleanInput u
-    "Connector of Boolean input signal"
+    "Boolean signal to be converted to a Real signal"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.RealOutput y
-    "Connector of Real output signal"
+    "Converted input signal as a Real"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 equation

--- a/Buildings/Controls/OBC/CDL/Conversions/IntegerToReal.mo
+++ b/Buildings/Controls/OBC/CDL/Conversions/IntegerToReal.mo
@@ -2,10 +2,10 @@ within Buildings.Controls.OBC.CDL.Conversions;
 block IntegerToReal
   "Convert Integer to Real signals"
   Buildings.Controls.OBC.CDL.Interfaces.IntegerInput u
-    "Connector of Integer input signal"
+    "Integer signal to be converted to a Real signal"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.RealOutput y
-    "Connector of Real output signal"
+    "Converted input signal as a Real"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 equation

--- a/Buildings/Controls/OBC/CDL/Conversions/RealToInteger.mo
+++ b/Buildings/Controls/OBC/CDL/Conversions/RealToInteger.mo
@@ -2,10 +2,10 @@ within Buildings.Controls.OBC.CDL.Conversions;
 block RealToInteger
   "Convert Real to Integer signal"
   Buildings.Controls.OBC.CDL.Interfaces.RealInput u
-    "Connector of Real input signal"
+    "Real signal to be converted to an Integer signal"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.IntegerOutput y
-    "Connector of Integer output signal"
+    "Converted input signal as an Integer"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 equation

--- a/Buildings/Controls/OBC/CDL/Discrete/FirstOrderHold.mo
+++ b/Buildings/Controls/OBC/CDL/Discrete/FirstOrderHold.mo
@@ -7,10 +7,10 @@ block FirstOrderHold
     min=1E-3)
     "Sample period of component";
   Buildings.Controls.OBC.CDL.Interfaces.RealInput u
-    "Continuous input signal"
+    "Input signal to be sampled"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.RealOutput y
-    "Continuous output signal"
+    "First order hold of input signal"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 protected

--- a/Buildings/Controls/OBC/CDL/Discrete/Sampler.mo
+++ b/Buildings/Controls/OBC/CDL/Discrete/Sampler.mo
@@ -7,10 +7,10 @@ block Sampler
     min=1E-3)
     "Sample period of component";
   Buildings.Controls.OBC.CDL.Interfaces.RealInput u
-    "Continuous input signal"
+    "Input signal to be sampled"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.RealOutput y
-    "Continuous output signal"
+    "Sampled input signal"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 protected

--- a/Buildings/Controls/OBC/CDL/Discrete/TriggeredMax.mo
+++ b/Buildings/Controls/OBC/CDL/Discrete/TriggeredMax.mo
@@ -2,13 +2,13 @@ within Buildings.Controls.OBC.CDL.Discrete;
 block TriggeredMax
   "Output the maximum, absolute value of a continuous signal at trigger instants"
   Buildings.Controls.OBC.CDL.Interfaces.RealInput u
-    "Connector with a Real input signal"
+    "Input signal to be sampled"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.BooleanInput trigger
-    "Connector for trigger"
+    "Input for trigger that causes u to be sampled"
     annotation (Placement(transformation(origin={0,-120},extent={{-20,-20},{20,20}},rotation=90)));
   Buildings.Controls.OBC.CDL.Interfaces.RealOutput y
-    "Connector with a Real output signal"
+    "Maximum of input signal over all trigger instants"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 initial equation

--- a/Buildings/Controls/OBC/CDL/Discrete/TriggeredMovingMean.mo
+++ b/Buildings/Controls/OBC/CDL/Discrete/TriggeredMovingMean.mo
@@ -5,13 +5,13 @@ block TriggeredMovingMean
     min=1)
     "Number of samples over which the input is averaged";
   Buildings.Controls.OBC.CDL.Interfaces.RealInput u
-    "Continuous input signal"
+    "Input signal to be sampled"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.BooleanInput trigger
-    "Boolean signal that triggers the block"
+    "Input for trigger that causes u to be sampled"
     annotation (Placement(transformation(origin={0,-120},extent={{-20,-20},{20,20}},rotation=90),iconTransformation(extent={{-20,-20},{20,20}},rotation=90,origin={0,-120})));
   Buildings.Controls.OBC.CDL.Interfaces.RealOutput y
-    "Discrete averaged signal"
+    "Moving mean of input signal over all trigger instants"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 protected

--- a/Buildings/Controls/OBC/CDL/Discrete/TriggeredSampler.mo
+++ b/Buildings/Controls/OBC/CDL/Discrete/TriggeredSampler.mo
@@ -4,13 +4,13 @@ block TriggeredSampler
   parameter Real y_start=0
     "Initial value of output signal";
   Buildings.Controls.OBC.CDL.Interfaces.RealInput u
-    "Connector with a Real input signal"
+    "Input signal to be sampled"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.BooleanInput trigger
-    "Signal that triggers the sampler"
+    "Input for trigger that causes u to be sampled"
     annotation (Placement(transformation(origin={0,-120},extent={{-20,-20},{20,20}},rotation=90)));
   Buildings.Controls.OBC.CDL.Interfaces.RealOutput y
-    "Connector with a Real output signal"
+    "Input signal at the last trigger instant"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 initial equation

--- a/Buildings/Controls/OBC/CDL/Discrete/UnitDelay.mo
+++ b/Buildings/Controls/OBC/CDL/Discrete/UnitDelay.mo
@@ -9,10 +9,10 @@ block UnitDelay
   parameter Real y_start=0
     "Initial value of output signal";
   Buildings.Controls.OBC.CDL.Interfaces.RealInput u
-    "Continuous input signal"
+    "Input signal to be sampled"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.RealOutput y
-    "Continuous output signal"
+    "Input signal at the previous sample instant"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 protected

--- a/Buildings/Controls/OBC/CDL/Discrete/ZeroOrderHold.mo
+++ b/Buildings/Controls/OBC/CDL/Discrete/ZeroOrderHold.mo
@@ -7,10 +7,10 @@ block ZeroOrderHold
     min=1E-3)
     "Sample period of component";
   Buildings.Controls.OBC.CDL.Interfaces.RealInput u
-    "Continuous input signal"
+    "Input signal to be sampled"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.RealOutput y
-    "Continuous output signal"
+    "Zero order hold of the input signal"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 protected

--- a/Buildings/Controls/OBC/CDL/Integers/Abs.mo
+++ b/Buildings/Controls/OBC/CDL/Integers/Abs.mo
@@ -2,17 +2,14 @@ within Buildings.Controls.OBC.CDL.Integers;
 block Abs
   "Output the absolute value of the input"
   Buildings.Controls.OBC.CDL.Interfaces.IntegerInput u
-    "Connector of Integer input signals"
+    "Input for absolute function"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.IntegerOutput y
-    "Connector of Integer output signals"
+    "Absolute value of the input"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 equation
-  y=if u >= 0 then
-      u
-    else
-      -u;
+  y=if u >= 0 then u else -u;
   annotation (
     defaultComponentName="absInt",
     Icon(

--- a/Buildings/Controls/OBC/CDL/Integers/Add.mo
+++ b/Buildings/Controls/OBC/CDL/Integers/Add.mo
@@ -2,13 +2,13 @@ within Buildings.Controls.OBC.CDL.Integers;
 block Add
   "Output the sum of the two inputs"
   Buildings.Controls.OBC.CDL.Interfaces.IntegerInput u1
-    "Connector of Integer input signal 1"
+    "Input to be added"
     annotation (Placement(transformation(extent={{-140,40},{-100,80}})));
   Buildings.Controls.OBC.CDL.Interfaces.IntegerInput u2
-    "Connector of Integer input signal 2"
+    "Input to be added"
     annotation (Placement(transformation(extent={{-140,-80},{-100,-40}})));
   Buildings.Controls.OBC.CDL.Interfaces.IntegerOutput y
-    "Connector of Integer output signal"
+    "Sum of the two inputs"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 equation

--- a/Buildings/Controls/OBC/CDL/Integers/AddParameter.mo
+++ b/Buildings/Controls/OBC/CDL/Integers/AddParameter.mo
@@ -1,10 +1,12 @@
 within Buildings.Controls.OBC.CDL.Integers;
 block AddParameter "Output the sum of an input plus a parameter"
   parameter Integer p
-    "Value to be added";
-  Buildings.Controls.OBC.CDL.Interfaces.IntegerInput u "Connector of Integer input signal"
+    "Parameter to be added to the input";
+  Buildings.Controls.OBC.CDL.Interfaces.IntegerInput u
+    "Input to be added to the parameter"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
-  Buildings.Controls.OBC.CDL.Interfaces.IntegerOutput y "Connector of Integer output signal"
+  Buildings.Controls.OBC.CDL.Interfaces.IntegerOutput y
+    "Sum of the parameter and the input"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 equation

--- a/Buildings/Controls/OBC/CDL/Integers/Change.mo
+++ b/Buildings/Controls/OBC/CDL/Integers/Change.mo
@@ -4,16 +4,16 @@ block Change
   parameter Integer pre_u_start=0
     "Start value of pre(u) at initial time";
   Buildings.Controls.OBC.CDL.Interfaces.IntegerInput u
-    "Connector of Integer input signal"
+    "Integer to be monitored for a change in value"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.BooleanOutput y
-    "Connector of Boolean output signal"
+    "Output that is true when the input changes its value"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.BooleanOutput up
-    "Connector of Boolean output signal indicating input increase"
+    "Output that is true when the input increased its value"
     annotation (Placement(transformation(extent={{100,40},{140,80}})));
   Buildings.Controls.OBC.CDL.Interfaces.BooleanOutput down
-    "Connector of Boolean output signal indicating input decrease"
+    "Output that is true when the input decreased its value"
     annotation (Placement(transformation(extent={{100,-80},{140,-40}})));
 
 initial equation

--- a/Buildings/Controls/OBC/CDL/Integers/Equal.mo
+++ b/Buildings/Controls/OBC/CDL/Integers/Equal.mo
@@ -2,13 +2,13 @@ within Buildings.Controls.OBC.CDL.Integers;
 block Equal
   "Output y is true, if input u1 is equal to input u2"
   Buildings.Controls.OBC.CDL.Interfaces.IntegerInput u1
-    "Connector of first Integer input signal"
+    "Input to be checked for equality with other input"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.IntegerInput u2
-    "Connector of second Integer input signal"
+    "Input to be checked for equality with other input"
     annotation (Placement(transformation(extent={{-140,-100},{-100,-60}})));
   Buildings.Controls.OBC.CDL.Interfaces.BooleanOutput y
-    "Connector of Boolean output signal"
+    "Outputs that is true if the two inputs are equal, and false otherwise"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 equation

--- a/Buildings/Controls/OBC/CDL/Integers/Greater.mo
+++ b/Buildings/Controls/OBC/CDL/Integers/Greater.mo
@@ -2,13 +2,13 @@ within Buildings.Controls.OBC.CDL.Integers;
 block Greater
   "Output y is true, if input u1 is greater than input u2"
   Buildings.Controls.OBC.CDL.Interfaces.IntegerInput u1
-    "Connector of first Integer input signal"
+    "First input u1"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.IntegerInput u2
-    "Connector of second Integer input signal"
+    "Second input u2"
     annotation (Placement(transformation(extent={{-140,-100},{-100,-60}})));
   Buildings.Controls.OBC.CDL.Interfaces.BooleanOutput y
-    "Connector of Boolean output signal"
+    "Outputs true if u1 is greater than u2"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 equation

--- a/Buildings/Controls/OBC/CDL/Integers/GreaterEqual.mo
+++ b/Buildings/Controls/OBC/CDL/Integers/GreaterEqual.mo
@@ -2,13 +2,13 @@ within Buildings.Controls.OBC.CDL.Integers;
 block GreaterEqual
   "Output y is true, if input u1 is greater or equal than input u2"
   Buildings.Controls.OBC.CDL.Interfaces.IntegerInput u1
-    "Connector of first Integer input signal"
+    "First input u1"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.IntegerInput u2
-    "Connector of second Integer input signal"
+    "Second input u2"
     annotation (Placement(transformation(extent={{-140,-100},{-100,-60}})));
   Buildings.Controls.OBC.CDL.Interfaces.BooleanOutput y
-    "Connector of Boolean output signal"
+    "Outputs true if u1 is greater or equal than u2"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 equation

--- a/Buildings/Controls/OBC/CDL/Integers/GreaterEqualThreshold.mo
+++ b/Buildings/Controls/OBC/CDL/Integers/GreaterEqualThreshold.mo
@@ -1,13 +1,13 @@
 within Buildings.Controls.OBC.CDL.Integers;
 block GreaterEqualThreshold
-  "Output y is true, if input u is greater or equal than threshold"
+  "Output y is true, if input u is greater or equal than a threshold"
   parameter Integer t=0
-    "Comparison with respect to a threshold";
+    "Threshold against which the input is compared to";
   Buildings.Controls.OBC.CDL.Interfaces.IntegerInput u
-    "Connector of Integer input signal"
+    "Input to be compared against the threshold"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.BooleanOutput y
-    "Connector of Boolean output signal"
+    "Outputs true if u is greater or equal than the threshold"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 equation

--- a/Buildings/Controls/OBC/CDL/Integers/GreaterThreshold.mo
+++ b/Buildings/Controls/OBC/CDL/Integers/GreaterThreshold.mo
@@ -2,12 +2,12 @@ within Buildings.Controls.OBC.CDL.Integers;
 block GreaterThreshold
   "Output y is true, if input u is greater than a threshold"
   parameter Integer t=0
-    "Threshold for comparison";
+    "Threshold against which the input is compared to";
   Buildings.Controls.OBC.CDL.Interfaces.IntegerInput u
-    "Connector of Integer input signal"
+    "Input to be compared against the threshold"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.BooleanOutput y
-    "Connector of Boolean output signal"
+    "Outputs true if u is greater than the threshold"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 equation

--- a/Buildings/Controls/OBC/CDL/Integers/Less.mo
+++ b/Buildings/Controls/OBC/CDL/Integers/Less.mo
@@ -2,13 +2,13 @@ within Buildings.Controls.OBC.CDL.Integers;
 block Less
   "Output y is true, if input u1 is less than input u2"
   Buildings.Controls.OBC.CDL.Interfaces.IntegerInput u1
-    "Connector of first Integer input signal"
+    "First input u1"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.IntegerInput u2
-    "Connector of second Integer input signal"
+    "Second input u2"
     annotation (Placement(transformation(extent={{-140,-100},{-100,-60}})));
   Buildings.Controls.OBC.CDL.Interfaces.BooleanOutput y
-    "Connector of Boolean output signal"
+    "Outputs true if u1 is less than u2"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 equation

--- a/Buildings/Controls/OBC/CDL/Integers/LessEqual.mo
+++ b/Buildings/Controls/OBC/CDL/Integers/LessEqual.mo
@@ -2,13 +2,13 @@ within Buildings.Controls.OBC.CDL.Integers;
 block LessEqual
   "Output y is true, if input u1 is less or equal than input u2"
   Buildings.Controls.OBC.CDL.Interfaces.IntegerInput u1
-    "Connector of first Integer input signal"
+    "First input"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.IntegerInput u2
-    "Connector of second Integer input signal"
+    "Second input"
     annotation (Placement(transformation(extent={{-140,-100},{-100,-60}})));
   Buildings.Controls.OBC.CDL.Interfaces.BooleanOutput y
-    "Connector of Boolean output signal"
+    "Outputs true if u1 is less or equal than u2"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 equation

--- a/Buildings/Controls/OBC/CDL/Integers/LessEqualThreshold.mo
+++ b/Buildings/Controls/OBC/CDL/Integers/LessEqualThreshold.mo
@@ -4,10 +4,10 @@ block LessEqualThreshold
   parameter Integer t=0
     "Threshold for comparison";
   Buildings.Controls.OBC.CDL.Interfaces.IntegerInput u
-    "Connector of Integer input signal"
+    "Input to be compared"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.BooleanOutput y
-    "Connector of Boolean output signal"
+    "Outputs true if u is less or equal than the threshold"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 equation

--- a/Buildings/Controls/OBC/CDL/Integers/LessThreshold.mo
+++ b/Buildings/Controls/OBC/CDL/Integers/LessThreshold.mo
@@ -4,10 +4,10 @@ block LessThreshold
   parameter Integer t=0
     "Threshold for comparison";
   Buildings.Controls.OBC.CDL.Interfaces.IntegerInput u
-    "Connector of Integer input signal"
+    "Input to be compared against the threshold"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.BooleanOutput y
-    "Connector of Boolean output signal"
+    "Outputs true if u is less than the threshold"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 equation

--- a/Buildings/Controls/OBC/CDL/Integers/Max.mo
+++ b/Buildings/Controls/OBC/CDL/Integers/Max.mo
@@ -2,19 +2,17 @@ within Buildings.Controls.OBC.CDL.Integers;
 block Max
   "Pass through the largest signal"
   Buildings.Controls.OBC.CDL.Interfaces.IntegerInput u1
-    "Connector of Integer input signal 1"
+    "Input to the max function"
     annotation (Placement(transformation(extent={{-140,40},{-100,80}})));
   Buildings.Controls.OBC.CDL.Interfaces.IntegerInput u2
-    "Connector of Integer input signal 2"
+    "Input to the max function"
     annotation (Placement(transformation(extent={{-140,-80},{-100,-40}})));
   Buildings.Controls.OBC.CDL.Interfaces.IntegerOutput y
-    "Connector of Integer output signal"
+    "Maximum of the inputs"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 equation
-  y=max(
-    u1,
-    u2);
+  y=max(u1, u2);
   annotation (
     defaultComponentName="maxInt",
     Documentation(

--- a/Buildings/Controls/OBC/CDL/Integers/Min.mo
+++ b/Buildings/Controls/OBC/CDL/Integers/Min.mo
@@ -2,19 +2,17 @@ within Buildings.Controls.OBC.CDL.Integers;
 block Min
   "Pass through the smallest signal"
   Buildings.Controls.OBC.CDL.Interfaces.IntegerInput u1
-    "Connector of Integer input signal 1"
+    "Input to the min function"
     annotation (Placement(transformation(extent={{-140,40},{-100,80}})));
   Buildings.Controls.OBC.CDL.Interfaces.IntegerInput u2
-    "Connector of Integer input signal 2"
+    "Input to the max function"
     annotation (Placement(transformation(extent={{-140,-80},{-100,-40}})));
   Buildings.Controls.OBC.CDL.Interfaces.IntegerOutput y
-    "Connector of Integer output signal"
+    "Minimum of the inputs"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 equation
-  y=min(
-    u1,
-    u2);
+  y=min(u1, u2);
   annotation (
     defaultComponentName="minInt",
     Documentation(

--- a/Buildings/Controls/OBC/CDL/Integers/MultiSum.mo
+++ b/Buildings/Controls/OBC/CDL/Integers/MultiSum.mo
@@ -1,25 +1,20 @@
 within Buildings.Controls.OBC.CDL.Integers;
 block MultiSum
   "Sum of Integers, y = k[1]*u[1] + k[2]*u[2] + ... + k[n]*u[n]"
-  parameter Integer nin(
-    min=0)=0
+  parameter Integer nin(min=0)=0
     "Number of input connections"
     annotation (Dialog(connectorSizing=true),HideResult=true);
-  parameter Integer k[nin]=fill(
-    1,
-    nin)
+  parameter Integer k[nin]=fill(1, nin)
     "Input gains";
   Buildings.Controls.OBC.CDL.Interfaces.IntegerInput u[nin]
-    "Connector of Integer input signals"
+    "Inputs to be multipled with gain and added"
     annotation (Placement(transformation(extent={{-140,70},{-100,-70}})));
   Buildings.Controls.OBC.CDL.Interfaces.IntegerOutput y
-    "Connector of Integer output signal"
+    "Sum of inputs multiplied by the gain"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 equation
-  if size(
-    u,
-    1) > 0 then
+  if size(u, 1) > 0 then
     y=k*u;
   else
     y=0;

--- a/Buildings/Controls/OBC/CDL/Integers/Multiply.mo
+++ b/Buildings/Controls/OBC/CDL/Integers/Multiply.mo
@@ -1,13 +1,13 @@
 within Buildings.Controls.OBC.CDL.Integers;
 block Multiply "Output product of the two inputs"
   Buildings.Controls.OBC.CDL.Interfaces.IntegerInput u1
-    "Connector of Integer input signal 1"
+    "Input for multiplication"
     annotation (Placement(transformation(extent={{-140,40},{-100,80}})));
   Buildings.Controls.OBC.CDL.Interfaces.IntegerInput u2
-    "Connector of Integer input signal 2"
+    "Input for multiplication"
     annotation (Placement(transformation(extent={{-140,-80},{-100,-40}})));
   Buildings.Controls.OBC.CDL.Interfaces.IntegerOutput y
-    "Connector of Integer output signal"
+    "Product of the inputs"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 equation

--- a/Buildings/Controls/OBC/CDL/Integers/OnCounter.mo
+++ b/Buildings/Controls/OBC/CDL/Integers/OnCounter.mo
@@ -4,13 +4,13 @@ block OnCounter
   parameter Integer y_start=0
     "Initial and reset value of y if input reset switches to true";
   Buildings.Controls.OBC.CDL.Interfaces.BooleanInput trigger
-    "Boolean input signal"
+    "Trigger, when set to true, the counter increases"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.BooleanInput reset
-    "Reset the counter"
+    "Reset, when true, the counter is set to y_start"
     annotation (Placement(transformation(extent={{-20,-20},{20,20}},rotation=90,origin={0,-120})));
   Buildings.Controls.OBC.CDL.Interfaces.IntegerOutput y
-    "Integer output signal"
+    "Counter value"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 initial equation

--- a/Buildings/Controls/OBC/CDL/Integers/Sources/Constant.mo
+++ b/Buildings/Controls/OBC/CDL/Integers/Sources/Constant.mo
@@ -4,7 +4,7 @@ block Constant
   parameter Integer k
     "Constant output value";
   Buildings.Controls.OBC.CDL.Interfaces.IntegerOutput y
-    "Connector of Integer output signal"
+    "Output with constant value"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 equation

--- a/Buildings/Controls/OBC/CDL/Integers/Sources/Pulse.mo
+++ b/Buildings/Controls/OBC/CDL/Integers/Sources/Pulse.mo
@@ -20,7 +20,7 @@ block Pulse
   parameter Integer offset=0
     "Offset of output signals";
   Buildings.Controls.OBC.CDL.Interfaces.IntegerOutput y
-    "Connector of Pulse output signal"
+    "Output connector with pulse value"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 protected

--- a/Buildings/Controls/OBC/CDL/Integers/Sources/TimeTable.mo
+++ b/Buildings/Controls/OBC/CDL/Integers/Sources/TimeTable.mo
@@ -12,7 +12,7 @@ block TimeTable
     min=1E-6)
     "Periodicity of table";
   Buildings.Controls.OBC.CDL.Interfaces.IntegerOutput y[nout]
-    "Output of the table"
+    "Output connector with tabulated value"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 protected

--- a/Buildings/Controls/OBC/CDL/Integers/Sources/TimeTable.mo
+++ b/Buildings/Controls/OBC/CDL/Integers/Sources/TimeTable.mo
@@ -12,7 +12,7 @@ block TimeTable
     min=1E-6)
     "Periodicity of table";
   Buildings.Controls.OBC.CDL.Interfaces.IntegerOutput y[nout]
-    "Output connector with tabulated value"
+    "Output with tabulated values"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 protected

--- a/Buildings/Controls/OBC/CDL/Integers/Stage.mo
+++ b/Buildings/Controls/OBC/CDL/Integers/Stage.mo
@@ -20,7 +20,7 @@ block Stage "Output total stages that should be enabled"
   Buildings.Controls.OBC.CDL.Interfaces.RealInput u(
     final min=0,
     final max=1)
-    "Real input for specifying stages"
+    "Input between 0 and 1 for specifying stages"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}}),
       iconTransformation(extent={{-140,-20},{-100,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.IntegerOutput y(

--- a/Buildings/Controls/OBC/CDL/Integers/Subtract.mo
+++ b/Buildings/Controls/OBC/CDL/Integers/Subtract.mo
@@ -1,13 +1,13 @@
 within Buildings.Controls.OBC.CDL.Integers;
 block Subtract "Output the difference of the two inputs"
   Buildings.Controls.OBC.CDL.Interfaces.IntegerInput u1
-    "Connector of Integer input signal 1"
+    "Input u1 for the minuend"
     annotation (Placement(transformation(extent={{-140,40},{-100,80}})));
   Buildings.Controls.OBC.CDL.Interfaces.IntegerInput u2
-    "Connector of Integer input signal 2"
+    "Input u2 for the subtrahend"
     annotation (Placement(transformation(extent={{-140,-80},{-100,-40}})));
   Buildings.Controls.OBC.CDL.Interfaces.IntegerOutput y
-    "Connector of Integer output signal"
+    "Output with the difference u1-u2"
     annotation (Placement(transformation(extent={{100,-20},{140,20}}),
         iconTransformation(extent={{100,-20},{140,20}})));
 

--- a/Buildings/Controls/OBC/CDL/Integers/Switch.mo
+++ b/Buildings/Controls/OBC/CDL/Integers/Switch.mo
@@ -8,7 +8,7 @@ block Switch
     "Boolean switch input signal, if true, y=u1, else y=u3"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.IntegerInput u3
-    "Integer u3"
+    "Input u3"
     annotation (Placement(transformation(extent={{-140,-100},{-100,-60}})));
   Buildings.Controls.OBC.CDL.Interfaces.IntegerOutput y
     "Output with u1 if u2 is true, else u3"

--- a/Buildings/Controls/OBC/CDL/Integers/Switch.mo
+++ b/Buildings/Controls/OBC/CDL/Integers/Switch.mo
@@ -2,23 +2,20 @@ within Buildings.Controls.OBC.CDL.Integers;
 block Switch
   "Switch between two integer signals"
   Buildings.Controls.OBC.CDL.Interfaces.IntegerInput u1
-    "Integer input signal"
+    "Input u1"
     annotation (Placement(transformation(extent={{-140,60},{-100,100}})));
   Buildings.Controls.OBC.CDL.Interfaces.BooleanInput u2
     "Boolean switch input signal, if true, y=u1, else y=u3"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.IntegerInput u3
-    "Integer input signal"
+    "Integer u3"
     annotation (Placement(transformation(extent={{-140,-100},{-100,-60}})));
   Buildings.Controls.OBC.CDL.Interfaces.IntegerOutput y
-    "Integer output signal"
+    "Output with u1 if u2 is true, else u3"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 equation
-  y=if u2 then
-      u1
-    else
-      u3;
+  y=if u2 then u1 else u3;
   annotation (
     defaultComponentName="intSwi",
     Documentation(

--- a/Buildings/Controls/OBC/CDL/Logical/And.mo
+++ b/Buildings/Controls/OBC/CDL/Logical/And.mo
@@ -2,13 +2,13 @@ within Buildings.Controls.OBC.CDL.Logical;
 block And
   "Logical 'and': y = u1 and u2"
   Buildings.Controls.OBC.CDL.Interfaces.BooleanInput u1
-    "Connector of first Boolean input signal"
+    "Input signal for logical 'and'"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.BooleanInput u2
-    "Connector of second Boolean input signal"
+    "Input signal for logical 'and'"
     annotation (Placement(transformation(extent={{-140,-100},{-100,-60}})));
   Buildings.Controls.OBC.CDL.Interfaces.BooleanOutput y
-    "Connector of Boolean output signal"
+    "Outputs true if u1 and u2 are both true"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 equation

--- a/Buildings/Controls/OBC/CDL/Logical/Change.mo
+++ b/Buildings/Controls/OBC/CDL/Logical/Change.mo
@@ -4,10 +4,10 @@ block Change
   parameter Boolean pre_u_start=false
     "Start value of pre(u) at initial time";
   Buildings.Controls.OBC.CDL.Interfaces.BooleanInput u
-    "Connector of Boolean input signal"
+    "Input to be monitored for a change"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.BooleanOutput y
-    "Connector of Boolean output signal"
+    "Output with true when the input changes"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 initial equation

--- a/Buildings/Controls/OBC/CDL/Logical/Edge.mo
+++ b/Buildings/Controls/OBC/CDL/Logical/Edge.mo
@@ -4,10 +4,10 @@ block Edge
   parameter Boolean pre_u_start=false
     "Start value of pre(u) at initial time";
   Buildings.Controls.OBC.CDL.Interfaces.BooleanInput u
-    "Connector of Boolean input signal"
+    "Input to be monitored"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.BooleanOutput y
-    "Connector of Boolean output signal"
+    "Outputs true when the input switches to true"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 initial equation

--- a/Buildings/Controls/OBC/CDL/Logical/FallingEdge.mo
+++ b/Buildings/Controls/OBC/CDL/Logical/FallingEdge.mo
@@ -4,10 +4,10 @@ block FallingEdge
   parameter Boolean pre_u_start=false
     "Start value of pre(u) at initial time";
   Buildings.Controls.OBC.CDL.Interfaces.BooleanInput u
-    "Connector of Boolean input signal"
+    "Input to be monitored"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.BooleanOutput y
-    "Connector of Boolean output signal"
+    "Outputs true when the input switches to false"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 protected

--- a/Buildings/Controls/OBC/CDL/Logical/Latch.mo
+++ b/Buildings/Controls/OBC/CDL/Logical/Latch.mo
@@ -8,7 +8,7 @@ block Latch
     "Clear input"
     annotation (Placement(transformation(extent={{-140,-80},{-100,-40}})));
   Buildings.Controls.OBC.CDL.Interfaces.BooleanOutput y
-    "Output signal"
+    "Output with latched signal"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 equation
   when initial() then

--- a/Buildings/Controls/OBC/CDL/Logical/MultiAnd.mo
+++ b/Buildings/Controls/OBC/CDL/Logical/MultiAnd.mo
@@ -1,15 +1,14 @@
 within Buildings.Controls.OBC.CDL.Logical;
 block MultiAnd
   "Logical MultiAnd, y = u[1] and u[2] and u[3] and ..."
-  parameter Integer nin(
-    min=0)=0
+  parameter Integer nin(min=0)=0
     "Number of input connections"
     annotation (Dialog(connectorSizing=true),HideResult=true);
   Buildings.Controls.OBC.CDL.Interfaces.BooleanInput u[nin]
-    "Connector of Boolean input signals"
+    "Input signals"
     annotation (Placement(transformation(extent={{-140,70},{-100,-70}})));
   Buildings.Controls.OBC.CDL.Interfaces.BooleanOutput y
-    "Connector of Boolean output signal"
+    "Output with true if all input signals are true"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 protected
@@ -17,20 +16,13 @@ protected
     "Temporary variable";
 
 equation
-  if size(
-    u,
-    1) > 1 then
+  if size(u, 1) > 1 then
     uTemp[1]=u[1];
-    for i in 2:size(
-      u,
-      1) loop
+    for i in 2:size(u, 1) loop
       uTemp[i]=u[i] and uTemp[i-1];
     end for;
     y=uTemp[nin];
-  elseif
-        (size(
-    u,
-    1) == 1) then
+  elseif (size(u, 1) == 1) then
     uTemp[1]=u[1];
     y=uTemp[1];
   else

--- a/Buildings/Controls/OBC/CDL/Logical/MultiOr.mo
+++ b/Buildings/Controls/OBC/CDL/Logical/MultiOr.mo
@@ -1,15 +1,14 @@
 within Buildings.Controls.OBC.CDL.Logical;
 block MultiOr
   "Logical MultiOr, y = u[1] or u[2] or u[3] or ..."
-  parameter Integer nin(
-    min=0)=0
+  parameter Integer nin(min=0)=0
     "Number of input connections"
     annotation (Dialog(connectorSizing=true),HideResult=true);
   Buildings.Controls.OBC.CDL.Interfaces.BooleanInput u[nin]
-    "Connector of Boolean input signals"
+    "Input signals"
     annotation (Placement(transformation(extent={{-140,70},{-100,-70}})));
   Buildings.Controls.OBC.CDL.Interfaces.BooleanOutput y
-    "Connector of Boolean output signal"
+    "Output with true if at least one input is true"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 protected
@@ -17,20 +16,13 @@ protected
     "Temporary variable";
 
 equation
-  if size(
-    u,
-    1) > 1 then
+  if size(u, 1) > 1 then
     uTemp[1]=u[1];
-    for i in 2:size(
-      u,
-      1) loop
+    for i in 2:size(u, 1) loop
       uTemp[i]=u[i] or uTemp[i-1];
     end for;
     y=uTemp[nin];
-  elseif
-        (size(
-    u,
-    1) == 1) then
+  elseif (size(u, 1) == 1) then
     uTemp[1]=u[1];
     y=uTemp[1];
   else

--- a/Buildings/Controls/OBC/CDL/Logical/Nand.mo
+++ b/Buildings/Controls/OBC/CDL/Logical/Nand.mo
@@ -2,18 +2,17 @@ within Buildings.Controls.OBC.CDL.Logical;
 block Nand
   "Logical 'nand': y = not (u1 and u2)"
   Buildings.Controls.OBC.CDL.Interfaces.BooleanInput u1
-    "Connector of first Boolean input signal"
+    "Input signal for 'nand'"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.BooleanInput u2
-    "Connector of second Boolean input signal"
+    "Input signal for 'nand'"
     annotation (Placement(transformation(extent={{-140,-100},{-100,-60}})));
   Buildings.Controls.OBC.CDL.Interfaces.BooleanOutput y
-    "Connector of Boolean output signal"
+    "Output with false if both inputs are true"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 equation
-  y=not
-       (u1 and u2);
+  y=not (u1 and u2);
   annotation (
     defaultComponentName="nand",
     Icon(

--- a/Buildings/Controls/OBC/CDL/Logical/Nor.mo
+++ b/Buildings/Controls/OBC/CDL/Logical/Nor.mo
@@ -2,18 +2,17 @@ within Buildings.Controls.OBC.CDL.Logical;
 block Nor
   "Logical 'nor': y = not (u1 or u2)"
   Buildings.Controls.OBC.CDL.Interfaces.BooleanInput u1
-    "Connector of first Boolean input signal"
+    "Input signal for 'nor'"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.BooleanInput u2
-    "Connector of second Boolean input signal"
+    "Input signal for 'nor'"
     annotation (Placement(transformation(extent={{-140,-100},{-100,-60}})));
   Buildings.Controls.OBC.CDL.Interfaces.BooleanOutput y
-    "Connector of Boolean output signal"
+    "Output with false if at least one of the inputs is true"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 equation
-  y=not
-       (u1 or u2);
+  y=not (u1 or u2);
   annotation (
     defaultComponentName="nor",
     Icon(

--- a/Buildings/Controls/OBC/CDL/Logical/Not.mo
+++ b/Buildings/Controls/OBC/CDL/Logical/Not.mo
@@ -1,11 +1,10 @@
 within Buildings.Controls.OBC.CDL.Logical;
-block Not
-  "Logical not"
+block Not "Logical not"
   Buildings.Controls.OBC.CDL.Interfaces.BooleanInput u
-    "Connector of Boolean input signal"
+    "Input to be negated"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.BooleanOutput y
-    "Connector of Boolean output signal"
+    "Output with negated input"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 equation

--- a/Buildings/Controls/OBC/CDL/Logical/Or.mo
+++ b/Buildings/Controls/OBC/CDL/Logical/Or.mo
@@ -2,13 +2,13 @@ within Buildings.Controls.OBC.CDL.Logical;
 block Or
   "Logical 'or': y = u1 or u2"
   Buildings.Controls.OBC.CDL.Interfaces.BooleanInput u1
-    "Connector of first Boolean input signal"
+    "Input for logical 'or'"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.BooleanInput u2
-    "Connector of second Boolean input signal"
+    "Input for logical 'or'"
     annotation (Placement(transformation(extent={{-140,-100},{-100,-60}})));
   Buildings.Controls.OBC.CDL.Interfaces.BooleanOutput y
-    "Connector of Boolean output signal"
+    "Output with true if at least one of the inputs is true"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 equation

--- a/Buildings/Controls/OBC/CDL/Logical/Pre.mo
+++ b/Buildings/Controls/OBC/CDL/Logical/Pre.mo
@@ -1,13 +1,13 @@
 within Buildings.Controls.OBC.CDL.Logical;
 block Pre
-  "Breaks algebraic loops by an infinitesimal small time delay (y = pre(u): event iteration continues until u = pre(u))"
+  "Breaks algebraic loops by adding a delay of the output without advancing time (y = pre(u): event iteration continues until u = pre(u))"
   parameter Boolean pre_u_start=false
     "Start value of pre(u) at initial time";
   Buildings.Controls.OBC.CDL.Interfaces.BooleanInput u
-    "Connector of Boolean input signal"
+    "Input to be delayed by one event iteration"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.BooleanOutput y
-    "Connector of Boolean output signal"
+    "Input delayed by one event iteration"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 initial equation

--- a/Buildings/Controls/OBC/CDL/Logical/Proof.mo
+++ b/Buildings/Controls/OBC/CDL/Logical/Proof.mo
@@ -18,11 +18,11 @@ block Proof "Verify two boolean inputs"
     annotation (Placement(transformation(extent={{-20,-20},{20,20}}, rotation=90, origin={0,-260}),
         iconTransformation(extent={{-20,-20},{20,20}}, rotation=90, origin={0,-120})));
   Buildings.Controls.OBC.CDL.Interfaces.BooleanOutput yLocFal
-    "True: measured input is locked to false even after the setpoint has changed to true"
+    "Output with true if the measured input is locked to false even after the setpoint has changed to true"
     annotation (Placement(transformation(extent={{240,100},{280,140}}),
         iconTransformation(extent={{100,30},{140,70}})));
   Buildings.Controls.OBC.CDL.Interfaces.BooleanOutput yLocTru
-    "True: measured input is locked to true even after the setpoint has changed to false"
+    "Output with true if the measured input is locked to true even after the setpoint has changed to false"
     annotation (Placement(transformation(extent={{240,-140},{280,-100}}),
         iconTransformation(extent={{100,-70},{140,-30}})));
 

--- a/Buildings/Controls/OBC/CDL/Logical/Sources/Constant.mo
+++ b/Buildings/Controls/OBC/CDL/Logical/Sources/Constant.mo
@@ -4,7 +4,7 @@ block Constant
   parameter Boolean k
     "Constant output value";
   Buildings.Controls.OBC.CDL.Interfaces.BooleanOutput y
-    "Connector of Boolean output signal"
+    "Output with constant value"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 equation

--- a/Buildings/Controls/OBC/CDL/Logical/Sources/Pulse.mo
+++ b/Buildings/Controls/OBC/CDL/Logical/Sources/Pulse.mo
@@ -16,7 +16,7 @@ block Pulse
     final unit="s")=0
     "Shift time for output";
   Buildings.Controls.OBC.CDL.Interfaces.BooleanOutput y
-    "Connector of Boolean output signal"
+    "Output with pulse value"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 protected

--- a/Buildings/Controls/OBC/CDL/Logical/Sources/SampleTrigger.mo
+++ b/Buildings/Controls/OBC/CDL/Logical/Sources/SampleTrigger.mo
@@ -11,7 +11,7 @@ block SampleTrigger
     final unit="s")=0
     "Shift time for output";
   Buildings.Controls.OBC.CDL.Interfaces.BooleanOutput y
-    "Connector of Boolean output signal"
+    "Output with trigger value"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 protected
@@ -27,9 +27,7 @@ initial equation
     n=6);
 
 equation
-  y=sample(
-    t0,
-    period);
+  y=sample(t0, period);
   annotation (
     defaultComponentName="samTri",
     Icon(

--- a/Buildings/Controls/OBC/CDL/Logical/Sources/TimeTable.mo
+++ b/Buildings/Controls/OBC/CDL/Logical/Sources/TimeTable.mo
@@ -11,17 +11,13 @@ block TimeTable
     final unit="s")
     "Periodicity of table";
   Buildings.Controls.OBC.CDL.Interfaces.BooleanOutput y[nout]
-    "Output with tabulated value"
+    "Output with tabulated values"
     annotation (Placement(transformation(extent={{120,-20},{160,20}}),iconTransformation(extent={{100,-20},{140,20}})));
 
 protected
-  final parameter Integer nout=size(
-    table,
-    2)-1
+  final parameter Integer nout=size(table, 2)-1
     "Dimension of output vector";
-  final parameter Integer nT=size(
-    table,
-    1)
+  final parameter Integer nT=size(table, 1)
     "Number of table points";
   Integers.Sources.TimeTable intTimTab(
     final table=table,
@@ -29,8 +25,7 @@ protected
     final period=period)
     "Time table"
     annotation (Placement(transformation(extent={{-12,-10},{8,10}})));
-  Integers.GreaterThreshold intGreThr[nout](
-    each t=0)
+  Integers.GreaterThreshold intGreThr[nout](each t=0)
     "Converts to boolean"
     annotation (Placement(transformation(extent={{40,-10},{60,10}})));
 

--- a/Buildings/Controls/OBC/CDL/Logical/Sources/TimeTable.mo
+++ b/Buildings/Controls/OBC/CDL/Logical/Sources/TimeTable.mo
@@ -11,7 +11,7 @@ block TimeTable
     final unit="s")
     "Periodicity of table";
   Buildings.Controls.OBC.CDL.Interfaces.BooleanOutput y[nout]
-    "Output of the table"
+    "Output with tabulated value"
     annotation (Placement(transformation(extent={{120,-20},{160,20}}),iconTransformation(extent={{100,-20},{140,20}})));
 
 protected
@@ -37,16 +37,11 @@ protected
 initial equation
   // Check that all values in the second column are Integer values
   for i in 1:nT loop
-    for j in 2:size(
-      table,
-      2) loop
-      assert(
-        (abs(
-          table[i,j]) < Constants.small) or
-                                           (abs(
-          table[i,j]-1.0) < Constants.small),
-        "Table value table["+String(i)+", "+String(j)+"] = "+String(
-          table[i,j])+" does not equal either 0 or 1.");
+    for j in 2:size(table, 2) loop
+      assert((abs(table[i,j]) < Constants.small) or
+             (abs(table[i,j]-1.0) < Constants.small),
+             "Table value table[" + String(i) + ", " + String(j) + "] = "
+               + String(table[i,j]) + " does not equal either 0 or 1.");
     end for;
   end for;
 

--- a/Buildings/Controls/OBC/CDL/Logical/Switch.mo
+++ b/Buildings/Controls/OBC/CDL/Logical/Switch.mo
@@ -2,23 +2,20 @@ within Buildings.Controls.OBC.CDL.Logical;
 block Switch
   "Switch between two boolean signals"
   Buildings.Controls.OBC.CDL.Interfaces.BooleanInput u1
-    "Boolean input signal"
+    "Input u1"
     annotation (Placement(transformation(extent={{-140,60},{-100,100}})));
   Buildings.Controls.OBC.CDL.Interfaces.BooleanInput u2
     "Boolean switch input signal, if true, y=u1, else y=u3"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.BooleanInput u3
-    "Boolean input signal"
+    "Input u3"
     annotation (Placement(transformation(extent={{-140,-100},{-100,-60}})));
   Buildings.Controls.OBC.CDL.Interfaces.BooleanOutput y
-    "Booelan output signal"
+    "Output with u1 if u2 is true, else u3"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 equation
-  y=if u2 then
-      u1
-    else
-      u3;
+  y=if u2 then u1 else u3;
   annotation (
     defaultComponentName="logSwi",
     Documentation(

--- a/Buildings/Controls/OBC/CDL/Logical/Timer.mo
+++ b/Buildings/Controls/OBC/CDL/Logical/Timer.mo
@@ -14,7 +14,7 @@ block Timer
     "Elapsed time"
     annotation (Placement(transformation(extent={{100,-20},{140,20}}),iconTransformation(extent={{100,-20},{140,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.BooleanOutput passed
-    "True if the elapsed time is greater than threshold"
+    "Output with true if the elapsed time is greater than threshold"
     annotation (Placement(transformation(extent={{100,-100},{140,-60}}),iconTransformation(extent={{100,-100},{140,-60}})));
 
 protected

--- a/Buildings/Controls/OBC/CDL/Logical/TimerAccumulating.mo
+++ b/Buildings/Controls/OBC/CDL/Logical/TimerAccumulating.mo
@@ -17,7 +17,7 @@ block TimerAccumulating
     "Elapsed time"
     annotation (Placement(transformation(extent={{100,-20},{140,20}}),iconTransformation(extent={{100,-20},{140,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.BooleanOutput passed
-    "True if the elapsed time is greater than threshold"
+    "Output with true if the elapsed time is greater than threshold"
     annotation (Placement(transformation(extent={{100,-100},{140,-60}}),iconTransformation(extent={{100,-100},{140,-60}})));
 
 protected

--- a/Buildings/Controls/OBC/CDL/Logical/Toggle.mo
+++ b/Buildings/Controls/OBC/CDL/Logical/Toggle.mo
@@ -8,7 +8,7 @@ block Toggle
     "Clear input"
     annotation (Placement(transformation(extent={{-140,-80},{-100,-40}})));
   Buildings.Controls.OBC.CDL.Interfaces.BooleanOutput y
-    "Output signal"
+    "Output with toggled signal"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 initial equation
@@ -19,25 +19,25 @@ initial equation
 equation
   when initial() then
     //scenario = 1
-    y=if clr then
-        false
-      else
-        u;
-  elsewhen
-          (not clr) and change(u) and
-                                     (pre(u) == false) and
-                                                          (pre(y) == false) then
+    y=if clr then false else u;
+      elsewhen
+	(not clr) and change(u) and
+        (pre(u) == false) and
+        (pre(y) == false)
+      then
     //scenario = 2
     y=true;
   elsewhen
-          (not clr) and change(u) and
-                                     (pre(u) == false) and
-                                                          (pre(y) == true) then
+        (not clr) and change(u) and
+        (pre(u) == false) and
+        (pre(y) == true)
+  then
     //scenario = 3
     y=false;
   elsewhen
-          (not clr) and change(u) and
-                                     (pre(u) == true) then
+       (not clr) and change(u) and
+       (pre(u) == true)
+  then
     //scenario = 4
     y=pre(y);
   elsewhen clr then

--- a/Buildings/Controls/OBC/CDL/Logical/TrueDelay.mo
+++ b/Buildings/Controls/OBC/CDL/Logical/TrueDelay.mo
@@ -1,6 +1,6 @@
 within Buildings.Controls.OBC.CDL.Logical;
 block TrueDelay
-  "Delay a rising edge of the input, but do not delay a falling edge."
+  "Delay a rising edge of the input, but do not delay a falling edge"
   parameter Real delayTime(
     final quantity="Time",
     final unit="s")
@@ -8,10 +8,10 @@ block TrueDelay
   parameter Boolean delayOnInit=false
     "Set to true to delay initial true input";
   Buildings.Controls.OBC.CDL.Interfaces.BooleanInput u
-    "Connector of Boolean input signal"
+    "Input signal to be delayed when it switches to true"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.BooleanOutput y
-    "Connector of Boolean output signal"
+    "Output with delayed input signal after it switched to true"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 protected
@@ -32,22 +32,11 @@ initial equation
 
 equation
   when initial() then
-    t_next=
-      if not delayOnInit then
-        t_past
-      else
-        time+delayTime;
-    y=if not
-            (delayOnInit and delayTime > 0) then
-        u
-      else
-        false;
+    t_next=if not delayOnInit then t_past else time+delayTime;
+    y=if not (delayOnInit and delayTime > 0) then u else false;
   elsewhen u then
     t_next=time+delayTime;
-    y=if delayTime > 0 then
-        false
-      else
-        true;
+    y=if delayTime > 0 then false else true;
   elsewhen not u then
     t_next=t_past;
     y=false;

--- a/Buildings/Controls/OBC/CDL/Logical/TrueFalseHold.mo
+++ b/Buildings/Controls/OBC/CDL/Logical/TrueFalseHold.mo
@@ -4,19 +4,19 @@ block TrueFalseHold
   parameter Real trueHoldDuration(
     final quantity="Time",
     final unit="s")
-    "true hold duration"
+    "Duration of true hold"
     annotation (Evaluate=true);
   parameter Real falseHoldDuration(
     final quantity="Time",
     final unit="s")=trueHoldDuration
-    "false hold duration"
+    "Duration of false hold"
     annotation (Evaluate=true);
   Buildings.Controls.OBC.CDL.Interfaces.BooleanInput u
-    "Boolean input signal"
+    "Input signal that is to be delayed"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}}),
       iconTransformation(extent={{-140,-20},{-100,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.BooleanOutput y
-    "Boolean output signal"
+    "Output with delayed input signal"
     annotation (Placement(transformation(extent={{100,-20},{140,20}}),
       iconTransformation(extent={{100,-20},{140,20}})));
 protected

--- a/Buildings/Controls/OBC/CDL/Logical/VariablePulse.mo
+++ b/Buildings/Controls/OBC/CDL/Logical/VariablePulse.mo
@@ -120,7 +120,7 @@ protected
       n=6);
     t_end = t_sta + u*period;
 
-    y = ((time>=t_sta) and (time<t_end));
+    y = (time>=t_sta) and (time<t_end);
 
   annotation (Icon(
         graphics={

--- a/Buildings/Controls/OBC/CDL/Logical/Xor.mo
+++ b/Buildings/Controls/OBC/CDL/Logical/Xor.mo
@@ -2,19 +2,17 @@ within Buildings.Controls.OBC.CDL.Logical;
 block Xor
   "Logical 'xor': y = u1 xor u2"
   Buildings.Controls.OBC.CDL.Interfaces.BooleanInput u1
-    "Connector of first Boolean input signal"
+    "Input for logical 'xor'"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.BooleanInput u2
-    "Connector of second Boolean input signal"
+    "Input for logical 'xor'"
     annotation (Placement(transformation(extent={{-140,-100},{-100,-60}})));
   Buildings.Controls.OBC.CDL.Interfaces.BooleanOutput y
-    "Connector of Boolean output signal"
+    "Output with u1 xor u2"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 equation
-  y=not
-       ((u1 and u2) or
-                      (not u1 and not u2));
+  y=not ((u1 and u2) or (not u1 and not u2));
   annotation (
     defaultComponentName="xor",
     Icon(

--- a/Buildings/Controls/OBC/CDL/Reals/Abs.mo
+++ b/Buildings/Controls/OBC/CDL/Reals/Abs.mo
@@ -2,10 +2,10 @@ within Buildings.Controls.OBC.CDL.Reals;
 block Abs
   "Output the absolute value of the input"
   Buildings.Controls.OBC.CDL.Interfaces.RealInput u
-    "Connector of Real input signal"
+    "Input for absolute function"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.RealOutput y
-    "Connector of Real output signal"
+    "Absolute value of the input"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 equation

--- a/Buildings/Controls/OBC/CDL/Reals/Acos.mo
+++ b/Buildings/Controls/OBC/CDL/Reals/Acos.mo
@@ -1,10 +1,10 @@
 within Buildings.Controls.OBC.CDL.Reals;
 block Acos "Output the arc cosine of the input"
   Buildings.Controls.OBC.CDL.Interfaces.RealInput u
-    "Connector of Real input signal"
+    "Input for arc cosine function"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
-  Buildings.Controls.OBC.CDL.Interfaces.RealOutput y(unit="rad")
-    "Connector of Real output signal"
+  Buildings.Controls.OBC.CDL.Interfaces.RealOutput y(final unit="rad")
+    "Arc cosine of the input"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 equation
   y = Modelica.Math.acos(u);

--- a/Buildings/Controls/OBC/CDL/Reals/Acos.mo
+++ b/Buildings/Controls/OBC/CDL/Reals/Acos.mo
@@ -3,7 +3,9 @@ block Acos "Output the arc cosine of the input"
   Buildings.Controls.OBC.CDL.Interfaces.RealInput u
     "Input for arc cosine function"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
-  Buildings.Controls.OBC.CDL.Interfaces.RealOutput y(final unit="rad")
+  Buildings.Controls.OBC.CDL.Interfaces.RealOutput y(
+    final unit="rad",
+    displayUnit="deg")
     "Arc cosine of the input"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 equation
@@ -58,6 +60,11 @@ Block that outputs <code>y = acos(u)</code>, where <code>u</code> is an input.
 </html>",
 revisions="<html>
 <ul>
+<li>
+November 8, 2024, by Michael Wetter:<br/>
+Added <code>final</code> keyword to unit declaration as block is only valid for this unit.<br/>
+Also added <code>displayUnit</code> keyword.
+</li>
 <li>
 March 7, 2023, by Jianjun Hu:<br/>
 Added unit <code>rad</code> to the output.<br/>

--- a/Buildings/Controls/OBC/CDL/Reals/Add.mo
+++ b/Buildings/Controls/OBC/CDL/Reals/Add.mo
@@ -2,13 +2,13 @@ within Buildings.Controls.OBC.CDL.Reals;
 block Add
   "Output the sum of the two inputs"
   Buildings.Controls.OBC.CDL.Interfaces.RealInput u1
-    "Connector of Real input signal 1"
+    "Input to be added"
     annotation (Placement(transformation(extent={{-140,40},{-100,80}})));
   Buildings.Controls.OBC.CDL.Interfaces.RealInput u2
-    "Connector of Real input signal 2"
+    "Input to be added"
     annotation (Placement(transformation(extent={{-140,-80},{-100,-40}})));
   Buildings.Controls.OBC.CDL.Interfaces.RealOutput y
-    "Connector of Real output signal"
+    "Sum of the inputs"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 equation

--- a/Buildings/Controls/OBC/CDL/Reals/AddParameter.mo
+++ b/Buildings/Controls/OBC/CDL/Reals/AddParameter.mo
@@ -1,11 +1,12 @@
 within Buildings.Controls.OBC.CDL.Reals;
-block AddParameter
-  "Output the sum of an input plus a parameter"
+block AddParameter "Output the sum of an input plus a parameter"
   parameter Real p
-    "Value to be added";
-  Buildings.Controls.OBC.CDL.Interfaces.RealInput u "Connector of Real input signal"
+    "Parameter to be added to the input";
+  Buildings.Controls.OBC.CDL.Interfaces.RealInput u
+    "Input to be added to the parameter"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
-  Buildings.Controls.OBC.CDL.Interfaces.RealOutput y "Connector of Real output signal"
+  Buildings.Controls.OBC.CDL.Interfaces.RealOutput y
+    "Sum of the parameter and the input"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 equation

--- a/Buildings/Controls/OBC/CDL/Reals/Asin.mo
+++ b/Buildings/Controls/OBC/CDL/Reals/Asin.mo
@@ -3,7 +3,9 @@ block Asin "Output the arc sine of the input"
   Buildings.Controls.OBC.CDL.Interfaces.RealInput u
     "Input for the arc sine function"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
-  Buildings.Controls.OBC.CDL.Interfaces.RealOutput y(unit="rad")
+  Buildings.Controls.OBC.CDL.Interfaces.RealOutput y(
+    final unit="rad",
+    displayUnit="deg")
     "Arc sin of the input"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 equation
@@ -58,6 +60,11 @@ Block that outputs <code>y = asin(u)</code>, where <code>u</code> is an input.
 </html>",
 revisions="<html>
 <ul>
+<li>
+November 8, 2024, by Michael Wetter:<br/>
+Added <code>final</code> keyword to unit declaration as block is only valid for this unit.<br/>
+Also added <code>displayUnit</code> keyword.
+</li>
 <li>
 March 7, 2023, by Jianjun Hu:<br/>
 Added unit <code>rad</code> to the output.<br/>

--- a/Buildings/Controls/OBC/CDL/Reals/Asin.mo
+++ b/Buildings/Controls/OBC/CDL/Reals/Asin.mo
@@ -1,10 +1,10 @@
 within Buildings.Controls.OBC.CDL.Reals;
 block Asin "Output the arc sine of the input"
   Buildings.Controls.OBC.CDL.Interfaces.RealInput u
-    "Connector of Real input signal"
+    "Input for the arc sine function"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.RealOutput y(unit="rad")
-    "Connector of Real output signal"
+    "Arc sin of the input"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 equation
   y = Modelica.Math.asin(u);

--- a/Buildings/Controls/OBC/CDL/Reals/Atan.mo
+++ b/Buildings/Controls/OBC/CDL/Reals/Atan.mo
@@ -3,7 +3,9 @@ block Atan "Output the arc tangent of the input"
   Buildings.Controls.OBC.CDL.Interfaces.RealInput u
     "Input for the arc tangent function"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
-  Buildings.Controls.OBC.CDL.Interfaces.RealOutput y(unit="rad")
+  Buildings.Controls.OBC.CDL.Interfaces.RealOutput y(
+    final unit="rad",
+    displayUnit="deg")
     "Arc tangent of the input"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
@@ -66,6 +68,11 @@ Block that outputs <code>y = atan(u)</code>, where <code>u</code> is an input.
 </html>",
 revisions="<html>
 <ul>
+<li>
+November 8, 2024, by Michael Wetter:<br/>
+Added <code>final</code> keyword to unit declaration as block is only valid for this unit.<br/>
+Also added <code>displayUnit</code> keyword.
+</li>
 <li>
 March 7, 2023, by Jianjun Hu:<br/>
 Added unit <code>rad</code> to the output.<br/>

--- a/Buildings/Controls/OBC/CDL/Reals/Atan.mo
+++ b/Buildings/Controls/OBC/CDL/Reals/Atan.mo
@@ -1,11 +1,10 @@
 within Buildings.Controls.OBC.CDL.Reals;
-block Atan
-  "Output the arc tangent of the input"
+block Atan "Output the arc tangent of the input"
   Buildings.Controls.OBC.CDL.Interfaces.RealInput u
-    "Connector of Real input signal"
+    "Input for the arc tangent function"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.RealOutput y(unit="rad")
-    "Connector of Real output signal"
+    "Arc tangent of the input"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 equation

--- a/Buildings/Controls/OBC/CDL/Reals/Atan2.mo
+++ b/Buildings/Controls/OBC/CDL/Reals/Atan2.mo
@@ -2,19 +2,17 @@ within Buildings.Controls.OBC.CDL.Reals;
 block Atan2
   "Output atan(u1/u2) of the inputs u1 and u2"
   Buildings.Controls.OBC.CDL.Interfaces.RealInput u1
-    "Connector of Real input signal 1"
+    "Input u1 for the atan2(u1/u2) function"
     annotation (Placement(transformation(extent={{-140,40},{-100,80}})));
   Buildings.Controls.OBC.CDL.Interfaces.RealInput u2
-    "Connector of Real input signal 2"
+    "Input u2 for the atan2(u1/u2) function"
     annotation (Placement(transformation(extent={{-140,-80},{-100,-40}})));
   Buildings.Controls.OBC.CDL.Interfaces.RealOutput y(unit="rad")
-    "Connector of Real output signal"
+    "Output with atan2(u1/u2)"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 equation
-  y=Modelica.Math.atan2(
-    u1,
-    u2);
+  y=Modelica.Math.atan2(u1, u2);
   annotation (
     defaultComponentName="atan2",
     Documentation(

--- a/Buildings/Controls/OBC/CDL/Reals/Atan2.mo
+++ b/Buildings/Controls/OBC/CDL/Reals/Atan2.mo
@@ -7,7 +7,9 @@ block Atan2
   Buildings.Controls.OBC.CDL.Interfaces.RealInput u2
     "Input u2 for the atan2(u1/u2) function"
     annotation (Placement(transformation(extent={{-140,-80},{-100,-40}})));
-  Buildings.Controls.OBC.CDL.Interfaces.RealOutput y(unit="rad")
+  Buildings.Controls.OBC.CDL.Interfaces.RealOutput y(
+    final unit="rad",
+    displayUnit="deg")
     "Output with atan2(u1/u2)"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
@@ -40,6 +42,11 @@ gives a solution in the range
 </html>",
       revisions="<html>
 <ul>
+<li>
+November 8, 2024, by Michael Wetter:<br/>
+Added <code>final</code> keyword to unit declaration as block is only valid for this unit.<br/>
+Also added <code>displayUnit</code> keyword.
+</li>
 <li>
 March 7, 2023, by Jianjun Hu:<br/>
 Added unit <code>rad</code> to the output.<br/>

--- a/Buildings/Controls/OBC/CDL/Reals/Average.mo
+++ b/Buildings/Controls/OBC/CDL/Reals/Average.mo
@@ -1,14 +1,13 @@
 within Buildings.Controls.OBC.CDL.Reals;
-block Average
-  "Output the average of its two inputs"
+block Average "Output the average of its two inputs"
   Buildings.Controls.OBC.CDL.Interfaces.RealInput u1
-    "Connector of Real input signal 1"
+    "Input for average function"
     annotation (Placement(transformation(extent={{-140,40},{-100,80}}),iconTransformation(extent={{-140,40},{-100,80}})));
   Buildings.Controls.OBC.CDL.Interfaces.RealInput u2
-    "Connector of Real input signal 2"
+    "Input for average function"
     annotation (Placement(transformation(extent={{-140,-80},{-100,-40}}),iconTransformation(extent={{-140,-80},{-100,-40}})));
   Buildings.Controls.OBC.CDL.Interfaces.RealOutput y
-    "Connector of Real output signal"
+    "Output with the average of the two inputs"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 equation

--- a/Buildings/Controls/OBC/CDL/Reals/Cos.mo
+++ b/Buildings/Controls/OBC/CDL/Reals/Cos.mo
@@ -1,11 +1,11 @@
 within Buildings.Controls.OBC.CDL.Reals;
 block Cos
   "Output the cosine of the input"
-  Buildings.Controls.OBC.CDL.Interfaces.RealInput u(unit="rad")
-    "Connector of Real input signal"
+  Buildings.Controls.OBC.CDL.Interfaces.RealInput u(final unit="rad")
+    "Input for the cosine function"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.RealOutput y
-    "Connector of Real output signal"
+    "Cosine of the input"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 equation

--- a/Buildings/Controls/OBC/CDL/Reals/Cos.mo
+++ b/Buildings/Controls/OBC/CDL/Reals/Cos.mo
@@ -1,7 +1,8 @@
 within Buildings.Controls.OBC.CDL.Reals;
-block Cos
-  "Output the cosine of the input"
-  Buildings.Controls.OBC.CDL.Interfaces.RealInput u(final unit="rad")
+block Cos "Output the cosine of the input"
+  Buildings.Controls.OBC.CDL.Interfaces.RealInput u(
+    final unit="rad",
+    displayUnit="deg")
     "Input for the cosine function"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.RealOutput y
@@ -71,6 +72,11 @@ where
 </html>",
       revisions="<html>
 <ul>
+<li>
+November 8, 2024, by Michael Wetter:<br/>
+Added <code>final</code> keyword to unit declaration as block is only valid for this unit.<br/>
+Also added <code>displayUnit</code> keyword.
+</li>
 <li>
 March 7, 2023, by Jianjun Hu:<br/>
 Added unit <code>rad</code> to the input.<br/>

--- a/Buildings/Controls/OBC/CDL/Reals/Derivative.mo
+++ b/Buildings/Controls/OBC/CDL/Reals/Derivative.mo
@@ -6,13 +6,13 @@ block Derivative
     annotation (Dialog(group="Initialization"));
 
   Buildings.Controls.OBC.CDL.Interfaces.RealInput k
-    "Connector for gain signal"
+    "Input for the gain"
     annotation (Placement(transformation(extent={{-140,60},{-100,100}})));
   Buildings.Controls.OBC.CDL.Interfaces.RealInput T(
     final quantity="Time",
     final unit="s",
     min=100*Buildings.Controls.OBC.CDL.Constants.eps)
-    "Time constant (T>0 required; T=0 is ideal derivative block)"
+    "Input for the time constant (T>0 required; T=0 is ideal derivative block)"
     annotation (Placement(transformation(extent={{-140,20},{-100,60}})));
   Buildings.Controls.OBC.CDL.Interfaces.RealInput u
     "Input to be differentiated"

--- a/Buildings/Controls/OBC/CDL/Reals/Divide.mo
+++ b/Buildings/Controls/OBC/CDL/Reals/Divide.mo
@@ -1,13 +1,13 @@
 within Buildings.Controls.OBC.CDL.Reals;
 block Divide "Output first input divided by second input"
   Buildings.Controls.OBC.CDL.Interfaces.RealInput u1
-    "Connector for dividend"
+    "Input for dividend"
     annotation (Placement(transformation(extent={{-140,40},{-100,80}})));
   Buildings.Controls.OBC.CDL.Interfaces.RealInput u2
-    "Connector for divisor"
+    "Input for divisor"
     annotation (Placement(transformation(extent={{-140,-80},{-100,-40}})));
   Buildings.Controls.OBC.CDL.Interfaces.RealOutput y
-    "Connector for quotient"
+    "Output with the quotient"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 equation

--- a/Buildings/Controls/OBC/CDL/Reals/Exp.mo
+++ b/Buildings/Controls/OBC/CDL/Reals/Exp.mo
@@ -1,11 +1,10 @@
 within Buildings.Controls.OBC.CDL.Reals;
-block Exp
-  "Output the exponential (base e) of the input"
+block Exp "Output the exponential (base e) of the input"
   Buildings.Controls.OBC.CDL.Interfaces.RealInput u
-    "Connector of Real input signal"
+    "Input for the base e exponential function"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.RealOutput y
-    "Connector of Real output signal"
+    "Base e exponential value of the input"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 equation

--- a/Buildings/Controls/OBC/CDL/Reals/Greater.mo
+++ b/Buildings/Controls/OBC/CDL/Reals/Greater.mo
@@ -1,6 +1,6 @@
 within Buildings.Controls.OBC.CDL.Reals;
 block Greater
-  "Output y is true, if input u1 is greater than input u2"
+  "Output y is true, if input u1 is greater than input u2 with hysteresis"
   parameter Real h(
     final min=0)=0
     "Hysteresis"
@@ -9,13 +9,13 @@ block Greater
     "Value of pre(y) at initial time"
     annotation (Dialog(tab="Advanced"));
   Buildings.Controls.OBC.CDL.Interfaces.RealInput u1
-    "Input u1"
+    "First input u1"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.RealInput u2
-    "Input u2"
+    "Second input u2"
     annotation (Placement(transformation(extent={{-140,-100},{-100,-60}})));
   Buildings.Controls.OBC.CDL.Interfaces.BooleanOutput y
-    "Output y"
+    "Output true if u1 is greater than u2 with hysteresis"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 protected

--- a/Buildings/Controls/OBC/CDL/Reals/GreaterThreshold.mo
+++ b/Buildings/Controls/OBC/CDL/Reals/GreaterThreshold.mo
@@ -1,6 +1,6 @@
 within Buildings.Controls.OBC.CDL.Reals;
 block GreaterThreshold
-  "Output y is true, if input u is greater than threshold"
+  "Output y is true, if input u is greater than threshold with hysteresis"
   parameter Real t=0
     "Threshold for comparison";
   parameter Real h(
@@ -11,10 +11,10 @@ block GreaterThreshold
     "Value of pre(y) at initial time"
     annotation (Dialog(tab="Advanced"));
   Buildings.Controls.OBC.CDL.Interfaces.RealInput u
-    "Input"
+    "Input to be compared against the threshold"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.BooleanOutput y
-    "Output"
+    "Outputs true if u is greater than the threshold with hysteresis"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 protected

--- a/Buildings/Controls/OBC/CDL/Reals/Hysteresis.mo
+++ b/Buildings/Controls/OBC/CDL/Reals/Hysteresis.mo
@@ -8,15 +8,14 @@ block Hysteresis
   parameter Boolean pre_y_start=false
     "Value of pre(y) at initial time";
   Buildings.Controls.OBC.CDL.Interfaces.RealInput u
-    "Real input signal"
+    "Input to be compared against hysteresis values"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.BooleanOutput y
-    "Boolean output signal"
+    "Output value of comparison"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 initial equation
-  assert(
-    uHigh > uLow,
+  assert(uHigh > uLow,
     "Hysteresis limits wrong. uHigh must be larger than uLow");
   pre(y)=pre_y_start;
 

--- a/Buildings/Controls/OBC/CDL/Reals/IntegratorWithReset.mo
+++ b/Buildings/Controls/OBC/CDL/Reals/IntegratorWithReset.mo
@@ -7,16 +7,16 @@ block IntegratorWithReset
     "Initial or guess value of output (= state)"
     annotation (Dialog(group="Initialization"));
   Buildings.Controls.OBC.CDL.Interfaces.RealInput u
-    "Connector of Real input signal"
+    "Input to be integrated"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.RealInput y_reset_in
     "Input signal for state to which integrator is reset"
     annotation (Placement(transformation(extent={{-140,-100},{-100,-60}})));
   Buildings.Controls.OBC.CDL.Interfaces.BooleanInput trigger
-    "Resets the integrator output when trigger becomes true"
+    "Input that resets the integrator output when it becomes true"
     annotation (Placement(transformation(extent={{-20,-20},{20,20}},rotation=90,origin={0,-120}),iconTransformation(extent={{-20,-20},{20,20}},rotation=90,origin={0,-120})));
   Buildings.Controls.OBC.CDL.Interfaces.RealOutput y
-    "Connector of Real output signal"
+    "Value of the integrator"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 initial equation
@@ -25,9 +25,7 @@ initial equation
 equation
   der(y)=k*u;
   when trigger then
-    reinit(
-      y,
-      y_reset_in);
+    reinit(y, y_reset_in);
   end when;
   annotation (
     defaultComponentName="intWitRes",

--- a/Buildings/Controls/OBC/CDL/Reals/Less.mo
+++ b/Buildings/Controls/OBC/CDL/Reals/Less.mo
@@ -1,21 +1,20 @@
 within Buildings.Controls.OBC.CDL.Reals;
 block Less
   "Output y is true, if input u1 is less than input u2"
-  parameter Real h(
-    final min=0)=0
+  parameter Real h(final min=0)=0
     "Hysteresis"
     annotation (Evaluate=true);
   parameter Boolean pre_y_start=false
     "Value of pre(y) at initial time"
     annotation (Dialog(tab="Advanced"));
   Buildings.Controls.OBC.CDL.Interfaces.RealInput u1
-    "Input u1"
+    "First input u1"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.RealInput u2
-    "Input u2"
+    "Second input u2"
     annotation (Placement(transformation(extent={{-140,-100},{-100,-60}})));
   Buildings.Controls.OBC.CDL.Interfaces.BooleanOutput y
-    "Output y"
+    "Outputs true if u1 is less than u2"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 protected
@@ -62,8 +61,7 @@ protected
 
   block LessWithHysteresis
     "Less block without hysteresis"
-    parameter Real h(
-      final min=0)=0
+    parameter Real h(final min=0)=0
       "Hysteresis"
       annotation (Evaluate=true);
     parameter Boolean pre_y_start=false
@@ -80,8 +78,7 @@ protected
       annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
   initial equation
-    assert(
-      h >= 0,
+    assert(h >= 0,
       "Hysteresis must not be negative");
     pre(y)=pre_y_start;
 

--- a/Buildings/Controls/OBC/CDL/Reals/LessThreshold.mo
+++ b/Buildings/Controls/OBC/CDL/Reals/LessThreshold.mo
@@ -1,20 +1,19 @@
 within Buildings.Controls.OBC.CDL.Reals;
 block LessThreshold
-  "Output y is true, if input u is less than threshold"
+  "Output y is true, if input u is less than threshold with hysteresis"
   parameter Real t=0
     "Threshold for comparison";
-  parameter Real h(
-    final min=0)=0
+  parameter Real h(final min=0)=0
     "Hysteresis"
     annotation (Evaluate=true);
   parameter Boolean pre_y_start=false
     "Value of pre(y) at initial time"
     annotation (Dialog(tab="Advanced"));
   Buildings.Controls.OBC.CDL.Interfaces.RealInput u
-    "Input"
+    "Input to be compared against the threshold"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.BooleanOutput y
-    "Output"
+    "Outputs true if u is less than the threshold with hysteresis"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 protected
@@ -79,8 +78,7 @@ protected
       annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
   initial equation
-    assert(
-      h >= 0,
+    assert(h >= 0,
       "Hysteresis must not be negative");
     pre(y)=pre_y_start;
 

--- a/Buildings/Controls/OBC/CDL/Reals/LimitSlewRate.mo
+++ b/Buildings/Controls/OBC/CDL/Reals/LimitSlewRate.mo
@@ -27,11 +27,9 @@ protected
     "Approximation to derivative between input and output";
 
 initial equation
-  assert(
-    raisingSlewRate > 0,
+  assert(raisingSlewRate > 0,
     "raisingSlewRate must be larger than zero.");
-  assert(
-    fallingSlewRate < 0,
+  assert(fallingSlewRate < 0,
     "fallingSlewRate must be less than zero.");
 
   y=u;

--- a/Buildings/Controls/OBC/CDL/Reals/Limiter.mo
+++ b/Buildings/Controls/OBC/CDL/Reals/Limiter.mo
@@ -6,15 +6,14 @@ block Limiter
   parameter Real uMin
     "Lower limit of input signal";
   Buildings.Controls.OBC.CDL.Interfaces.RealInput u
-    "Connector of Real input signal"
+    "Input to be limited"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.RealOutput y
-    "Connector of Real output signal"
+    "Limited value of input signal"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 initial equation
-  assert(
-    uMin < uMax,
+  assert(uMin < uMax,
     "uMin must be smaller than uMax. Check parameters.");
 
 equation

--- a/Buildings/Controls/OBC/CDL/Reals/Line.mo
+++ b/Buildings/Controls/OBC/CDL/Reals/Line.mo
@@ -8,59 +8,51 @@ block Line
     "If true, limit input u to be no larger than x2"
     annotation (Evaluate=true);
   Buildings.Controls.OBC.CDL.Interfaces.RealInput x1
-    "Support point x1, with x1 < x2"
+    "Input for support point x1, with x1 < x2"
     annotation (Placement(transformation(extent={{-140,60},{-100,100}})));
   Buildings.Controls.OBC.CDL.Interfaces.RealInput f1
-    "Support point f(x1)"
+    "Input for support point f(x1)"
     annotation (Placement(transformation(extent={{-140,20},{-100,60}})));
   Buildings.Controls.OBC.CDL.Interfaces.RealInput x2
-    "Support point x2, with x2 > x1"
+    "Input for support point x2, with x2 > x1"
     annotation (Placement(transformation(extent={{-140,-60},{-100,-20}})));
   Buildings.Controls.OBC.CDL.Interfaces.RealInput f2
-    "Support point f(x2)"
+    "Input for support point f(x2)"
     annotation (Placement(transformation(extent={{-140,-100},{-100,-60}})));
   Buildings.Controls.OBC.CDL.Interfaces.RealInput u
-    "Independent variable"
+    "Input for independent variable"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.RealOutput y
-    "f(x) along the line specified by (x1, f1) and (x2, f2)"
+    "Output with f(x) along the line specified by (x1, f1) and (x2, f2)"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 protected
-  Real a
-    "Intercept";
-  Real b
-    "Slope";
-  Real xLim
-    "Input value after applying the limits";
+  Real a "Intercept";
+  Real b "Slope";
+  Real xLim "Input value after applying the limits";
 
 equation
   if limitBelow or limitAbove then
-    assert(
-      x2 > x1,
-      "x2 must be bigger than x1 in "+getInstanceName(),
+    assert(x2 > x1,
+      "x2 must be bigger than x1 in " + getInstanceName(),
       AssertionLevel.warning);
   end if;
+
   b=(f2-f1)/(x2-x1);
   a=f2-b*x2;
+
   if limitBelow and limitAbove then
-    xLim=min(
-      x2,
-      max(
-        x1,
-        u));
+    xLim=min(x2, max(x1, u));
   elseif limitBelow then
-    xLim=max(
-      x1,
-      u);
+    xLim=max(x1, u);
   elseif limitAbove then
-    xLim=min(
-      x2,
-      u);
+    xLim=min(x2, u);
   else
     xLim=u;
   end if;
-  y=a+b*xLim;
+
+  y = a + b * xLim;
+
   annotation (
     defaultComponentName="lin",
     Icon(

--- a/Buildings/Controls/OBC/CDL/Reals/Log.mo
+++ b/Buildings/Controls/OBC/CDL/Reals/Log.mo
@@ -2,10 +2,10 @@ within Buildings.Controls.OBC.CDL.Reals;
 block Log
   "Output the natural (base e) logarithm of the input (input > 0 required)"
   Buildings.Controls.OBC.CDL.Interfaces.RealInput u
-    "Connector of Real input signal"
+    "Input for base e logarithm"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.RealOutput y
-    "Connector of Real output signal"
+    "Base e logarithm of the input"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 equation

--- a/Buildings/Controls/OBC/CDL/Reals/Log10.mo
+++ b/Buildings/Controls/OBC/CDL/Reals/Log10.mo
@@ -2,10 +2,10 @@ within Buildings.Controls.OBC.CDL.Reals;
 block Log10
   "Output the base 10 logarithm of the input (input > 0 required)"
   Buildings.Controls.OBC.CDL.Interfaces.RealInput u
-    "Connector of Real input signal"
+    "Input for base 10 logarithm"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.RealOutput y
-    "Connector of Real output signal"
+    "Base 10 logarithm of the input"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 equation

--- a/Buildings/Controls/OBC/CDL/Reals/MatrixGain.mo
+++ b/Buildings/Controls/OBC/CDL/Reals/MatrixGain.mo
@@ -1,25 +1,19 @@
 within Buildings.Controls.OBC.CDL.Reals;
 block MatrixGain
   "Output the product of a gain matrix with the input signal vector"
-  parameter Real K[:,:]=[
-    1,0;
-    0,1]
+  parameter Real K[:,:]=[1, 0; 0, 1]
     "Gain matrix which is multiplied with the input";
   Buildings.Controls.OBC.CDL.Interfaces.RealInput u[nin]
-    "Connector of Real input signals"
+    "Input to be multiplied with the gain matrix"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.RealOutput y[nout]
-    "Connector of Real output signals"
+    "Product of gain matrix times the input"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 protected
-  parameter Integer nin=size(
-    K,
-    2)
+  parameter Integer nin=size(K, 2)
     "Number of inputs";
-  parameter Integer nout=size(
-    K,
-    1)
+  parameter Integer nout=size(K, 1)
     "Number of outputs";
 
 equation

--- a/Buildings/Controls/OBC/CDL/Reals/MatrixMax.mo
+++ b/Buildings/Controls/OBC/CDL/Reals/MatrixMax.mo
@@ -3,25 +3,16 @@ block MatrixMax
   "Output vector of row- or column-wise maximum of the input matrix"
   parameter Boolean rowMax=true
     "If true, outputs row-wise maximum, otherwise column-wise";
-  parameter Integer nRow(
-    final min=1)
+  parameter Integer nRow(final min=1)
     "Number of rows in input matrix";
-  parameter Integer nCol(
-    final min=1)
+  parameter Integer nCol(final min=1)
     "Number of columns in input matrix";
-  Buildings.Controls.OBC.CDL.Interfaces.RealInput u[nRow,nCol]
-    "Connector of Real input signals"
+  Buildings.Controls.OBC.CDL.Interfaces.RealInput u[nRow, nCol]
+    "Input for the matrix max function"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.RealOutput y[
-    if rowMax then
-      size(
-        u,
-        1)
-    else
-      size(
-        u,
-        2)]
-    "Connector of Real output signals"
+    if rowMax then size(u, 1) else size(u, 2)]
+    "Output with vector of row- or colum-wise maximum of the input matrix"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 equation

--- a/Buildings/Controls/OBC/CDL/Reals/MatrixMin.mo
+++ b/Buildings/Controls/OBC/CDL/Reals/MatrixMin.mo
@@ -3,25 +3,16 @@ block MatrixMin
   "Output vector of row- or column-wise minimum values"
   parameter Boolean rowMin=true
     "If true, outputs row-wise minimum, otherwise column-wise";
-  parameter Integer nRow(
-    final min=1)
+  parameter Integer nRow(final min=1)
     "Number of rows in input matrix";
-  parameter Integer nCol(
-    final min=1)
+  parameter Integer nCol(final min=1)
     "Number of columns in input matrix";
-  Buildings.Controls.OBC.CDL.Interfaces.RealInput u[nRow,nCol]
-    "Connector of Real input signals"
+  Buildings.Controls.OBC.CDL.Interfaces.RealInput u[nRow, nCol]
+    "Input for the matrix min function"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.RealOutput y[
-    if rowMin then
-      size(
-        u,
-        1)
-    else
-      size(
-        u,
-        2)]
-    "Connector of Real output signals"
+    if rowMin then size(u, 1) else size(u, 2)]
+    "Output with vector of row- or colum-wise minimum of the input matrix"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 equation

--- a/Buildings/Controls/OBC/CDL/Reals/Max.mo
+++ b/Buildings/Controls/OBC/CDL/Reals/Max.mo
@@ -2,19 +2,17 @@ within Buildings.Controls.OBC.CDL.Reals;
 block Max
   "Pass through the largest signal"
   Buildings.Controls.OBC.CDL.Interfaces.RealInput u1
-    "Connector of Real input signal 1"
+    "Input to the max function"
     annotation (Placement(transformation(extent={{-140,40},{-100,80}})));
   Buildings.Controls.OBC.CDL.Interfaces.RealInput u2
-    "Connector of Real input signal 2"
+    "Input to the max function"
     annotation (Placement(transformation(extent={{-140,-80},{-100,-40}})));
   Buildings.Controls.OBC.CDL.Interfaces.RealOutput y
-    "Connector of Real output signal"
+    "Maximum of the inputs"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 equation
-  y=max(
-    u1,
-    u2);
+  y=max(u1, u2);
   annotation (
     defaultComponentName="max",
     Documentation(

--- a/Buildings/Controls/OBC/CDL/Reals/Min.mo
+++ b/Buildings/Controls/OBC/CDL/Reals/Min.mo
@@ -2,19 +2,17 @@ within Buildings.Controls.OBC.CDL.Reals;
 block Min
   "Pass through the smallest signal"
   Buildings.Controls.OBC.CDL.Interfaces.RealInput u1
-    "Connector of Real input signal 1"
+    "Input to the min function"
     annotation (Placement(transformation(extent={{-140,40},{-100,80}})));
   Buildings.Controls.OBC.CDL.Interfaces.RealInput u2
-    "Connector of Real input signal 2"
+    "Input to the min function"
     annotation (Placement(transformation(extent={{-140,-80},{-100,-40}})));
   Buildings.Controls.OBC.CDL.Interfaces.RealOutput y
-    "Connector of Real output signal"
+    "Minimum of the inputs"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 equation
-  y=min(
-    u1,
-    u2);
+  y=min(u1, u2);
   annotation (
     defaultComponentName="min",
     Documentation(

--- a/Buildings/Controls/OBC/CDL/Reals/Modulo.mo
+++ b/Buildings/Controls/OBC/CDL/Reals/Modulo.mo
@@ -2,19 +2,17 @@ within Buildings.Controls.OBC.CDL.Reals;
 block Modulo
   "Output the remainder of first input divided by second input (~=0)"
   Buildings.Controls.OBC.CDL.Interfaces.RealInput u1
-    "Connector of Real input signal 1"
+    "Dividend of the modulus function"
     annotation (Placement(transformation(extent={{-140,40},{-100,80}})));
   Buildings.Controls.OBC.CDL.Interfaces.RealInput u2
-    "Connector of Real input signal 2"
+    "Divisor of the modulus function"
     annotation (Placement(transformation(extent={{-140,-80},{-100,-40}})));
   Buildings.Controls.OBC.CDL.Interfaces.RealOutput y
-    "Connector of Real output signal"
+    "Modulus u1 mod u2"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 equation
-  y=mod(
-    u1,
-    u2);
+  y=mod(u1, u2);
   annotation (
     defaultComponentName="mod",
     Icon(

--- a/Buildings/Controls/OBC/CDL/Reals/MovingAverage.mo
+++ b/Buildings/Controls/OBC/CDL/Reals/MovingAverage.mo
@@ -6,10 +6,10 @@ block MovingAverage "Block to output moving average"
     min=1E-5)
     "Time horizon over which the input is averaged";
   Buildings.Controls.OBC.CDL.Interfaces.RealInput u
-    "Connector of Real input signal"
+    "Input to be averaged"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.RealOutput y
-    "Connector of Real output signal"
+    "Moving average of the input"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 protected
@@ -33,9 +33,7 @@ initial equation
 
 equation
   u=der(mu);
-  muDel=delay(
-    mu,
-    delta);
+  muDel=delay(mu, delta);
   // Compute the mode so that Dymola generates
   // time and not state events as it would with
   // an if-then construct

--- a/Buildings/Controls/OBC/CDL/Reals/MultiMax.mo
+++ b/Buildings/Controls/OBC/CDL/Reals/MultiMax.mo
@@ -1,15 +1,14 @@
 within Buildings.Controls.OBC.CDL.Reals;
 block MultiMax
   "Output the maximum element of the input vector"
-  parameter Integer nin(
-    min=0)=0
-    "Number of input connections"
+  parameter Integer nin(min=0)=0
+    "Number of input signals"
     annotation (Dialog(connectorSizing=true),HideResult=true);
   Buildings.Controls.OBC.CDL.Interfaces.RealInput u[nin]
-    "Connector of Real input signals"
+    "Input to max function"
     annotation (Placement(transformation(extent={{-140,20},{-100,-20}})));
   Buildings.Controls.OBC.CDL.Interfaces.RealOutput y
-    "Connector of Real output signals"
+    "Largest element of the input vector"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 equation

--- a/Buildings/Controls/OBC/CDL/Reals/MultiMin.mo
+++ b/Buildings/Controls/OBC/CDL/Reals/MultiMin.mo
@@ -1,15 +1,14 @@
 within Buildings.Controls.OBC.CDL.Reals;
 block MultiMin
   "Output the minimum element of the input vector"
-  parameter Integer nin(
-    min=0)=0
-    "Number of input connections"
+  parameter Integer nin(min=0)=0
+    "Number of input signals"
     annotation (Dialog(connectorSizing=true),HideResult=true);
   Buildings.Controls.OBC.CDL.Interfaces.RealInput u[nin]
-    "Connector of Real input signals"
+    "Input to the min function"
     annotation (Placement(transformation(extent={{-140,20},{-100,-20}})));
   Buildings.Controls.OBC.CDL.Interfaces.RealOutput y
-    "Connector of Real output signals"
+    "Smallest element of the input vector"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 equation

--- a/Buildings/Controls/OBC/CDL/Reals/MultiSum.mo
+++ b/Buildings/Controls/OBC/CDL/Reals/MultiSum.mo
@@ -1,25 +1,20 @@
 within Buildings.Controls.OBC.CDL.Reals;
 block MultiSum
   "Sum of Reals, y = k[1]*u[1] + k[2]*u[2] + ... + k[n]*u[n]"
-  parameter Integer nin(
-    min=0)=0
-    "Number of input connections"
+  parameter Integer nin(min=0)=0
+    "Number of input signals"
     annotation (Dialog(connectorSizing=true),HideResult=true);
-  parameter Real k[nin]=fill(
-    1,
-    nin)
+  parameter Real k[nin]=fill(1, nin)
     "Input gains";
   Buildings.Controls.OBC.CDL.Interfaces.RealInput u[nin]
-    "Connector of Real input signals"
+    "Input to multiplied by gain and then added"
     annotation (Placement(transformation(extent={{-140,20},{-100,-20}})));
   Buildings.Controls.OBC.CDL.Interfaces.RealOutput y
-    "Connector of Real output signal"
+    "Sum of inputs times gains"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 equation
-  if size(
-    u,
-    1) > 0 then
+  if size(u, 1) > 0 then
     y=k*u;
   else
     y=0;

--- a/Buildings/Controls/OBC/CDL/Reals/Multiply.mo
+++ b/Buildings/Controls/OBC/CDL/Reals/Multiply.mo
@@ -1,13 +1,13 @@
 within Buildings.Controls.OBC.CDL.Reals;
 block Multiply "Output product of the two inputs"
   Buildings.Controls.OBC.CDL.Interfaces.RealInput u1
-    "Connector of Real input signal 1"
+    "Input to be multiplied"
     annotation (Placement(transformation(extent={{-140,40},{-100,80}})));
   Buildings.Controls.OBC.CDL.Interfaces.RealInput u2
-    "Connector of Real input signal 2"
+    "Input to be multiplied"
     annotation (Placement(transformation(extent={{-140,-80},{-100,-40}})));
   Buildings.Controls.OBC.CDL.Interfaces.RealOutput y
-    "Connector of Real output signal"
+    "Product of the inputs"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 equation

--- a/Buildings/Controls/OBC/CDL/Reals/MultiplyByParameter.mo
+++ b/Buildings/Controls/OBC/CDL/Reals/MultiplyByParameter.mo
@@ -2,12 +2,12 @@ within Buildings.Controls.OBC.CDL.Reals;
 block MultiplyByParameter
   "Output the product of a gain value with the input signal"
   parameter Real k
-    "Gain value multiplied with input signal";
+    "Factor to be multiplied with input signal";
   Buildings.Controls.OBC.CDL.Interfaces.RealInput u
-    "Input signal connector"
+    "Input to be multiplied with gain"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.RealOutput y
-    "Output signal connector"
+    "Product of the parameter times the input"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 equation

--- a/Buildings/Controls/OBC/CDL/Reals/PID.mo
+++ b/Buildings/Controls/OBC/CDL/Reals/PID.mo
@@ -1,7 +1,8 @@
 within Buildings.Controls.OBC.CDL.Reals;
 block PID
   "P, PI, PD, and PID controller"
-  parameter Buildings.Controls.OBC.CDL.Types.SimpleController controllerType=Buildings.Controls.OBC.CDL.Types.SimpleController.PI
+  parameter Buildings.Controls.OBC.CDL.Types.SimpleController controllerType =
+    Buildings.Controls.OBC.CDL.Types.SimpleController.PI
     "Type of controller";
   parameter Real k(
     min=100*Constants.eps)=1
@@ -45,13 +46,13 @@ block PID
   parameter Boolean reverseActing=true
     "Set to true for reverse acting, or false for direct acting control action";
   Buildings.Controls.OBC.CDL.Interfaces.RealInput u_s
-    "Connector of setpoint input signal"
+    "Setpoint input signal"
     annotation (Placement(transformation(extent={{-260,-20},{-220,20}}),iconTransformation(extent={{-140,-20},{-100,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.RealInput u_m
-    "Connector of measurement input signal"
+    "Measurement input signal"
     annotation (Placement(transformation(origin={0,-220},extent={{20,-20},{-20,20}},rotation=270),iconTransformation(extent={{20,-20},{-20,20}},rotation=270,origin={0,-120})));
   Buildings.Controls.OBC.CDL.Interfaces.RealOutput y
-    "Connector of actuator output signal"
+    "Actuator output signal"
     annotation (Placement(transformation(extent={{220,-20},{260,20}}),iconTransformation(extent={{100,-20},{140,20}})));
   Buildings.Controls.OBC.CDL.Reals.Subtract controlError "Control error (set point - measurement)"
     annotation (Placement(transformation(extent={{-200,-16},{-180,4}})));
@@ -86,16 +87,16 @@ block PID
     annotation (Placement(transformation(extent={{120,80},{140,100}})));
 
 protected
-  final parameter Real revAct=
-    if reverseActing then
-      1
-    else
-      -1
+  final parameter Real revAct= if reverseActing then 1 else -1
     "Switch for sign for reverse or direct acting controller";
-  final parameter Boolean with_I=controllerType == Buildings.Controls.OBC.CDL.Types.SimpleController.PI or controllerType == Buildings.Controls.OBC.CDL.Types.SimpleController.PID
+    final parameter Boolean with_I =
+      controllerType == Buildings.Controls.OBC.CDL.Types.SimpleController.PI or
+      controllerType == Buildings.Controls.OBC.CDL.Types.SimpleController.PID
     "Boolean flag to enable integral action"
     annotation (Evaluate=true,HideResult=true);
-  final parameter Boolean with_D=controllerType == Buildings.Controls.OBC.CDL.Types.SimpleController.PD or controllerType == Buildings.Controls.OBC.CDL.Types.SimpleController.PID
+    final parameter Boolean with_D =
+      controllerType == Buildings.Controls.OBC.CDL.Types.SimpleController.PD or
+      controllerType == Buildings.Controls.OBC.CDL.Types.SimpleController.PID
     "Boolean flag to enable derivative action"
     annotation (Evaluate=true,HideResult=true);
   Sources.Constant kDer(k=k*Td) if with_D
@@ -104,8 +105,8 @@ protected
   Sources.Constant TDer(k=Td/Nd) if with_D
     "Time constant for approximation in derivative block"
     annotation (Placement(transformation(extent={{-100,80},{-80,100}})));
-  Buildings.Controls.OBC.CDL.Reals.Sources.Constant Dzero(
-    final k=0) if not with_D
+  Buildings.Controls.OBC.CDL.Reals.Sources.Constant Dzero(final k=0)
+    if not with_D
     "Zero input signal"
     annotation (Evaluate=true,HideResult=true,Placement(transformation(extent={{-50,90},
             {-30,110}})));
@@ -136,16 +137,16 @@ protected
     "Assertion on yMin and yMax"
     annotation (Placement(transformation(extent={{160,-160},{180,-140}})));
 
-  Buildings.Controls.OBC.CDL.Reals.Sources.Constant Izero(
-    final k=0) if not with_I
+  Buildings.Controls.OBC.CDL.Reals.Sources.Constant Izero(final k=0)
+    if not with_I
     "Zero input signal"
     annotation (Placement(transformation(extent={{-50,20},{-30,40}})));
-  Buildings.Controls.OBC.CDL.Reals.Sources.Constant con(
-    final k=0) if with_I
+  Buildings.Controls.OBC.CDL.Reals.Sources.Constant con(final k=0)
+    if with_I
     "Constant zero"
     annotation (Placement(transformation(extent={{-100,-50},{-80,-30}})));
-  Buildings.Controls.OBC.CDL.Logical.Sources.Constant con1(
-    final k=false) if with_I
+  Buildings.Controls.OBC.CDL.Logical.Sources.Constant con1(final k=false)
+    if with_I
     "Constant false"
     annotation (Placement(transformation(extent={{-100,-90},{-80,-70}})));
 

--- a/Buildings/Controls/OBC/CDL/Reals/PIDWithReset.mo
+++ b/Buildings/Controls/OBC/CDL/Reals/PIDWithReset.mo
@@ -1,10 +1,10 @@
 within Buildings.Controls.OBC.CDL.Reals;
 block PIDWithReset
   "P, PI, PD, and PID controller with output reset"
-  parameter Buildings.Controls.OBC.CDL.Types.SimpleController controllerType=Buildings.Controls.OBC.CDL.Types.SimpleController.PI
+  parameter Buildings.Controls.OBC.CDL.Types.SimpleController controllerType =
+    Buildings.Controls.OBC.CDL.Types.SimpleController.PI
     "Type of controller";
-  parameter Real k(
-    min=100*Constants.eps)=1
+  parameter Real k(min=100*Constants.eps)=1
     "Gain of controller"
     annotation (Dialog(group="Control gains"));
   parameter Real Ti(
@@ -19,8 +19,7 @@ block PIDWithReset
     min=100*Constants.eps)=0.1
     "Time constant of derivative block"
     annotation (Dialog(group="Control gains",enable=controllerType == CDL.Types.SimpleController.PD or controllerType == CDL.Types.SimpleController.PID));
-  parameter Real r(
-    min=100*Constants.eps)=1
+  parameter Real r(min=100*Constants.eps)=1
     "Typical range of control error, used for scaling the control error";
   parameter Real yMax=1
     "Upper limit of output"
@@ -62,7 +61,8 @@ block PIDWithReset
   Buildings.Controls.OBC.CDL.Reals.Subtract controlError
     "Control error (set point - measurement)"
     annotation (Placement(transformation(extent={{-200,-16},{-180,4}})));
-  Buildings.Controls.OBC.CDL.Reals.MultiplyByParameter P(final k=k) "Proportional action"
+  Buildings.Controls.OBC.CDL.Reals.MultiplyByParameter P(final k=k)
+    "Proportional action"
     annotation (Placement(transformation(extent={{-50,130},{-30,150}})));
   Buildings.Controls.OBC.CDL.Reals.IntegratorWithReset I(
     final k=k/Ti,
@@ -91,16 +91,16 @@ block PIDWithReset
     "Limiter"
     annotation (Placement(transformation(extent={{120,80},{140,100}})));
 protected
-  final parameter Real revAct=
-    if reverseActing then
-      1
-    else
-      -1
+  final parameter Real revAct= if reverseActing then 1 else -1
     "Switch for sign for reverse or direct acting controller";
-  final parameter Boolean with_I=controllerType == Buildings.Controls.OBC.CDL.Types.SimpleController.PI or controllerType == Buildings.Controls.OBC.CDL.Types.SimpleController.PID
+  final parameter Boolean with_I =
+    controllerType == Buildings.Controls.OBC.CDL.Types.SimpleController.PI or
+    controllerType == Buildings.Controls.OBC.CDL.Types.SimpleController.PID
     "Boolean flag to enable integral action"
     annotation (Evaluate=true,HideResult=true);
-  final parameter Boolean with_D=controllerType == Buildings.Controls.OBC.CDL.Types.SimpleController.PD or controllerType == Buildings.Controls.OBC.CDL.Types.SimpleController.PID
+  final parameter Boolean with_D =
+    controllerType == Buildings.Controls.OBC.CDL.Types.SimpleController.PD or
+    controllerType == Buildings.Controls.OBC.CDL.Types.SimpleController.PID
     "Boolean flag to enable derivative action"
     annotation (Evaluate=true,HideResult=true);
   Sources.Constant kDer(k=k*Td) if with_D

--- a/Buildings/Controls/OBC/CDL/Reals/Ramp.mo
+++ b/Buildings/Controls/OBC/CDL/Reals/Ramp.mo
@@ -16,14 +16,14 @@ block Ramp "Limit the changing rate of the input"
     "Derivative time constant";
 
   Buildings.Controls.OBC.CDL.Interfaces.RealInput u
-    "Connector of Real input signal"
+    "Input that is being rate limited"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.BooleanInput active
     "Set to true to enable rate limiter"
     annotation (Placement(transformation(extent={{-140,-100},{-100,-60}}),
         iconTransformation(extent={{-140,-100},{-100,-60}})));
   Buildings.Controls.OBC.CDL.Interfaces.RealOutput y
-    "Connector of Real output signal"
+    "Rate limited output if active is true, else output is equal to input"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 protected
@@ -33,11 +33,9 @@ protected
     "Internal variable to track the slew limited value";
 
 initial equation
-  assert(
-    raisingSlewRate > 0,
+  assert(raisingSlewRate > 0,
     "raisingSlewRate must be larger than zero.");
-  assert(
-    fallingSlewRate < 0,
+  assert(fallingSlewRate < 0,
     "fallingSlewRate must be less than zero.");
   y_internal = u;
 
@@ -50,10 +48,9 @@ equation
         if thr < fallingSlewRate then
           fallingSlewRate
         else
-          if thr > raisingSlewRate then
-            raisingSlewRate
-          else
-            thr));
+          if thr > raisingSlewRate then raisingSlewRate else thr
+        )
+     );
   y = if active then y_internal else u;
 
 annotation (defaultComponentName="ram",

--- a/Buildings/Controls/OBC/CDL/Reals/Round.mo
+++ b/Buildings/Controls/OBC/CDL/Reals/Round.mo
@@ -2,12 +2,12 @@ within Buildings.Controls.OBC.CDL.Reals;
 block Round
   "Round real number to given digits"
   parameter Integer n
-    "Number of digits being round to";
+    "Number of digits to be round to";
   Buildings.Controls.OBC.CDL.Interfaces.RealInput u
-    "Connector of Real input signal"
+    "Input to be rounded"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.RealOutput y
-    "Connector of Real output signal"
+    "Output with rounded input"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 protected
@@ -15,13 +15,10 @@ protected
     "Factor used for rounding";
 
 equation
-  y=if
-      (u > 0) then
-      floor(
-        u*fac+0.5)/fac
+  y=if (u > 0) then
+      floor( u*fac+0.5)/fac
     else
-      ceil(
-        u*fac-0.5)/fac;
+      ceil(u*fac-0.5)/fac;
   annotation (
     defaultComponentName="rou",
     Icon(

--- a/Buildings/Controls/OBC/CDL/Reals/Sin.mo
+++ b/Buildings/Controls/OBC/CDL/Reals/Sin.mo
@@ -1,7 +1,7 @@
 within Buildings.Controls.OBC.CDL.Reals;
 block Sin
   "Output the sine of the input"
-  Buildings.Controls.OBC.CDL.Interfaces.RealInput u(unit="rad")
+  Buildings.Controls.OBC.CDL.Interfaces.RealInput u(final unit="rad")
     "Connector of Real input signal"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.RealOutput y

--- a/Buildings/Controls/OBC/CDL/Reals/Sin.mo
+++ b/Buildings/Controls/OBC/CDL/Reals/Sin.mo
@@ -1,11 +1,12 @@
 within Buildings.Controls.OBC.CDL.Reals;
-block Sin
-  "Output the sine of the input"
-  Buildings.Controls.OBC.CDL.Interfaces.RealInput u(final unit="rad")
-    "Connector of Real input signal"
+block Sin "Output the sine of the input"
+  Buildings.Controls.OBC.CDL.Interfaces.RealInput u(
+    final unit="rad",
+    displayUnit="deg")
+    "Input for the sine function"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.RealOutput y
-    "Connector of Real output signal"
+    "Sine of input"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 equation
@@ -71,6 +72,11 @@ where
 </html>",
       revisions="<html>
 <ul>
+<li>
+November 8, 2024, by Michael Wetter:<br/>
+Added <code>final</code> keyword to unit declaration as block is only valid for this unit.<br/>
+Also added <code>displayUnit</code> keyword.
+</li>
 <li>
 March 7, 2023, by Jianjun Hu:<br/>
 Added unit <code>rad</code> to the input.<br/>

--- a/Buildings/Controls/OBC/CDL/Reals/Sort.mo
+++ b/Buildings/Controls/OBC/CDL/Reals/Sort.mo
@@ -3,24 +3,22 @@ block Sort
   "Sort elements of input vector in ascending or descending order"
   parameter Integer nin(
     final min=0)=0
-    "Number of input connections"
+    "Number of input signals"
     annotation (Dialog(connectorSizing=true),HideResult=true);
   parameter Boolean ascending=true
     "Set to true if ascending order, otherwise order is descending";
   Buildings.Controls.OBC.CDL.Interfaces.RealInput u[nin]
-    "Connector of Real input signals"
+    "Input to be sorted"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.RealOutput y[nin]
-    "Connector of Real output signals"
+    "Output with sorted input"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.IntegerOutput yIdx[nin]
     "Indices of the sorted vector with respect to the original vector"
     annotation (Placement(transformation(extent={{100,-80},{140,-40}}),
       iconTransformation(extent={{100,-80},{140,-40}})));
 equation
-  (y, yIdx)=Modelica.Math.Vectors.sort(
-    u,
-    ascending=ascending);
+  (y, yIdx)=Modelica.Math.Vectors.sort(u, ascending=ascending);
 
   annotation (
     defaultComponentName="sort",

--- a/Buildings/Controls/OBC/CDL/Reals/Sources/CivilTime.mo
+++ b/Buildings/Controls/OBC/CDL/Reals/Sources/CivilTime.mo
@@ -1,7 +1,6 @@
 within Buildings.Controls.OBC.CDL.Reals.Sources;
 block CivilTime "Civil time"
-  Buildings.Controls.OBC.CDL.Interfaces.RealOutput y(
-    final unit="s")
+  Buildings.Controls.OBC.CDL.Interfaces.RealOutput y(final unit="s")
     "Civil time"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 

--- a/Buildings/Controls/OBC/CDL/Reals/Sources/Constant.mo
+++ b/Buildings/Controls/OBC/CDL/Reals/Sources/Constant.mo
@@ -4,7 +4,7 @@ block Constant
   parameter Real k
     "Constant output value";
   Buildings.Controls.OBC.CDL.Interfaces.RealOutput y
-    "Connector of Real output signal"
+    "Constant output signal"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 equation

--- a/Buildings/Controls/OBC/CDL/Reals/Sources/Pulse.mo
+++ b/Buildings/Controls/OBC/CDL/Reals/Sources/Pulse.mo
@@ -20,7 +20,7 @@ block Pulse
   parameter Real offset=0.0
     "Offset of output signals";
   Buildings.Controls.OBC.CDL.Interfaces.RealOutput y
-    "Connector of Pulse output signal"
+    "Pulse output signal"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 protected

--- a/Buildings/Controls/OBC/CDL/Reals/Sources/Ramp.mo
+++ b/Buildings/Controls/OBC/CDL/Reals/Sources/Ramp.mo
@@ -15,7 +15,7 @@ block Ramp
     final unit="s")=0
     "Output = offset for time < startTime";
   Buildings.Controls.OBC.CDL.Interfaces.RealOutput y
-    "Connector of Real output signal"
+    "Ramp output signal"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 equation
@@ -23,7 +23,7 @@ equation
     if time < startTime then
       0
     else
-      if time <(startTime+duration) then
+      if time < (startTime+duration) then
         (time-startTime)*height/duration
       else
         height);

--- a/Buildings/Controls/OBC/CDL/Reals/Sources/Sin.mo
+++ b/Buildings/Controls/OBC/CDL/Reals/Sources/Sin.mo
@@ -20,7 +20,7 @@ block Sin
     final unit="s")=0
     "Output = offset for time < startTime";
   Buildings.Controls.OBC.CDL.Interfaces.RealOutput y
-    "Connector of Real output signal"
+    "Sine output signal"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 equation
@@ -87,6 +87,11 @@ Block that outputs a <code>sine</code>.
 </html>",
       revisions="<html>
 <ul>
+<li>
+November 8, 2024, by Michael Wetter:<br/>
+Added <code>final</code> keyword to unit declaration as block is only valid for this unit.<br/>
+Also added <code>displayUnit</code> keyword.
+</li>
 <li>
 April 13, 2023, by Michael Wetter:<br/>
 Renamed block from <code>Sine</code> to <code>Sin</code>

--- a/Buildings/Controls/OBC/CDL/Reals/Sources/TimeTable.mo
+++ b/Buildings/Controls/OBC/CDL/Reals/Sources/TimeTable.mo
@@ -7,21 +7,17 @@ block TimeTable
     "Smoothness of table interpolation";
   parameter CDL.Types.Extrapolation extrapolation=CDL.Types.Extrapolation.Periodic
     "Extrapolation of data outside the definition range";
-  parameter Real offset[:]=fill(
-    0,
-    nout)
+  parameter Real offset[:]=fill(0, nout)
     "Offsets of output signals as a vector with length equal to number of table matrix columns less one";
   parameter Real timeScale(
     final unit="1")=1
     "Time scale of first table column. Set to 3600 if time in table is in hours";
   Buildings.Controls.OBC.CDL.Interfaces.RealOutput y[nout]
-    "Output of the table"
+    "Output with tabulated values"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 protected
-  final parameter Integer nout=size(
-    table,
-    2)-1
+  final parameter Integer nout=size(table,2)-1
     "Dimension of output vector";
   parameter Real t0(
     final quantity="Time",
@@ -59,11 +55,7 @@ protected
         Modelica.Blocks.Types.Extrapolation.Periodic,
     final offset=offset,
     final startTime=
-      if
-        (extrapolation == Types.Extrapolation.Periodic) then
-        t0
-      else
-        0,
+      if (extrapolation == Types.Extrapolation.Periodic) then t0 else 0,
     final timeScale=timeScale)
     "Time table"
     annotation (Placement(transformation(extent={{-12,-10},{8,10}})));

--- a/Buildings/Controls/OBC/CDL/Reals/Sqrt.mo
+++ b/Buildings/Controls/OBC/CDL/Reals/Sqrt.mo
@@ -2,14 +2,15 @@ within Buildings.Controls.OBC.CDL.Reals;
 block Sqrt
   "Output the square root of the input (input >= 0 required)"
   Buildings.Controls.OBC.CDL.Interfaces.RealInput u
-    "Connector of Real input signal"
+    "Input to square root function"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.RealOutput y
-    "Connector of Real output signal"
+    "Output with square root of the input"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 equation
   y=sqrt(u);
+
   annotation (
     defaultComponentName="sqr",
     Icon(

--- a/Buildings/Controls/OBC/CDL/Reals/Subtract.mo
+++ b/Buildings/Controls/OBC/CDL/Reals/Subtract.mo
@@ -1,13 +1,13 @@
 within Buildings.Controls.OBC.CDL.Reals;
 block Subtract "Output the difference of the two inputs"
   Buildings.Controls.OBC.CDL.Interfaces.RealInput u1
-    "Connector of Real input signal 1"
+    "Input with minuend"
     annotation (Placement(transformation(extent={{-140,40},{-100,80}})));
   Buildings.Controls.OBC.CDL.Interfaces.RealInput u2
-    "Connector of Real input signal 2"
+    "Input with subtrahend"
     annotation (Placement(transformation(extent={{-140,-80},{-100,-40}})));
   Buildings.Controls.OBC.CDL.Interfaces.RealOutput y
-    "Connector of Real output signal"
+    "Output with difference"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 equation

--- a/Buildings/Controls/OBC/CDL/Reals/Switch.mo
+++ b/Buildings/Controls/OBC/CDL/Reals/Switch.mo
@@ -2,16 +2,16 @@ within Buildings.Controls.OBC.CDL.Reals;
 block Switch
   "Switch between two Real signals"
   Buildings.Controls.OBC.CDL.Interfaces.RealInput u1
-    "Real input signal"
+    "Input u1"
     annotation (Placement(transformation(extent={{-140,60},{-100,100}})));
   Buildings.Controls.OBC.CDL.Interfaces.BooleanInput u2
     "Boolean switch input signal, if true, y=u1, else y=u3"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.RealInput u3
-    "Real input signal"
+    "Input u3"
     annotation (Placement(transformation(extent={{-140,-100},{-100,-60}})));
   Buildings.Controls.OBC.CDL.Interfaces.RealOutput y
-    "Real output signal"
+    "Output with u1 if u2 is true, else u3"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 equation

--- a/Buildings/Controls/OBC/CDL/Reals/Tan.mo
+++ b/Buildings/Controls/OBC/CDL/Reals/Tan.mo
@@ -1,7 +1,7 @@
 within Buildings.Controls.OBC.CDL.Reals;
 block Tan
   "Output the tangent of the input"
-  Buildings.Controls.OBC.CDL.Interfaces.RealInput u(unit="rad")
+  Buildings.Controls.OBC.CDL.Interfaces.RealInput u(final unit="rad")
     "Connector of Real input signal"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.RealOutput y

--- a/Buildings/Controls/OBC/CDL/Reals/Tan.mo
+++ b/Buildings/Controls/OBC/CDL/Reals/Tan.mo
@@ -1,11 +1,12 @@
 within Buildings.Controls.OBC.CDL.Reals;
-block Tan
-  "Output the tangent of the input"
-  Buildings.Controls.OBC.CDL.Interfaces.RealInput u(final unit="rad")
-    "Connector of Real input signal"
+block Tan "Output the tangent of the input"
+  Buildings.Controls.OBC.CDL.Interfaces.RealInput u(
+    final unit="rad",
+    displayUnit="deg")
+    "Input for the tangent function"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.RealOutput y
-    "Connector of Real output signal"
+    "Tangent of the input"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 equation
@@ -71,6 +72,11 @@ where
 </html>",
       revisions="<html>
 <ul>
+<li>
+November 8, 2024, by Michael Wetter:<br/>
+Added <code>final</code> keyword to unit declaration as block is only valid for this unit.<br/>
+Also added <code>displayUnit</code> keyword.
+</li>
 <li>
 March 7, 2023, by Jianjun Hu:<br/>
 Added unit <code>rad</code> to the input.<br/>

--- a/Buildings/Controls/OBC/CDL/Routing/BooleanScalarReplicator.mo
+++ b/Buildings/Controls/OBC/CDL/Routing/BooleanScalarReplicator.mo
@@ -1,19 +1,16 @@
 within Buildings.Controls.OBC.CDL.Routing;
-block BooleanScalarReplicator
-  "Boolean signal replicator"
+block BooleanScalarReplicator "Boolean signal replicator"
   parameter Integer nout=1
     "Number of outputs";
   Buildings.Controls.OBC.CDL.Interfaces.BooleanInput u
-    "Connector of Boolean input signal"
+    "Input signal to be replicated"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.BooleanOutput y[nout]
-    "Connector of Boolean output signals"
+    "Output with replicated input signal"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 equation
-  y=fill(
-    u,
-    nout);
+  y=fill(u, nout);
   annotation (
     defaultComponentName="booScaRep",
     Icon(

--- a/Buildings/Controls/OBC/CDL/Routing/BooleanVectorFilter.mo
+++ b/Buildings/Controls/OBC/CDL/Routing/BooleanVectorFilter.mo
@@ -1,15 +1,15 @@
 within Buildings.Controls.OBC.CDL.Routing;
-block BooleanVectorFilter
-  "Filter a boolean vector based on a boolean mask"
+block BooleanVectorFilter "Filter a boolean vector based on a boolean mask"
+
   parameter Integer nin "Size of input vector";
   parameter Integer nout "Size of output vector";
   parameter Boolean msk[nin]=fill(true,nin) "Array mask";
 
   Buildings.Controls.OBC.CDL.Interfaces.BooleanInput u[nin]
-    "Connector of Boolean input signal"
+    "Input signals from which values are extracted"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.BooleanOutput y[nout]
-    "Connector of Boolean output signals"
+    "Output with extracted input signals"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 protected

--- a/Buildings/Controls/OBC/CDL/Routing/BooleanVectorReplicator.mo
+++ b/Buildings/Controls/OBC/CDL/Routing/BooleanVectorReplicator.mo
@@ -1,12 +1,14 @@
 within Buildings.Controls.OBC.CDL.Routing;
 block BooleanVectorReplicator "Boolean vector signal replicator"
+
   parameter Integer nin=1 "Size of input vector";
   parameter Integer nout=1 "Number of row in output";
+
   Buildings.Controls.OBC.CDL.Interfaces.BooleanInput u[nin]
-    "Connector of Boolean vector input signal"
+    "Input signal to be replicated"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.BooleanOutput y[nout, nin]
-    "Connector of Boolean matrix output signals"
+    "Output with replicated input signal"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 equation

--- a/Buildings/Controls/OBC/CDL/Routing/IntegerScalarReplicator.mo
+++ b/Buildings/Controls/OBC/CDL/Routing/IntegerScalarReplicator.mo
@@ -1,19 +1,16 @@
 within Buildings.Controls.OBC.CDL.Routing;
-block IntegerScalarReplicator
-  "Integer signal replicator"
+block IntegerScalarReplicator "Integer signal replicator"
   parameter Integer nout=1
     "Number of outputs";
   Buildings.Controls.OBC.CDL.Interfaces.IntegerInput u
-    "Connector of Integer input signal"
+    "Input signal to be replicated"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.IntegerOutput y[nout]
-    "Connector of Integer output signals"
+    "Output with replicated input signal"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 equation
-  y=fill(
-    u,
-    nout);
+  y=fill(u, nout);
   annotation (
     defaultComponentName="intScaRep",
     Icon(

--- a/Buildings/Controls/OBC/CDL/Routing/IntegerVectorFilter.mo
+++ b/Buildings/Controls/OBC/CDL/Routing/IntegerVectorFilter.mo
@@ -1,15 +1,15 @@
 within Buildings.Controls.OBC.CDL.Routing;
-block IntegerVectorFilter
-  "Filter an integer vector based on a boolean mask"
+block IntegerVectorFilter "Filter an integer vector based on a boolean mask"
+
   parameter Integer nin "Size of input vector";
   parameter Integer nout "Size of output vector";
   parameter Boolean msk[nin]=fill(true,nin) "Array mask";
 
   Buildings.Controls.OBC.CDL.Interfaces.IntegerInput u[nin]
-    "Connector of Integer input signal"
+    "Input signals from which values are extracted"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.IntegerOutput y[nout]
-    "Connector of Integer output signals"
+    "Output with extracted input signals"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 protected
@@ -18,8 +18,8 @@ protected
 
 initial equation
   assert(nout==sum({if msk[i] then 1 else 0 for i in 1:nin}),
-    "The size of the output vector does not match the
-    size of included elements in the mask.");
+    "In " + getInstanceName() + ": The size of the output vector does not
+    match the size of included elements in the mask.");
 equation
   y = u[mskId];
   annotation (

--- a/Buildings/Controls/OBC/CDL/Routing/IntegerVectorReplicator.mo
+++ b/Buildings/Controls/OBC/CDL/Routing/IntegerVectorReplicator.mo
@@ -1,12 +1,14 @@
 within Buildings.Controls.OBC.CDL.Routing;
 block IntegerVectorReplicator "Integer vector signal replicator"
+
   parameter Integer nin=1 "Size of input vector";
   parameter Integer nout=1 "Number of row in output";
+
   Buildings.Controls.OBC.CDL.Interfaces.IntegerInput u[nin]
-    "Connector of Integer vector input signal"
+    "Input signal to be replicated"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.IntegerOutput y[nout, nin]
-    "Connector of Integer matrix output signals"
+    "Output with replicated input signal"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 equation

--- a/Buildings/Controls/OBC/CDL/Routing/RealScalarReplicator.mo
+++ b/Buildings/Controls/OBC/CDL/Routing/RealScalarReplicator.mo
@@ -4,16 +4,14 @@ block RealScalarReplicator
   parameter Integer nout=1
     "Number of outputs";
   Buildings.Controls.OBC.CDL.Interfaces.RealInput u
-    "Connector of Real input signal"
+    "Input signal to be replicated"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.RealOutput y[nout]
-    "Connector of Real output signal"
+    "Output with replicated input signal"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 equation
-  y=fill(
-    u,
-    nout);
+  y=fill(u, nout);
   annotation (
     defaultComponentName="reaScaRep",
     Icon(

--- a/Buildings/Controls/OBC/CDL/Routing/RealVectorFilter.mo
+++ b/Buildings/Controls/OBC/CDL/Routing/RealVectorFilter.mo
@@ -1,15 +1,15 @@
 within Buildings.Controls.OBC.CDL.Routing;
-block RealVectorFilter
-  "Filter a real vector of based on a boolean mask"
+block RealVectorFilter "Filter a real vector of based on a boolean mask"
+
   parameter Integer nin "Size of input vector";
   parameter Integer nout "Size of output vector";
   parameter Boolean msk[nin]=fill(true,nin) "Array mask";
 
   Buildings.Controls.OBC.CDL.Interfaces.RealInput u[nin]
-    "Connector of Real input signal"
+    "Input signals from which values are extracted"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.RealOutput y[nout]
-    "Connector of Real output signals"
+    "Output with extracted input signals"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 protected
@@ -18,8 +18,8 @@ protected
 
 initial equation
   assert(nout==sum({if msk[i] then 1 else 0 for i in 1:nin}),
-    "The size of the output vector does not match the
-    size of included elements in the mask.");
+    "In " + getInstanceName() + ": The size of the output vector does not
+    match the size of included elements in the mask.");
 equation
   y = u[mskId];
   annotation (

--- a/Buildings/Controls/OBC/CDL/Routing/RealVectorReplicator.mo
+++ b/Buildings/Controls/OBC/CDL/Routing/RealVectorReplicator.mo
@@ -1,12 +1,14 @@
 within Buildings.Controls.OBC.CDL.Routing;
 block RealVectorReplicator "Real vector signal replicator"
+
   parameter Integer nin=1 "Size of input vector";
   parameter Integer nout=1 "Number of row in output";
+
   Buildings.Controls.OBC.CDL.Interfaces.RealInput u[nin]
-    "Connector of Real vector input signal"
+    "Input signal to be replicated"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.RealOutput y[nout, nin]
-    "Connector of Real matrix output signals"
+    "Output with replicated input signal"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
 
 equation

--- a/Buildings/Controls/OBC/CDL/Types/SimpleController.mo
+++ b/Buildings/Controls/OBC/CDL/Types/SimpleController.mo
@@ -1,13 +1,9 @@
 within Buildings.Controls.OBC.CDL.Types;
 type SimpleController = enumeration(
-    P
-  "P controller",
-    PI
-  "PI controller",
-    PD
-  "PD controller",
-    PID
-  "PID controller")
+    P "P controller",
+    PI "PI controller",
+    PD "PD controller",
+    PID "PID controller")
   "Enumeration defining P, PI, PD, or PID simple controller type"
   annotation (Evaluate=true,Documentation(info="<html>
 <p>

--- a/Buildings/Controls/OBC/CDL/Types/Smoothness.mo
+++ b/Buildings/Controls/OBC/CDL/Types/Smoothness.mo
@@ -1,9 +1,7 @@
 within Buildings.Controls.OBC.CDL.Types;
 type Smoothness = enumeration(
-    LinearSegments
-  "Table points are linearly interpolated",
-    ConstantSegments
-  "Table points are not interpolated, but the previous tabulated value is returned")
+    LinearSegments "Table points are linearly interpolated",
+    ConstantSegments "Table points are not interpolated, but the previous tabulated value is returned")
   "Enumeration defining the smoothness of table interpolation"
   annotation (Documentation(info="<html>
 <p>

--- a/Buildings/Controls/OBC/CDL/Utilities/Assert.mo
+++ b/Buildings/Controls/OBC/CDL/Utilities/Assert.mo
@@ -8,10 +8,7 @@ block Assert
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
 
 equation
-  assert(
-    u,
-    message,
-    AssertionLevel.warning);
+  assert(u, message, AssertionLevel.warning);
   annotation (
     defaultComponentName="assMes",
     Icon(

--- a/Buildings/Controls/OBC/CDL/Utilities/SunRiseSet.mo
+++ b/Buildings/Controls/OBC/CDL/Utilities/SunRiseSet.mo
@@ -29,7 +29,7 @@ block SunRiseSet
     "Time of next sunset"
     annotation (Placement(transformation(extent={{100,-20},{140,20}})));
   Buildings.Controls.OBC.CDL.Interfaces.BooleanOutput sunUp
-    "Output true if the sun is up"
+    "Output with true if the sun is up"
     annotation (Placement(transformation(extent={{100,-80},{140,-40}})));
 
 protected

--- a/Buildings/Controls/OBC/CDL/package.mo
+++ b/Buildings/Controls/OBC/CDL/package.mo
@@ -4,11 +4,13 @@ package CDL "Package with blocks, examples and validation tests for control desc
     Documentation(
       info="<html>
 <p>
-Package that has elementary input-output blocks
+Package that has Elementary Blocks
 that form the Control Description Language (CDL).
+</p>
+<p>
 The implementation is structured into sub-packages.
-The packages <code>Validation</code> and <code>Examples</code>
-contain validation and example models.
+The packages <code>Validation</code>
+contain validation models.
 These are not part of the CDL specification, but rather
 implemented to provide reference responses computed by the CDL blocks.
 For a specification of CDL, see


### PR DESCRIPTION
This closes #4038.

This also sets the `unit` of the trigonometric blocks as `final`, and adds `displayUnit=deg` specification.