### PR TITLE
enable simulation of rack model in Dymola 2026x

### DIFF
--- a/Buildings/Resources/Scripts/BuildingsPy/conf.yml
+++ b/Buildings/Resources/Scripts/BuildingsPy/conf.yml
@@ -167,10 +167,6 @@
   openmodelica:
     comment: 'CalledProcessError: Command ''[''omc'', ''Buildings.Fluid.Chillers.ModularReversible.Validation.TableData2DLoadDep_HeatRecovery_translate.mos'']'' returned non-zero exit status 2.'
     translate: false
-- model_name: Buildings.Fluid.DataCenterEquipment.Racks.Hybrid.LiquidCooledSinglePhase.Examples.LiquidCooledSinglePhase
-  dymola:
-    comment: "Dassault bug report: SR01576125-01 due to problem with data record"
-    translate: false
 - model_name: Buildings.Fluid.Examples.FlowSystem.Basic
   openmodelica:
     comment: '''omc'' caused ''simulation terminated by an assertion at initialization''.'

--- a/Buildings/Resources/Scripts/Dymola/Fluid/DataCenterEquipment/Racks/Hybrid/LiquidCooledSinglePhase/Examples/LiquidCooledSinglePhase.mos
+++ b/Buildings/Resources/Scripts/Dymola/Fluid/DataCenterEquipment/Racks/Hybrid/LiquidCooledSinglePhase/Examples/LiquidCooledSinglePhase.mos
@@ -1,4 +1,8 @@
+// This is for Dymola, service request SR01576125-01, for Dymola 2026x
+old_hidden_TestRecordEquations=Hidden.TestRecordEquations;
+Hidden.TestRecordEquations=2;
 simulateModel("Buildings.Fluid.DataCenterEquipment.Racks.Hybrid.LiquidCooledSinglePhase.Examples.LiquidCooledSinglePhase", stopTime=7200, method="CVode", tolerance=1e-06, resultFile="LiquidCooledSinglePhase");
+Hidden.TestRecordEquations=old_hidden_TestRecordEquations;
 createPlot(id=1,
  position={15, 10, 590, 440},
  y={"utiLiq.y[1]", "utiAir.y"},


### PR DESCRIPTION
This PR adds a work-around to enable translation and simulation of `Fluid.DataCenterEquipment.Racks.Hybrid.LiquidCooledSinglePhase.Examples.LiquidCooledSinglePhase`