### PR TITLE
Corrected miss-placed bracket in the computation of the average inlet temperature to the zone. (maint_12.x)

### DIFF
--- a/Buildings/Obsolete/ThermalZones/EnergyPlus_9_6_0/BaseClasses/ThermalZoneAdapter.mo
+++ b/Buildings/Obsolete/ThermalZones/EnergyPlus_9_6_0/BaseClasses/ThermalZoneAdapter.mo
@@ -275,7 +275,7 @@ equation
         if m_flow[i] > 0 then
           TInlet[i]*m_flow[i]
         else
-          0 for i in 1:nFluPor)+m_flow_small*pre(TAveInlet)/(mInlet_flow+m_flow_small));
+          0 for i in 1:nFluPor)+m_flow_small*pre(TAveInlet))/(mInlet_flow+m_flow_small);
     // Below, the term X_w/(1.-X_w) is for conversion from kg/kg_total_air (Modelica) to kg/kg_dry_air (EnergyPlus)
     QGaiRadAve_flow = (EGaiRadLast-pre(EGaiRadLast))/dtLast;
 
@@ -318,6 +318,12 @@ of its class <code>adapter</code>, of EnergyPlus.
 </html>",
       revisions="<html>
 <ul>
+<li>
+April 22, 2026, by Michael Wetter:<br/>
+Corrected miss-placed bracket in the computation of the average inlet temperature to the zone.<br/>
+This is for
+<a href=\"https://github.com/lbl-srg/modelica-buildings/issues/4559\">#4559</a>.
+</li>
 <li>
 March 22, 2024, by Michael Wetter:<br/>
 Changed radiative heat flow rate sent to EnergyPlus to be the average over the last

--- a/Buildings/ThermalZones/EnergyPlus_24_2_0/BaseClasses/ThermalZoneAdapter.mo
+++ b/Buildings/ThermalZones/EnergyPlus_24_2_0/BaseClasses/ThermalZoneAdapter.mo
@@ -54,26 +54,24 @@ model ThermalZoneAdapter
     final unit="K",
     displayUnit="degC")
     "Zone air temperature"
-    annotation (Placement(transformation(extent={{-140,80},{-100,120}}),iconTransformation(extent={{-140,80},
-            {-100,120}})));
+    annotation (Placement(transformation(extent={{-140,60},{-100,100}}),iconTransformation(extent={{-140,60},{-100,100}})));
   Modelica.Blocks.Interfaces.RealInput X_w(
     final unit="kg/kg")
     "Zone air mass fraction in kg/kg total air"
-    annotation (Placement(transformation(extent={{-140,40},{-100,80}}),iconTransformation(extent={{-140,40},
-            {-100,80}})));
+    annotation (Placement(transformation(extent={{-140,20},{-100,60}}),iconTransformation(extent={{-140,20},{-100,60}})));
   Modelica.Blocks.Interfaces.RealInput m_flow[nFluPor](
     each final unit="kg/s")
     "Mass flow rate"
-    annotation (Placement(transformation(extent={{-140,0},{-100,40}})));
+    annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
   Modelica.Blocks.Interfaces.RealInput TInlet[nFluPor](
     each final unit="K",
     each displayUnit="degC")
     "Air inlet temperatures"
-    annotation (Placement(transformation(extent={{-140,-40},{-100,0}})));
+    annotation (Placement(transformation(extent={{-140,-60},{-100,-20}})));
   Modelica.Blocks.Interfaces.RealInput QGaiRad_flow(
-    final unit="W") "Radiative heat gain"
-    annotation (Placement(transformation(extent={{-140,-80},{-100,-40}}), iconTransformation(extent={{-140,
-            -80},{-100,-40}})));
+    final unit="W")
+    "Radiative heat gain"
+    annotation (Placement(transformation(extent={{-140,-100},{-100,-60}}),iconTransformation(extent={{-140,-100},{-100,-60}})));
   Modelica.Blocks.Interfaces.RealOutput TRad(
     final unit="K",
     displayUnit="degC")
@@ -91,17 +89,8 @@ model ThermalZoneAdapter
     final unit="W")
     "Total heat gain from people, to be used for optional computation of CO2 released"
     annotation (Placement(transformation(extent={{100,-70},{120,-50}}),iconTransformation(extent={{100,-70},{120,-50}})));
-  Modelica.Blocks.Interfaces.RealInput p(
-    final unit="Pa")
-    "Absolute pressure of room air" annotation (Placement(transformation(extent={{-140,
-            -120},{-100,-80}}),      iconTransformation(extent={{-140,-120},{-100,
-            -80}})));
-protected
-  constant Modelica.Units.SI.AbsolutePressure pMin = 30E3
-     "Minimum allowed pressure; this is below the pressure on 8000 m, and hence certainly a modeling error";
-  constant Modelica.Units.SI.AbsolutePressure pMax = 110E3
-    "Maximum allowed pressure; this is higher than the maximum pressure measured in an anti-cyclone, and hence certainly a modeling error";
 
