### PR TITLE
Issue2884 pid autotuning

### DIFF
--- a/Buildings/Controls/OBC/Utilities/PIDWithAutotuning/FirstOrderAMIGO.mo
+++ b/Buildings/Controls/OBC/Utilities/PIDWithAutotuning/FirstOrderAMIGO.mo
@@ -461,18 +461,18 @@ generated. The ongoing tuning process will be halted, and no adjustments will be
 to the PID parameters.
 </li>
 <li>
-The autotuning must be conducted after the initialization completes.
+The autotuning must be conducted after the initialization is completed.
 </li>
 </ul>
 <h4>Guidance for setting the parameters</h4>
 <p>
-The performance of the autotuning is affected by the parameters including the
+The performance of the autotuning is determined by several parameters, including the
 typical range of the control error <code>r</code>,
 the reference output for the tuning process <code>yRef</code>, the higher and
 lower values for the relay output <code>yHig</code> and <code>yLow</code>, and the
 deadband <code>deaBan</code>.
-These parameters must be manually specified by users on a case-by-case basis. 
-Below are the steps for setting them.
+Generally, these parameters must be manually specified by users on a case-by-case basis. 
+Below are recommended steps for setting them.
 </p>
 <p>
 Step 1: Conduct a &quot;test run&quot;

