### PR TITLE
Remove all remaining occurence of cardinality.

### DIFF
--- a/Buildings/Fluid/Sources/BaseClasses/PartialAirSource.mo
+++ b/Buildings/Fluid/Sources/BaseClasses/PartialAirSource.mo
@@ -21,7 +21,12 @@ partial model PartialAirSource
     each h_outflow(nominal=Medium.h_default),
     each Xi_outflow(each nominal=0.01))
     "Fluid ports"
-    annotation (Placement(transformation(extent={{90,40},{110,-40}})));
+    annotation (mayOnlyConnectOnce = "
+Each ports[i] of boundary shall at most be connected to one component.
+If two or more connections are present, ideal mixing takes
+place in these connections, which is usually not the intention
+of the modeller. Increase nPorts to add an additional port.
+", Placement(transformation(extent={{90,40},{110,-40}})));
 
 protected
   parameter Modelica.Fluid.Types.PortFlowDirection flowDirection=Modelica.Fluid.Types.PortFlowDirection.Bidirectional
@@ -40,17 +45,6 @@ protected
   Modelica.Blocks.Interfaces.RealInput C_in_internal[Medium.nC](
     final quantity=Medium.extraPropertiesNames)
     "Needed to connect to conditional connector";
-
-initial equation
-  // Only one connection allowed to a port to avoid unwanted ideal mixing
-  for i in 1:nPorts loop
-    assert(cardinality(ports[i]) <= 1,"
-Each ports[i] of boundary shall at most be connected to one component.
-If two or more connections are present, ideal mixing takes
-place in these connections, which is usually not the intention
-of the modeller. Increase nPorts to add an additional port.
-");
-  end for;
 
 equation
   connect(medium.p, p_in_internal);

--- a/Buildings/Fluid/Sources/BaseClasses/PartialSource.mo
+++ b/Buildings/Fluid/Sources/BaseClasses/PartialSource.mo
@@ -27,7 +27,12 @@ partial model PartialSource
     each h_outflow(nominal=Medium.h_default),
     each Xi_outflow(each nominal=0.01))
     "Fluid ports"
-    annotation (Placement(transformation(extent={{90,40},{110,-40}})));
+    annotation (mayOnlyConnectOnce = "
+Each ports[i] of boundary shall at most be connected to one component.
+If two or more connections are present, ideal mixing takes
+place in these connections, which is usually not the intention
+of the modeller. Increase nPorts to add an additional port.
+", Placement(transformation(extent={{90,40},{110,-40}})));
 
 protected
   parameter Modelica.Fluid.Types.PortFlowDirection flowDirection=Modelica.Fluid.Types.PortFlowDirection.Bidirectional
@@ -44,18 +49,6 @@ protected
   Modelica.Blocks.Interfaces.RealInput C_in_internal[Medium.nC](
     final quantity=Medium.extraPropertiesNames)
     "Needed to connect to conditional connector";
-
-
-initial equation
-  // Only one connection allowed to a port to avoid unwanted ideal mixing
-  for i in 1:nPorts loop
-    assert(cardinality(ports[i]) <= 1,"
-Each ports[i] of boundary shall at most be connected to one component.
-If two or more connections are present, ideal mixing takes
-place in these connections, which is usually not the intention
-of the modeller. Increase nPorts to add an additional port.
-");
-  end for;
 
 equation
   connect(medium.p, p_in_internal);

--- a/Buildings/Fluid/Sources/TraceSubstancesFlowSource.mo
+++ b/Buildings/Fluid/Sources/TraceSubstancesFlowSource.mo
@@ -25,7 +25,12 @@ model TraceSubstancesFlowSource
   Modelica.Fluid.Interfaces.FluidPorts_b ports[nPorts](
     redeclare each package Medium = Medium)
     "Connector for fluid ports"
-    annotation (Placement(transformation(extent={{90,40},{110,-40}})));
+    annotation (mayOnlyConnectOnce = "
+Each ports[i] of boundary shall at most be connected to one component.
+If two or more connections are present, ideal mixing takes
+place in these connections, which is usually not the intention
+of the modeller. Increase nPorts to add an additional port.
+", Placement(transformation(extent={{90,40},{110,-40}})));
 
 protected
   parameter Medium.ExtraProperty C_in_internal[Medium.nC](
@@ -49,16 +54,6 @@ initial equation
   assert(sum(C_in_internal) > 1E-4, "Trace substance '" + substanceName + "' is not present in medium '"
          + Medium.mediumName + "'.\n"
          + "Check source parameter and medium model.");
-
-  // Only one connection allowed to a port to avoid unwanted ideal mixing
-  for i in 1:nPorts loop
-    assert(cardinality(ports[i]) <= 1,"
-Each ports[i] of boundary shall at most be connected to one component.
-If two or more connections are present, ideal mixing takes
-place in these connections, which is usually not the intention
-of the modeller. Increase nPorts to add an additional port.
-");
-  end for;
 
 equation
   sum(ports.m_flow) = -m_flow_in_internal;

--- a/Buildings/ThermalZones/EnergyPlus_24_2_0/OpaqueConstruction.mo
+++ b/Buildings/ThermalZones/EnergyPlus_24_2_0/OpaqueConstruction.mo
@@ -9,10 +9,10 @@ model OpaqueConstruction
     "Surface area";
   Modelica.Thermal.HeatTransfer.Interfaces.HeatPort_a heaPorFro
     "Heat port for front surface"
-    annotation (Placement(transformation(extent={{-110,-10},{-90,10}}),iconTransformation(extent={{-110,-10},{-90,10}})));
+    annotation (mustBeConnected = "In " + getInstanceName() +": The heat port heaPorFro must be connected to another heat port.", Placement(transformation(extent={{-110,-10},{-90,10}}),iconTransformation(extent={{-110,-10},{-90,10}})));
   Modelica.Thermal.HeatTransfer.Interfaces.HeatPort_b heaPorBac
     "Heat port for back surface"
-    annotation (Placement(transformation(extent={{90,-10},{110,10}}),iconTransformation(extent={{88,-10},{108,10}})));
+    annotation (mustBeConnected = "In " + getInstanceName() +": The heat port heaPorBac must be connected to another heat port.", Placement(transformation(extent={{90,-10},{110,10}}),iconTransformation(extent={{88,-10},{108,10}})));
   Modelica.Units.SI.HeatFlux qFro_flow
     "Heat flow rate at front surface per unit area";
   Modelica.Units.SI.HeatFlux qBac_flow
@@ -111,15 +111,6 @@ initial equation
     A > 0,
     "Surface area must not be zero.");
 equation
-  // Make sure the heat ports are connected.
-  // These statements must be in the equation section. Otherwise,
-  // Dymola 2021 does trigger an error during the symbolic processing
-  // rather than these assertions if the heat port is not connected.
-  assert(cardinality(heaPorFro) > 0,
-    "In " + getInstanceName() +": The heat port heaPorFro must be connected to another heat port.");
-  assert(cardinality(heaPorBac) > 0,
-    "In " + getInstanceName() +": The heat port heaPorBac must be connected to another heat port.");
-
   when {initial(),time >= pre(tNext)} then
     // Initialization of output variables.
     TFroLast=heaPorFro.T;


### PR DESCRIPTION
`cardinality` is a deprecated construct in the modelica language and all remaining use case in the library are covered by either `mustBeConnected` or `mayOnlyConnectOnce`.