+protected
   constant Integer nParOut=3
     "Number of parameter values retrieved from EnergyPlus";
   constant Integer nInp=5
@@ -272,14 +261,6 @@ equation
 
   // Synchronization with EnergyPlus
   when {time >= pre(tNext)} then
-    // Monitor pressure to catch cases where a user may forget to add a flow path for exhaust air
-    assert(p < pMax,
-      "In " + getInstanceName() + ": Air pressure is above physically reasonable limit.
-  Require " + String(pMin) + " < p < " + String(pMax) + ", but p = " + String(p) + " Pa. Model seems to have fresh air supply but no exhaust air or exfiltration.");
-    assert(p > pMin,
-      "In " + getInstanceName() + ": Air pressure is below physically reasonable limit.
-  Require " + String(pMin) + " < p < " + String(pMax) + ", but p = " + String(p) + " Pa. Model seems to have exhaust air but no supply air or infiltration.");
-
     // Initialization of output variables.
     TRooLast=T;
     dtLast=time-pre(tLast);
@@ -342,12 +323,6 @@ April 22, 2026, by Michael Wetter:<br/>
 Corrected miss-placed bracket in the computation of the average inlet temperature to the zone.<br/>
 This is for
 <a href=\"https://github.com/lbl-srg/modelica-buildings/issues/4559\">#4559</a>.
-</li>
-<li>
-March 30, 2026, by Michael Wetter:<br/>
-Added check for air pressure to be within reasonable limits.<br/>
-This is for
-<a href=\"https://github.com/lbl-srg/modelica-buildings/issues/3319\">#3319</a>.
 </li>
 <li>
 March 22, 2024, by Michael Wetter:<br/>

--- a/Buildings/ThermalZones/EnergyPlus_24_2_0/BaseClasses/ThermalZoneAdapter.mo
+++ b/Buildings/ThermalZones/EnergyPlus_24_2_0/BaseClasses/ThermalZoneAdapter.mo
@@ -54,24 +54,26 @@ model ThermalZoneAdapter
     final unit="K",
     displayUnit="degC")
     "Zone air temperature"
-    annotation (Placement(transformation(extent={{-140,60},{-100,100}}),iconTransformation(extent={{-140,60},{-100,100}})));
+    annotation (Placement(transformation(extent={{-140,80},{-100,120}}),iconTransformation(extent={{-140,80},
+            {-100,120}})));
   Modelica.Blocks.Interfaces.RealInput X_w(
     final unit="kg/kg")
     "Zone air mass fraction in kg/kg total air"
-    annotation (Placement(transformation(extent={{-140,20},{-100,60}}),iconTransformation(extent={{-140,20},{-100,60}})));
+    annotation (Placement(transformation(extent={{-140,40},{-100,80}}),iconTransformation(extent={{-140,40},
+            {-100,80}})));
   Modelica.Blocks.Interfaces.RealInput m_flow[nFluPor](
     each final unit="kg/s")
     "Mass flow rate"
-    annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
+    annotation (Placement(transformation(extent={{-140,0},{-100,40}})));
   Modelica.Blocks.Interfaces.RealInput TInlet[nFluPor](
     each final unit="K",
     each displayUnit="degC")
     "Air inlet temperatures"
-    annotation (Placement(transformation(extent={{-140,-60},{-100,-20}})));
+    annotation (Placement(transformation(extent={{-140,-40},{-100,0}})));
   Modelica.Blocks.Interfaces.RealInput QGaiRad_flow(
-    final unit="W")
-    "Radiative heat gain"
-    annotation (Placement(transformation(extent={{-140,-100},{-100,-60}}),iconTransformation(extent={{-140,-100},{-100,-60}})));
+    final unit="W") "Radiative heat gain"
+    annotation (Placement(transformation(extent={{-140,-80},{-100,-40}}), iconTransformation(extent={{-140,
+            -80},{-100,-40}})));
   Modelica.Blocks.Interfaces.RealOutput TRad(
     final unit="K",
     displayUnit="degC")
@@ -89,8 +91,17 @@ model ThermalZoneAdapter
     final unit="W")
     "Total heat gain from people, to be used for optional computation of CO2 released"
     annotation (Placement(transformation(extent={{100,-70},{120,-50}}),iconTransformation(extent={{100,-70},{120,-50}})));
