### PR TITLE
Add missing header files and correct type comparison in Utilities.Plotter

### DIFF
--- a/Buildings/Resources/C-Sources/plotInit.c
+++ b/Buildings/Resources/C-Sources/plotInit.c
@@ -7,6 +7,7 @@
 
 #include <stdlib.h>
 #include <stdio.h>
+#include <string.h>
 #include "ModelicaUtilities.h"
 
 #include "plotObjectStructure.h"

--- a/Buildings/Resources/C-Sources/plotSendReal.c
+++ b/Buildings/Resources/C-Sources/plotSendReal.c
@@ -8,6 +8,7 @@
 
  #include <string.h>
  #include <stdlib.h>
+ #include "ModelicaUtilities.h"
 
 void plotSendReal(void* object, const double* dbl){
   int i;

--- a/Buildings/Utilities/Plotters/BaseClasses/PartialPlotter.mo
+++ b/Buildings/Utilities/Plotters/BaseClasses/PartialPlotter.mo
@@ -130,9 +130,9 @@ equation
           visible=activation == Buildings.Utilities.Plotters.Types.LocalActivation.use_activation),
         Ellipse(
           extent={{-95,67},{-81,53}},
-          lineColor=DynamicSelect({235,235,235}, if activate > 0.5 then {0,255,0}
+          lineColor=DynamicSelect({235,235,235}, if activate then {0,255,0}
                else {235,235,235}),
-          fillColor=DynamicSelect({235,235,235}, if activate > 0.5 then {0,255,0}
+          fillColor=DynamicSelect({235,235,235}, if activate then {0,255,0}
                else {235,235,235}),
           fillPattern=FillPattern.Solid,
           visible=activation == Buildings.Utilities.Plotters.Types.LocalActivation.use_input)}),


### PR DESCRIPTION
This closes #4209.
This closes #4210.

It also corrects a comparison between boolean and real in the graphical annotion.