### PR TITLE
Add `LibraryDirectory` annotation to `pureReadLine`

### DIFF
--- a/Buildings/DHC/Loads/BaseClasses/getPeakLoad.mo
+++ b/Buildings/DHC/Loads/BaseClasses/getPeakLoad.mo
@@ -41,7 +41,8 @@ protected
         endOfFile) annotation (
       IncludeDirectory="modelica://Modelica/Resources/C-Sources",
       Include="#include \"ModelicaInternal.h\"",
-      Library="ModelicaExternalC");
+      Library="ModelicaExternalC",
+      LibraryDirectory="modelica://Modelica/Resources/Library");
   annotation (Documentation(info="<html>
 <p>
 This function implements


### PR DESCRIPTION
Wolfram System Modeler fails to evaluate calls to `pureReadLine` because it is missing the `LibraryDirectory` annotation telling the tool where to find `ModelicaExternalC`.
This PR adds it.