-
+  Modelica.Blocks.Interfaces.RealInput p(
+    final unit="Pa")
+    "Absolute pressure of room air" annotation (Placement(transformation(extent={{-140,
+            -120},{-100,-80}}),      iconTransformation(extent={{-140,-120},{-100,
+            -80}})));
 protected
+  constant Modelica.Units.SI.AbsolutePressure pMin = 30E3
+     "Minimum allowed pressure; this is below the pressure on 8000 m, and hence certainly a modeling error";
+  constant Modelica.Units.SI.AbsolutePressure pMax = 110E3
+    "Maximum allowed pressure; this is higher than the maximum pressure measured in an anti-cyclone, and hence certainly a modeling error";
+
   constant Integer nParOut=3
     "Number of parameter values retrieved from EnergyPlus";
   constant Integer nInp=5
@@ -261,6 +272,14 @@ equation
 
   // Synchronization with EnergyPlus
   when {time >= pre(tNext)} then
+    // Monitor pressure to catch cases where a user may forget to add a flow path for exhaust air
+    assert(p < pMax,
+      "In " + getInstanceName() + ": Air pressure is above physically reasonable limit.
+  Require " + String(pMin) + " < p < " + String(pMax) + ", but p = " + String(p) + " Pa. Model seems to have fresh air supply but no exhaust air or exfiltration.");
+    assert(p > pMin,
+      "In " + getInstanceName() + ": Air pressure is below physically reasonable limit.
+  Require " + String(pMin) + " < p < " + String(pMax) + ", but p = " + String(p) + " Pa. Model seems to have exhaust air but no supply air or infiltration.");
+
     // Initialization of output variables.
     TRooLast=T;
     dtLast=time-pre(tLast);
@@ -275,7 +294,7 @@ equation
         if m_flow[i] > 0 then
           TInlet[i]*m_flow[i]
         else
-          0 for i in 1:nFluPor)+m_flow_small*pre(TAveInlet)/(mInlet_flow+m_flow_small));
+          0 for i in 1:nFluPor)+m_flow_small*pre(TAveInlet))/(mInlet_flow+m_flow_small);
     // Below, the term X_w/(1.-X_w) is for conversion from kg/kg_total_air (Modelica) to kg/kg_dry_air (EnergyPlus)
     QGaiRadAve_flow = (EGaiRadLast-pre(EGaiRadLast))/dtLast;
 
@@ -318,6 +337,18 @@ of its class <code>adapter</code>, of EnergyPlus.
 </html>",
       revisions="<html>
 <ul>
+<li>
+April 22, 2026, by Michael Wetter:<br/>
+Corrected miss-placed bracket in the computation of the average inlet temperature to the zone.<br/>
+This is for
+<a href=\"https://github.com/lbl-srg/modelica-buildings/issues/4559\">#4559</a>.
+</li>
+<li>
+March 30, 2026, by Michael Wetter:<br/>
+Added check for air pressure to be within reasonable limits.<br/>
+This is for
+<a href=\"https://github.com/lbl-srg/modelica-buildings/issues/3319\">#3319</a>.
+</li>
 <li>
 March 22, 2024, by Michael Wetter:<br/>
 Changed radiative heat flow rate sent to EnergyPlus to be the average over the last

--- a/Buildings/UsersGuide/ReleaseNotes/Version_12_1_1.mo
+++ b/Buildings/UsersGuide/ReleaseNotes/Version_12_1_1.mo
@@ -131,12 +131,15 @@ The following <b style=\"color:red\">critical errors</b> have been fixed (i.e., 
 that can lead to wrong simulation results):
 </p>
 <table class=\"releaseTable\" summary=\"summary\" border=\"1\" cellspacing=\"0\" cellpadding=\"2\" style=\"border-collapse:collapse;\">
-<tr><td colspan=\"2\"><b>xxx</b>
+<tr><td colspan=\"2\"><b>Buildings.Obsolete.ThermalZones.EnergyPlus_9_6_0<br/>
+                       Buildings.ThermalZones.EnergyPlus_24_2_0</b>
     </td>
 </tr>
-<tr><td valign=\"top\">xxx
+<tr><td valign=\"top\">Buildings.Obsolete.ThermalZones.EnergyPlus_9_6_0.BaseClasses.ThermalZoneAdapter<br/>
+                       Buildings.ThermalZones.EnergyPlus_24_2_0.BaseClasses.ThermalZoneAdapter
     </td>
-    <td valign=\"top\">xxx.
+    <td valign=\"top\">Corrected misplaced bracket in the computation of the average inlet temperature to the zone.<br/>
+                       This is for <a href=\"https://github.com/lbl-srg/modelica-buildings/issues/4559\">#4559</a>.
     </td>
 </tr>
 </table>


### PR DESCRIPTION
For #4559