### PR TITLE
Update FMI Library to version 3.0, up from 2.2

### DIFF
--- a/Buildings/Resources/src/fmi-library/CMakeLists.txt
+++ b/Buildings/Resources/src/fmi-library/CMakeLists.txt
@@ -7,7 +7,7 @@ cmake_policy(SET CMP0048 NEW)
 cmake_minimum_required(VERSION 3.8)
 
 project( fmi-library
-  VERSION 2.2
+  VERSION 3.0
   DESCRIPTION "FMI Library for Modelica Buildings Library"
   LANGUAGES C
 )
@@ -64,14 +64,17 @@ ExternalProject_Add(
 
   PREFIX         ${FMI_LIBRARY}
   GIT_REPOSITORY https://github.com/modelon-community/fmi-library
-  GIT_TAG        2.2
+  GIT_TAG        3.0
   GIT_SHALLOW    ON
 
   BUILD_ALWAYS   OFF
 
 #--Configure step-------------
 #  CONFIGURE_COMMAND ""
-  CMAKE_ARGS        DFMILIB_BUILD_SHARED_LIB=OFF DFMILIB_GENERATE_DOXYGEN_DOC=OFF
+  CMAKE_ARGS        
+      -DFMILIB_BUILD_SHARED_LIB=OFF
+      -DFMILIB_GENERATE_DOXYGEN_DOC=OFF
+      -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_SOURCE_DIR}/build/fmi-library-modelon/src/install
 
 #--Build step-----------------
 #  BUILD_COMMAND     "" #cmake --build ..
@@ -118,7 +121,7 @@ file(REMOVE_RECURSE "${CMAKE_CURRENT_SOURCE_DIR}/doc")
 add_custom_command(TARGET ${FMI_LIBRARY}
   POST_BUILD
   COMMAND "${CMAKE_COMMAND}" -E copy_directory
-        "${CMAKE_CURRENT_SOURCE_DIR}/build/fmi-library-modelon/src/install/doc"
+        "${CMAKE_CURRENT_SOURCE_DIR}/build/fmi-library-modelon/src/install/share/doc"
         "${CMAKE_CURRENT_SOURCE_DIR}/doc"
   COMMENT "Copying doc files to ${CMAKE_CURRENT_SOURCE_DIR}/doc"
 )


### PR DESCRIPTION
This PR includes changes to the build system to instead use the latest FMILibrary (FMIL) released yesterday.

Let me know if anything else is needed, any tests or similar? For now I have only verified that the build command that was in the top of the file works, that is:
```
rm -rf build && mkdir build && cd build && cmake .. && cmake --build . && cd ..
```

End of build output:
```
...
100% tests passed, 0 tests failed out of 65

Label Time Summary:
skip_memcheck    =   0.01 sec*proc (1 test)

Total Test time (real) =   2.05 sec
[ 77%] Completed 'fmi-library-modelon'
Copying to Modelica library directory '/opt/modelica-buildings/Buildings/Resources/src/fmi-library/../../Library/linux64/'
Deleting /opt/modelica-buildings/Buildings/Resources/src/fmi-library/../../Library/linux64//libfmilib.a
Copying doc files to /opt/modelica-buildings/Buildings/Resources/src/fmi-library/doc
Copying include files to /opt/modelica-buildings/Buildings/Resources/src/fmi-library/include
Copying platform specific include file to /opt/modelica-buildings/Buildings/Resources/src/fmi-library/include/fmilib_config-linux64.h
Copying portable include file to /opt/modelica-buildings/Buildings/Resources/src/fmi-library/include
[100%] Built target fmi-library-modelon
```