--- a/Buildings/Controls/OBC/Utilities/PIDWithAutotuning/FirstOrderAMIGO.mo
+++ b/Buildings/Controls/OBC/Utilities/PIDWithAutotuning/FirstOrderAMIGO.mo
@@ -383,15 +383,15 @@ equation
 annotation (defaultComponentName = "conPIDWitTun",
 Documentation(info="<html>
 <p>
-This block implements a rule-based tuning method for a PI or a PID controller, with the following
-steps:
+This block implements a PI or PID controller with the control gains being tuned by a rule-based method. 
+The tuning has the following steps:
 </p>
 <p>
-Step 1: Introducing a relay disturbance
+Step 1: Introduce a relay disturbance
 </p>
 <ul>
 <li>
-During the tuning process, the relay controller
+A relay controller
 switches the output between two constants (<code>yHig</code> and <code>yLow</code>), based
 on the control error <i>e(t) = u<sub>s</sub>(t) - u<sub>m</sub>(t)</i>.
 Details can be found in
@@ -400,11 +400,11 @@ Buildings.Controls.OBC.Utilities.PIDWithAutotuning.Relay.Controller</a>.
 </li>
 </ul>
 <p>
-Step 2: Extracting parameters of a first-order plus time-delay (FOPTD) model
+Step 2: Extract parameters of a first-order plus time-delay (FOPTD) model
 </p>
 <ul>
 <li>
-Based on the inputs and outputs from the relay controller during the tuning process, the
+Based on the inputs and outputs from the relay controller, the
 parameters of the FOPTD model is calculated (see 
 <a href=\"modelica://Buildings.Controls.OBC.Utilities.PIDWithAutotuning.SystemIdentification\">
 Buildings.Controls.OBC.Utilities.PIDWithAutotuning.SystemIdentification</a>).
@@ -412,7 +412,7 @@ The FOPTD is a simplified representation of the control process.
 </li>
 </ul>
 <p>
-Step 3: Calculating the PID gains
+Step 3: Calculate the PID gains
 </p>
 <ul>
 <li>
@@ -461,7 +461,9 @@ generated. The ongoing tuning process will be halted, and no adjustments will be
 to the PID parameters.
 </li>
 <li>
-The autotuning must be conducted after the initialization is completed.
+The autotuning must be conducted after the simulation reaches a stable state from the initial conditions.
+The user should monitor changes in important system variables (e.g., mass flow rate, temperature) over time.
+When these changes become small (e.g., less than 5%) or exhibit regular oscillations, the simulation can be considered stable.
 </li>
 </ul>
 <h4>Guidance for setting the parameters</h4>
@@ -471,8 +473,8 @@ typical range of the control error <code>r</code>,
 the reference output for the tuning process <code>yRef</code>, the higher and
 lower values for the relay output <code>yHig</code> and <code>yLow</code>, and the
 deadband <code>deaBan</code>.
-Generally, these parameters must be manually specified by users on a case-by-case basis. 
-Below are recommended steps for setting them.
+These parameters must be specified on a case-by-case basis. 
+To set them, the user should conduct the following steps.
 </p>
 <p>
 Step 1: Conduct a &quot;test run&quot;
@@ -487,8 +489,7 @@ output of the relay controller, <code>rel.yDif</code>,
 stays between 0 and 1.
 </li>
 <li>
-The test run must start after the initialization,
-and end when the simulation reaches a stable state or enters regular oscillations. 
+The test run should begin once the simulation reaches a stable state and end when it reaches a different stable state 
 </li>
 </ul>
 <p>
@@ -513,6 +514,12 @@ Step 3: Determine <code>yHig</code> and <code>yLow</code>
 <li>
 Adjust <code>yHig</code> and <code>yLow</code> so that the relay
 output is asymmetric, i.e., <code>yHig - yRef &ne; yRef - yLow</code>.
+</li>
+<li>
+<code>yHig</code> must be greater than <code>yRef</code> but less than 1.
+</li>
+<li>
+<code>yLow</code> must be greater than 0 but less than <code>yRef</code>.
 </li>
 </ul>
 <h4>References</h4>

--- a/Buildings/Controls/OBC/Utilities/PIDWithAutotuning/FirstOrderAMIGO.mo
+++ b/Buildings/Controls/OBC/Utilities/PIDWithAutotuning/FirstOrderAMIGO.mo
@@ -461,9 +461,9 @@ generated. The ongoing tuning process will be halted, and no adjustments will be
 to the PID parameters.
 </li>
 <li>
-The autotuning must be conducted after the simulation reaches a stable state from the initial conditions.
+The autotuning must be conducted when the simulation is in a stable state.
 The user should monitor changes in important system variables (e.g., mass flow rate, temperature) over time.
-When these changes become small (e.g., less than 5%) or exhibit regular oscillations, the simulation can be considered stable.
+When these changes become small (e.g., less than 5%) or exhibit regular oscillations, the simulation can be considered in a stable state.
 </li>
 </ul>
 <h4>Guidance for setting the parameters</h4>
@@ -489,7 +489,7 @@ output of the relay controller, <code>rel.yDif</code>,
 stays between 0 and 1.
 </li>
 <li>
-The test run should begin once the simulation reaches a stable state and end when it reaches a different stable state 
+The test run should begin once the simulation reaches a stable state and end when it reaches a different stable state.
 </li>
 </ul>
 <p>

--- a/Buildings/Controls/OBC/Utilities/PIDWithAutotuning/FirstOrderAMIGO.mo
+++ b/Buildings/Controls/OBC/Utilities/PIDWithAutotuning/FirstOrderAMIGO.mo
@@ -383,8 +383,8 @@ equation
 annotation (defaultComponentName = "conPIDWitTun",
 Documentation(info="<html>
 <p>
-This block implements a PI or PID controller with the control gains being tuned by a rule-based method. 
-The tuning has the following steps:
+This block implements a PI or PID controller with the control gains being tuned by a rule-based method.
+This rule-based method automatically conducts tuning through the following steps:
 </p>
 <p>
 Step 1: Introduce a relay disturbance
@@ -462,8 +462,12 @@ to the PID parameters.
 </li>
 <li>
 The autotuning must be conducted when the simulation is in a stable state.
-The user should monitor changes in important system variables (e.g., mass flow rate, temperature) over time.
-When these changes become small (e.g., less than 5%) or exhibit regular oscillations, the simulation can be considered in a stable state.
+The user should monitor changes in the independent variables and
+the control variables (e.g., mass flow rate, temperature) over time.
+When the changes in the independent variables are small (e.g., less than 10%),
+and the changes in the control variables are either small or
+exhibit regular oscillations,
+the simulation can be considered in a stable state.
 </li>
 </ul>
 <h4>Guidance for setting the parameters</h4>
@@ -481,7 +485,8 @@ Step 1: Conduct a &quot;test run&quot;
 </p>
 <ul>
 <li>
-In the test run, disable the autotuning and keep the setpoint value constant.
+In the test run, disable the autotuning and keep the independent variables,
+including but not limited to the setpoint value, constant.
 </li>
 <li>
 During the test run, adjust <code>r</code> so that the 
@@ -489,7 +494,8 @@ output of the relay controller, <code>rel.yDif</code>,
 stays between 0 and 1.
 </li>
 <li>
-The test run should begin once the simulation reaches a stable state and end when it reaches a different stable state.
+The test run must begin once the simulation reaches a stable state and end
+when it reaches another stable state.
 </li>
 </ul>
 <p>

--- a/Buildings/Controls/OBC/Utilities/PIDWithAutotuning/FirstOrderAMIGO.mo
+++ b/Buildings/Controls/OBC/Utilities/PIDWithAutotuning/FirstOrderAMIGO.mo
@@ -387,7 +387,7 @@ This block implements a rule-based tuning method for a PI or a PID controller, w
 steps:
 </p>
 <p>
-Step 1: Introducing a periodic disturbance
+Step 1: Introducing a relay disturbance
 </p>
 <ul>
 <li>
@@ -460,6 +460,9 @@ If the set point is changed during an autotuning process, a warning will be
 generated. The ongoing tuning process will be halted, and no adjustments will be made
 to the PID parameters.
 </li>
+<li>
+The autotuning must be conducted after the initialization completes.
+</li>
 </ul>
 <h4>Guidance for setting the parameters</h4>
 <p>
@@ -467,50 +470,48 @@ The performance of the autotuning is affected by the parameters including the
 typical range of the control error <code>r</code>,
 the reference output for the tuning process <code>yRef</code>, the higher and
 lower values for the relay output <code>yHig</code> and <code>yLow</code>, and the
-deadband <code>deaBan</code>. These parameters can be specified with the following
-steps:
+deadband <code>deaBan</code>.
+These parameters must be manually specified by users on a case-by-case basis. 
+Below are the steps for setting them.
 </p>
 <p>
-Step 1: Conducting a &quot;test run&quot;
+Step 1: Conduct a &quot;test run&quot;
 </p>
 <ul>
 <li>
-In the test run, the autotuning must be disabled and the set point
-must be constant.
+In the test run, disable the autotuning and keep the setpoint value constant.
 </li>
 <li>
-During the test run, <code>r</code> must be adjusted so that the 
+During the test run, adjust <code>r</code> so that the 
 output of the relay controller, <code>rel.yDif</code>,
 stays between 0 and 1.
 </li>
 <li>
-This test run must stop after the system is stable.
-</li>
-<li>
-Once stable, note the highest and lowest values of the measurement.
+The test run must start after the initialization,
+and end when the simulation reaches a stable state or enters regular oscillations. 
 </li>
 </ul>
 <p>
-Step 2: Calculating <code>yRef</code> and <code>deaBan</code>
+Step 2: Calculate <code>yRef</code> and <code>deaBan</code>
 </p>
 <ul>
 <li>
-The <code>yRef</code> is calculated by dividing the set point by the sum of the
-minimum and the maximum values of the measurement.
+To calculate the <code>yRef</code>, divide the set point by the sum of the
+minimum and the maximum values of the measurement during the test run.
 </li>
 <li>
-To calculate <code>deaBan</code>, first divide the maximum and the
+For the <code>deaBan</code>, first divide the maximum and the
 minimum control errors during the test run by <code>r</code>.
-The <code>deaBan</code> can then be set as half of the smaller absolute value
+Then set the <code>deaBan</code> to half of the smaller absolute value
 of those two deviations.
 </li>
 </ul>
 <p>
-Step 3: Determining <code>yHig</code> and <code>yLow</code>
+Step 3: Determine <code>yHig</code> and <code>yLow</code>
 </p>
 <ul>
 <li>
-The <code>yHig</code> and <code>yLow</code> must be adjusted so that the relay
+Adjust <code>yHig</code> and <code>yLow</code> so that the relay
 output is asymmetric, i.e., <code>yHig - yRef &ne; yRef - yLow</code>.
 </li>
 </ul>


### PR DESCRIPTION
Enhance the model documentation to clarify that: 1) users must adjust specific parameters based on their use case; and 2) the initialization process should be excluded from both the autotuning and the test run.